### PR TITLE
chore: add way-* pattern to CodeRabbit base branches

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -24,6 +24,7 @@ reviews:
       - "feat/.*"
       - "gt/.*"      # Graphite stacked branches with slash prefix
       - "gt-.*"      # Graphite stacked branches with dash prefix
+      - "way-.*"     # Linear-generated branches like way-123-description
       - ".*-way-[0-9]+"  # Linear-generated branches like feature-way-123
 
   tools:


### PR DESCRIPTION
Include Linear-generated branches starting with 'way-' (e.g., way-123-description)
in CodeRabbit auto-review base branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>