### PR TITLE
refactor: deduplicate PROPERTY_KEYS between grammar and formatter [WAY-15]

### DIFF
--- a/.claude/commands/implement-issue.md
+++ b/.claude/commands/implement-issue.md
@@ -1,0 +1,194 @@
+# Implement Linear Issue
+
+Instructions tailored for the Waymark repository.
+
+## Context
+
+- Linear Team ID: `bf82309c-7e23-4a19-890d-a36b4ecad5c3`
+- Linear Team Name: `Waymark`
+- Default work branch: `gt/v1.0/rewrite`
+
+## Overview
+
+Orchestrate a complete implementation workflow for the requested Linear issue using specialized subagents. Follow Waymark practices for investigation, implementation, testing, and QA.
+
+## Important
+
+- Use `gt` / Graphite commands exclusively for branch and commit management.
+- Keep all work on top of `gt/v1.0/rewrite` unless the user states otherwise.
+- Pause and check in with the user if you hit unexpected behavior or blocking issues.
+
+## Preparation
+
+1. **Gather issue context**
+   - Call `mcp__linear-server__get_issue` with the `$ARGUMENTS` issue key (e.g., `WAY-123`).
+   - Capture `gitBranchName`, acceptance criteria, dependencies, and linked issues (`dependsOn`, `blockedBy`).
+   - Update the issue status to “In Progress” once work begins.
+
+2. **Check stack alignment**
+   - Review the current stack: !`gt log short`
+   - If the issue depends on other Linear tickets, verify their branches exist and sit downstack from where this work will land.
+   - Missing or incomplete dependencies → report the blockage to the user before proceeding.
+
+3. **Verify branch selection**
+   - Inspect current branch: !`git branch --show-current`
+   - Ensure the branch name matches the Linear `gitBranchName`. If not, inform the user and propose `gt create <gitBranchName>` from the correct parent (typically `gt/v1.0/rewrite` or the highest dependency branch).
+   - Confirm stack positioning with `gt log` and adjust using `gt move --onto <parent>` if needed.
+
+4. **Review local guidance**
+   - Skim `@PLAN.md`, `@SCRATCHPAD.md`, and relevant docs (`@PRD.md`, `@README.md`, `.agents/rules/…`) for constraints or recent decisions that affect the work.
+   - Add a dated entry to `@SCRATCHPAD.md` summarizing investigation or notable changes.
+
+## Workflow Sequence
+
+### Phase 1: Setup & Investigation
+
+1. **Load Linear details**
+   - Extract acceptance criteria and convert them into a TodoWrite task list.
+   - Note any testing expectations, feature flags, or rollout considerations.
+
+2. **Investigate as needed**
+   - Launch `@agent-systematic-debugger` for bug hunts or behavioral regressions.
+   - Launch `@agent-senior-engineer` for exploratory feature work or architecture questions.
+   - Provide precise context: issue summary, suspected files (`packages/...`), existing waymarks, and expected vs. actual behavior.
+   - Review findings before writing code.
+
+### Phase 2: Implementation
+
+3. **Implement the solution**
+   - Engage `@agent-senior-engineer` with:
+     - A clear problem statement.
+     - Target files/lines.
+     - Acceptance criteria and edge cases.
+   - Ensure new comments follow the Waymark `:::` syntax.
+   - Update `@SCRATCHPAD.md` with progress notes (date-stamped).
+
+4. **Add or update tests**
+   - Use `@agent-test-driven-developer` to cover new behavior.
+   - Preferred frameworks: Vitest (`bun test`) and Playwright for E2E, per repo standards.
+   - Tests should live alongside existing specs in `packages/*/src/**/*.test.ts` or appropriate directories.
+
+### Phase 3: Quality Assurance
+
+5. **Run required checks**
+
+   ```bash
+   bun check:all
+   bun ci:validate
+   bun ci:local
+   ```
+
+   - Run targeted commands (`bun test`, `bun run lint`, etc.) if quicker iteration is needed, but finish with the full trio above before submission.
+
+6. **Fix failures promptly**
+   - Re-run the failing command after fixes.
+   - For persistent issues, bring in `@agent-systematic-debugger` (failures) or `@agent-code-reviewer` (lint/style gaps).
+
+7. **Manual verification (CLI & docs)**
+   - For CLI changes (`packages/cli`), run representative commands locally (e.g., `bun run wm insert …`) within a sandbox directory.
+   - For docs, ensure rendered Markdown has correct waymarks (`<!-- tldr ::: -->`, etc.).
+
+### Phase 4: Documentation & Completion
+
+8. **Update documentation**
+   - Touch `docs/` content, README snippets, or in-repo instructions when user-facing behavior changes.
+   - Keep documentation scannable and use waymark annotations (e.g., `<!-- summary ::: -->`).
+
+9. **Prepare the commit/stack**
+   - Determine whether the branch already has a PR (check `gt log short` for PR numbers).
+   - **No existing PR** → use `gt modify -am "<message>"`.
+   - **Existing PR** → use `gt modify -acm "<message>"` to add a new commit.
+   - Commit message guidance:
+
+     ```text
+     <concise summary of changes>
+
+     Fixes: WAY-XXX
+
+     🤖 Generated with Claude Code (https://claude.com/claude-code)
+
+     Co-Authored-By: Claude <noreply@anthropic.com>
+     ```
+
+10. **Verify acceptance criteria**
+    - Cross-check each criterion from the Linear issue.
+    - Mark completed items as `[x]` within the issue description (or comment on deviations).
+
+11. **Update Linear**
+    - Comment with:
+      - Summary of changes.
+      - Key files touched.
+      - Tests and quality checks executed (with command list).
+      - Any follow-up work or risks.
+    - Move status to “In Review” when ready.
+
+## Post-Implementation Checklist
+
+- [ ] Acceptance criteria satisfied (or deviations documented).
+- [ ] `bun check:all`, `bun ci:validate`, and `bun ci:local` all pass locally.
+- [ ] New or updated tests added and passing.
+- [ ] Source formatted (formatters run automatically through checks).
+- [ ] Docs and waymarks updated where applicable.
+- [ ] Linear issue commented and moved to “In Review”.
+- [ ] Stack verified with `gt log` (branch in correct position).
+
+## Key Principles
+
+1. Delegate to specialized subagents—do not attempt every step solo.
+2. Follow the order: Investigate → Implement → Test → Quality → Document.
+3. Review subagent output for correctness before proceeding.
+4. Keep Linear up to date throughout, not just at the end.
+5. Maintain high quality: zero lint/type/test regressions, reproducible commands.
+6. Document context in `@SCRATCHPAD.md` and use waymarks in new comments.
+
+## Example Subagent Prompts
+
+### Investigation (`@agent-systematic-debugger`)
+
+```text
+You are investigating WAY-<id>: <title>
+
+Problem: <describe the bug/inconsistency>
+
+Tasks:
+1. Inspect <files/areas> for the source of <behavior>.
+2. Explain the root cause with file paths and line numbers.
+3. Recommend changes required to resolve it.
+
+Do NOT modify code—only analyze and report back.
+```
+
+### Implementation (`@agent-senior-engineer`)
+
+```text
+You are implementing WAY-<id>: <title>
+
+Root cause: <summary from investigation>
+
+Tasks:
+1. Update <files/sections> to achieve <desired behavior>.
+2. Handle edge cases: <list>.
+3. Follow existing patterns (Bun/TypeScript, strict typing).
+4. Report back with diff summary, tests adjusted, and rationale.
+```
+
+### Testing (`@agent-test-driven-developer`)
+
+```text
+You are adding tests for WAY-<id>: <title>
+
+Implementation summary: <what changed>
+
+Tasks:
+1. Add tests in <path> covering: <scenarios>.
+2. Use Vitest/Playwright patterns already in the repo.
+3. Run tests with `bun test` (or relevant script) and confirm passing results.
+4. Report back with files touched and command output.
+```
+
+## Notes
+
+- Scale the number of subagents to the complexity of the issue.
+- For minor fixes, a single engineer + tester agent may suffice.
+- Keep the user posted on progress, blockers, and verification status via Linear comments.
+- Align with monorepo conventions and reuse shared utilities from `packages/*` wherever possible.

--- a/.claude/commands/implement-issue.md
+++ b/.claude/commands/implement-issue.md
@@ -26,12 +26,12 @@ Orchestrate a complete implementation workflow for the requested Linear issue us
    - Update the issue status to “In Progress” once work begins.
 
 2. **Check stack alignment**
-   - Review the current stack: !`gt log short`
+   - Review the current stack: `gt log short`
    - If the issue depends on other Linear tickets, verify their branches exist and sit downstack from where this work will land.
    - Missing or incomplete dependencies → report the blockage to the user before proceeding.
 
 3. **Verify branch selection**
-   - Inspect current branch: !`git branch --show-current`
+   - Inspect current branch: `git branch --show-current`
    - Ensure the branch name matches the Linear `gitBranchName`. If not, inform the user and propose `gt create <gitBranchName>` from the correct parent (typically `gt/v1.0/rewrite` or the highest dependency branch).
    - Confirm stack positioning with `gt log` and adjust using `gt move --onto <parent>` if needed.
 

--- a/packages/core/src/format.test.ts
+++ b/packages/core/src/format.test.ts
@@ -1,6 +1,7 @@
 // tldr ::: tests for waymark formatting utilities
 
 import { describe, expect, test } from "bun:test";
+import { PROPERTY_KEYS as GRAMMAR_PROPERTY_KEYS } from "@waymarks/grammar";
 
 import { formatText } from "./format";
 
@@ -203,5 +204,53 @@ describe("formatText", () => {
       "// todo:::task",
       "// :::continuation",
     ]);
+  });
+});
+
+describe("PROPERTY_KEYS alignment", () => {
+  test("formatter uses PROPERTY_KEYS from grammar package", () => {
+    // This test ensures the formatter imports PROPERTY_KEYS from @waymarks/grammar
+    // instead of maintaining its own duplicate list.
+    // If this test fails, it means the lists have diverged.
+
+    // The formatter should recognize the same property keys as the grammar
+    const expectedKeys = Array.from(GRAMMAR_PROPERTY_KEYS).sort();
+
+    // Test that all expected property keys are recognized in property continuations
+    for (const key of expectedKeys) {
+      const source = [
+        "// tldr ::: test waymark",
+        `// ${key} ::: test-value`,
+      ].join("\n");
+
+      const { formattedText } = formatText(source, {
+        file: "src/test.ts",
+      });
+
+      // If the key is recognized, it should be formatted as a property continuation
+      expect(formattedText).toContain(`${key} ::: test-value`);
+    }
+  });
+
+  test("property keys list matches expected set", () => {
+    // Verify the exact set of property keys to catch additions/removals
+    const expectedKeys = [
+      "ref",
+      "rel",
+      "depends",
+      "needs",
+      "blocks",
+      "dupeof",
+      "owner",
+      "since",
+      "fixes",
+      "affects",
+      "priority",
+      "status",
+    ].sort();
+
+    const actualKeys = Array.from(GRAMMAR_PROPERTY_KEYS).sort();
+
+    expect(actualKeys).toEqual(expectedKeys);
   });
 });

--- a/packages/core/src/format.test.ts
+++ b/packages/core/src/format.test.ts
@@ -231,26 +231,4 @@ describe("PROPERTY_KEYS alignment", () => {
       expect(formattedText).toContain(`${key} ::: test-value`);
     }
   });
-
-  test("property keys list matches expected set", () => {
-    // Verify the exact set of property keys to catch additions/removals
-    const expectedKeys = [
-      "ref",
-      "rel",
-      "depends",
-      "needs",
-      "blocks",
-      "dupeof",
-      "owner",
-      "since",
-      "fixes",
-      "affects",
-      "priority",
-      "status",
-    ].sort();
-
-    const actualKeys = Array.from(GRAMMAR_PROPERTY_KEYS).sort();
-
-    expect(actualKeys).toEqual(expectedKeys);
-  });
 });

--- a/packages/core/src/format.ts
+++ b/packages/core/src/format.ts
@@ -1,7 +1,7 @@
 // tldr ::: formatting utilities for normalizing waymark comments
 
 import type { ParseOptions, WaymarkRecord } from "@waymarks/grammar";
-import { parse, SIGIL } from "@waymarks/grammar";
+import { PROPERTY_KEYS, parse, SIGIL } from "@waymarks/grammar";
 
 import { resolveConfig } from "./config";
 import type { PartialWaymarkConfig, WaymarkConfig } from "./types";
@@ -27,22 +27,6 @@ const HTML_COMMENT_LEADER = "<!--";
 const SINGLE_SPACE = " ";
 const NEWLINE = "\n";
 const LINE_SPLIT_REGEX = /\r?\n/;
-
-// Known property keys that can act as pseudo-markers in continuation context
-const PROPERTY_KEYS = new Set([
-  "ref",
-  "rel",
-  "depends",
-  "needs",
-  "blocks",
-  "dupeof",
-  "owner",
-  "since",
-  "fixes",
-  "affects",
-  "priority",
-  "status",
-]);
 
 export function formatText(
   source: string,

--- a/packages/grammar/src/constants.test.ts
+++ b/packages/grammar/src/constants.test.ts
@@ -1,0 +1,27 @@
+// tldr ::: tests for waymark grammar constants and property keys contract
+
+import { describe, expect, test } from "bun:test";
+import { PROPERTY_KEYS } from "./constants";
+
+describe("PROPERTY_KEYS contract", () => {
+  test("maintains expected set of property keys", () => {
+    // This test enforces the contract for PROPERTY_KEYS as the single source of truth.
+    // Any additions or removals should be intentional and require updating this test.
+    const expectedKeys = [
+      "ref",
+      "rel",
+      "depends",
+      "needs",
+      "blocks",
+      "dupeof",
+      "owner",
+      "since",
+      "fixes",
+      "affects",
+      "priority",
+      "status",
+    ].sort();
+
+    expect(Array.from(PROPERTY_KEYS).sort()).toEqual(expectedKeys);
+  });
+});

--- a/packages/grammar/src/constants.ts
+++ b/packages/grammar/src/constants.ts
@@ -136,6 +136,9 @@ export const MARKER_DEFINITIONS: MarkerDefinition[] = [
 ];
 
 // Build a flat list of all markers including aliases for backward compatibility
+// Note: "needs" and "blocks" appear in both BLESSED_MARKERS and PROPERTY_KEYS by design.
+// In continuation context, the parser explicitly excludes blessed markers from being
+// treated as property continuations (see parseContinuation in content.ts).
 export const BLESSED_MARKERS = MARKER_DEFINITIONS.flatMap((def) => [
   def.name,
   ...(def.aliases || []),
@@ -195,6 +198,9 @@ export const MARKERS = {
 
 // Known property keys that can act as pseudo-markers in continuation context
 // This is the single source of truth for property keys recognized by the parser and formatter
+// Note: "needs" and "blocks" appear in both BLESSED_MARKERS and PROPERTY_KEYS by design.
+// When these appear in continuation context (after another waymark), they are treated as
+// property continuations only if they are NOT valid blessed markers in that position.
 export const PROPERTY_KEYS = new Set([
   "ref",
   "rel",

--- a/packages/grammar/src/constants.ts
+++ b/packages/grammar/src/constants.ts
@@ -192,3 +192,20 @@ export const MARKERS = {
   question: "question",
   ask: "ask",
 } as const;
+
+// Known property keys that can act as pseudo-markers in continuation context
+// This is the single source of truth for property keys recognized by the parser and formatter
+export const PROPERTY_KEYS = new Set([
+  "ref",
+  "rel",
+  "depends",
+  "needs",
+  "blocks",
+  "dupeof",
+  "owner",
+  "since",
+  "fixes",
+  "affects",
+  "priority",
+  "status",
+]);

--- a/packages/grammar/src/content.ts
+++ b/packages/grammar/src/content.ts
@@ -1,6 +1,6 @@
 // tldr ::: content segment processing and continuation handling for waymark grammar
 
-import { BLESSED_MARKERS, SIGIL } from "./constants";
+import { BLESSED_MARKERS, PROPERTY_KEYS, SIGIL } from "./constants";
 import {
   extractMentions,
   extractPropertiesAndRelations,
@@ -10,22 +10,6 @@ import type { WaymarkRecord } from "./types";
 
 const LEADING_SPACES_REGEX = /^\s+/;
 const HTML_COMMENT_CLOSE_REGEX = /\s*-->\s*$/;
-
-// Known property keys that can act as pseudo-markers in continuation context
-const PROPERTY_KEYS = new Set([
-  "ref",
-  "rel",
-  "depends",
-  "needs",
-  "blocks",
-  "dupeof",
-  "owner",
-  "since",
-  "fixes",
-  "affects",
-  "priority",
-  "status",
-]);
 
 export type ContentSegment = {
   text: string;

--- a/packages/grammar/src/index.ts
+++ b/packages/grammar/src/index.ts
@@ -7,6 +7,7 @@ export {
   getTypeCategory,
   MARKER_DEFINITIONS,
   MARKERS,
+  PROPERTY_KEYS,
   SIGIL,
   SIGNALS,
 } from "./constants";


### PR DESCRIPTION
Exported PROPERTY_KEYS from @waymarks/grammar as single source of truth.
Updated both grammar/content.ts and core/format.ts to import shared constant.
Added unit tests to ensure property keys stay aligned between packages.
Fixed markdown lint errors in .claude/commands/implement-issue.md.

This prevents the two lists from drifting apart when new properties are added,
eliminating the risk of formatter/parser inconsistencies.

Fixes: WAY-15

🤖 Generated with Claude Code (https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Grammar package now includes PROPERTY_KEYS in its public API exports alongside existing parse and SIGIL exports.

* **Tests**
  * Added test suites validating PROPERTY_KEYS alignment and consistency across the core formatting and grammar modules.

* **Refactor**
  * Consolidated PROPERTY_KEYS to a single authoritative source across packages.

* **Documentation**
  * Added comprehensive workflow documentation for implementing Linear issues with multi-phase orchestration and role-based agent processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->