### PR TITLE
chore: gitignore test database artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,10 @@ lerna-debug.log*
 # Testing
 coverage/
 .nyc_output/
+**/test-cache/
+**/test-cache.db
+**/test-cache.db-shm
+**/test-cache.db-wal
 
 # Temporary files
 tmp/


### PR DESCRIPTION
Remove test cache database files from git tracking and add them to .gitignore.
These are generated during test runs and should not be committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>