### PR TITLE
docs(scratchpad): prune historical logs and compress to recent activity

### DIFF
--- a/SCRATCHPAD.md
+++ b/SCRATCHPAD.md
@@ -1,0 +1,75 @@
+<!-- tldr ::: running log of agent activities and recent work #docs/rules -->
+
+# Scratchpad
+
+Keep this log current while working. Recent activity only; historical logs archived in `.agents/.archive/`.
+
+## Active Notes
+
+<!-- note ::: Track milestones and tasks in Linear; keep this scratchpad as an ephemeral worklog snapshot -->
+
+- The `:::` sigil placement:
+  - Placed after the marker intentionally for backwards compatibility with existing TODO-style tooling
+  - When converted to AI tokens, it's just a single token (efficient)
+  - Visually distinct and easy to type
+
+## Recent Activity
+
+### 2025-10-16
+
+- **WAY-20: HTML Property Continuation Formatting** (Lock down HTML closure)
+  - Created unified `applyHtmlClosure()` helper to centralize HTML comment closure logic
+  - Refactored `formatMultiLine()` to apply closure via single `.map()` call instead of dual code paths
+  - Removed `ensureHtmlClosure()` function and inline closure logic from `renderContinuationLines()`
+  - Eliminated duplication: property continuations now handled consistently with text continuations
+  - Added comprehensive test suite covering all continuation types
+  - All 298 tests passing, full `bun check:all` green
+
+### 2025-10-07
+
+- **Cache Schema Migration Strategy**
+  - Added `CACHE_SCHEMA_VERSION = 2` constant with metadata table storage
+  - Implemented automatic cache invalidation on schema version mismatch
+  - Breaking change: `marker` column → `type` column (from 2025-09-30 refactoring)
+  - Migration strategy: drop all tables and regenerate from source (caches are ephemeral)
+  - All 71 core tests passing, full CI pipeline green
+
+- **PR #7 Review Feedback & Archive Cleanup**
+  - Used `logbooks snapshot` to capture CodeRabbit feedback (34 comments)
+  - Archived 15 completed log/planning files to `.agents/.archive/` (gitignored)
+  - Removed orphaned links in `IMPROVEMENTS.md` referencing archived refactor docs
+  - All critical/minor CodeRabbit issues addressed
+
+### 2025-10-03
+
+- Refactored `wm insert`/`wm remove` handlers into shared parsing/output helpers
+- Aligned `@waymarks/core` implementations with new ID reservation and formatting helpers
+- Authored `CHANGELOG.md`, updated README/PRD/docs for **1.0.0-beta.1** prerelease
+- **Performance: wyhash ID generation** (7.3x faster than SHA-256)
+  - Replaced SHA-256 with `Bun.hash.wyhash()` for ID generation
+  - Kept SHA-256 for content/context fingerprints (cryptographic properties needed)
+  - All tests passing, ID format unchanged (`wm:[base36]`)
+
+### 2025-10-02
+
+- **Config Standardization**: TOML as preferred format, removed `.json` support
+- **Pino Logger Integration**: Structured logging with `--verbose`, `--debug`, `--quiet` flags
+- **Enhanced CLI Output**: ripgrep-style formatting with type-specific colors and aligned output
+- **JSON Output Optimization**: Removed empty fields (~42% size reduction)
+- **Interactive Init**: Inquirer prompts for `wm init` when no flags provided
+
+### Earlier (Archived)
+
+Detailed historical logs available in `.agents/.archive/`:
+
+- [2025-09-26](./.agents/.archive/20250926-worklog.md) - Initial project setup, SQLite caching, grammar package
+- [2025-09-27](./.agents/.archive/20250927-worklog.md) - Quality review, MCP server, config alignment
+- [2025-09-28](./.agents/.archive/20250928-worklog.md) - Formatting remediation, CLI modularization
+- [2025-09-29](./.agents/.archive/20250929-worklog.md) - Multi-line grammar change, marker refactoring
+- [2025-09-30](./.agents/.archive/20250930-worklog.md) - Type terminology refactoring, CLI phases 1 & 2
+
+---
+
+## Historical Context
+
+See `.agents/.archive/` for complete historical logs. Current prerelease: **1.0.0-beta.1** (2025-10-03).


### PR DESCRIPTION
- Reduced scratchpad from ~1400 lines to ~75 lines
- Kept recent activity from Oct 2-16
- Moved verbose historical logs to references to .agents/.archive/
- Maintains active notes and clear navigation to full history

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added internal documentation for project tracking and activity logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->