### PR TITLE
feat(cli): rename --pretty flag to --text (WAY-36)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ wm src/ --graph --json               # JSON output for tooling
 # Output formats
 wm src/ --json                       # compact JSON array
 wm src/ --jsonl                      # newline-delimited JSON
-wm src/ --pretty                     # pretty-printed JSON
+wm src/ --text                       # human-readable formatted text
 
 # Standalone commands
 wm format src/example.ts --write     # format a file

--- a/packages/cli/src/commands/help/registry.ts
+++ b/packages/cli/src/commands/help/registry.ts
@@ -44,10 +44,15 @@ const commonFlags = {
     type: "boolean",
     description: "Output as JSON lines (newline-delimited)",
   },
+  text: {
+    name: "text",
+    type: "boolean",
+    description: "Output as human-readable formatted text",
+  },
   pretty: {
     name: "pretty",
     type: "boolean",
-    description: "Output as pretty-printed JSON",
+    description: "(deprecated: use --text) Output as pretty-printed JSON",
   },
   long: {
     name: "long",
@@ -621,6 +626,7 @@ queries, filtering by type/tag/mention, and multiple output formats.
     },
     commonFlags.json,
     commonFlags.jsonl,
+    commonFlags.text,
     commonFlags.pretty,
     commonFlags.long,
     commonFlags.tree,

--- a/packages/cli/src/commands/scan.ts
+++ b/packages/cli/src/commands/scan.ts
@@ -42,7 +42,8 @@ export function parseScanArgs(argv: string[]): ParsedScanArgs {
   const formatFlags: Record<string, ScanOutputFormat> = {
     "--json": "json",
     "--jsonl": "jsonl",
-    "--pretty": "pretty",
+    "--text": "text",
+    "--pretty": "text", // Deprecated alias for --text
   };
 
   for (const arg of argv) {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -585,7 +585,8 @@ const BOOLEAN_OPTION_FLAGS = [
   { key: "summary", flag: "--summary" },
   { key: "json", flag: "--json" },
   { key: "jsonl", flag: "--jsonl" },
-  { key: "pretty", flag: "--pretty" },
+  { key: "text", flag: "--text" },
+  { key: "pretty", flag: "--pretty" }, // Deprecated alias for --text
   { key: "long", flag: "--long" },
   { key: "tree", flag: "--tree" },
   { key: "flat", flag: "--flat" },
@@ -1175,7 +1176,11 @@ See 'wm migrate --prompt' for agent-facing documentation.
     .option("--summary", "show summary footer (map mode)")
     .option("--json", "output as JSON")
     .option("--jsonl", "output as JSON Lines")
-    .option("--pretty", "output as pretty-printed JSON")
+    .option("--text", "output as human-readable formatted text")
+    .option(
+      "--pretty",
+      "(deprecated: use --text) output as pretty-printed JSON"
+    )
     .option("--long", "show detailed record information")
     .option("--tree", "group output by directory structure")
     .option("--flat", "show flat list (default)")


### PR DESCRIPTION
- Rename --pretty to --text for human-readable formatted output
- Keep --pretty as deprecated alias for backward compatibility
- Update all option definitions and help text
- Update README documentation to use --text
- Maintain all existing functionality with new flag name