### PR TITLE
feat(cli): rename complete command to completions (WAY-32)

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,33 +96,33 @@ The CLI relies on the core formatter, parser, and map helpers exported from `@wa
 
 #### Shell Completions
 
-Generate completions dynamically with the built-in `complete` command. The
+Generate completions dynamically with the built-in `completions` command. The
 examples below write the script to a cache directory and source it from your
 shell profile:
 
 ```bash
 # Zsh
 mkdir -p ~/.local/share/waymark/completions
-wm complete zsh > ~/.local/share/waymark/completions/wm.zsh
+wm completions zsh > ~/.local/share/waymark/completions/wm.zsh
 echo 'source ~/.local/share/waymark/completions/wm.zsh' >> ~/.zshrc
 
 # Bash
 mkdir -p ~/.local/share/waymark/completions
-wm complete bash > ~/.local/share/waymark/completions/wm.bash
+wm completions bash > ~/.local/share/waymark/completions/wm.bash
 echo 'source ~/.local/share/waymark/completions/wm.bash' >> ~/.bashrc
 
 # Fish
 mkdir -p ~/.config/fish/completions
-wm complete fish > ~/.config/fish/completions/wm.fish
+wm completions fish > ~/.config/fish/completions/wm.fish
 
 # PowerShell
 mkdir -p ~/.config/waymark/completions
-wm complete powershell > ~/.config/waymark/completions/wm.ps1
+wm completions powershell > ~/.config/waymark/completions/wm.ps1
 Add-Content $PROFILE "`n. ~/.config/waymark/completions/wm.ps1"
 ```
 
-Run `wm complete` without arguments to list supported shells or emit debugging
-information.
+Run `wm completions` without arguments to list supported shells or emit debugging
+information. Note: `wm complete` is also supported as a backward-compatible alias.
 
 ### MCP Server
 

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -47,33 +47,33 @@ wm --version
 
 ## Shell Completions
 
-Use the built-in `wm complete` command to generate completions for your shell.
+Use the built-in `wm completions` command to generate completions for your shell.
 Each command below writes the script to a cache directory and references it from
 your shell profile:
 
 ```bash
 # Zsh
 mkdir -p ~/.local/share/waymark/completions
-wm complete zsh > ~/.local/share/waymark/completions/wm.zsh
+wm completions zsh > ~/.local/share/waymark/completions/wm.zsh
 echo 'source ~/.local/share/waymark/completions/wm.zsh' >> ~/.zshrc
 
 # Bash
 mkdir -p ~/.local/share/waymark/completions
-wm complete bash > ~/.local/share/waymark/completions/wm.bash
+wm completions bash > ~/.local/share/waymark/completions/wm.bash
 echo 'source ~/.local/share/waymark/completions/wm.bash' >> ~/.bashrc
 
 # Fish
 mkdir -p ~/.config/fish/completions
-wm complete fish > ~/.config/fish/completions/wm.fish
+wm completions fish > ~/.config/fish/completions/wm.fish
 
 # PowerShell
 mkdir -p ~/.config/waymark/completions
-wm complete powershell > ~/.config/waymark/completions/wm.ps1
+wm completions powershell > ~/.config/waymark/completions/wm.ps1
 Add-Content $PROFILE "`n. ~/.config/waymark/completions/wm.ps1"
 ```
 
-Run `wm complete` without arguments to list supported shells and debugging
-helpers.
+Run `wm completions` without arguments to list supported shells and debugging
+helpers. Note: `wm complete` is also supported as a backward-compatible alias.
 
 ---
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -81,26 +81,26 @@ wm src/ --tree              # Tree view grouped by directory
 
 ## Shell Completions
 
-Generate completions with the built-in `wm complete` command:
+Generate completions with the built-in `wm completions` command:
 
 ```bash
 # Zsh
-wm complete zsh > ~/.local/share/waymark/completions/wm.zsh
+wm completions zsh > ~/.local/share/waymark/completions/wm.zsh
 echo 'source ~/.local/share/waymark/completions/wm.zsh' >> ~/.zshrc
 
 # Bash
-wm complete bash > ~/.local/share/waymark/completions/wm.bash
+wm completions bash > ~/.local/share/waymark/completions/wm.bash
 echo 'source ~/.local/share/waymark/completions/wm.bash' >> ~/.bashrc
 
 # Fish
-wm complete fish > ~/.config/fish/completions/wm.fish
+wm completions fish > ~/.config/fish/completions/wm.fish
 
 # PowerShell
-wm complete powershell > ~/.config/waymark/completions/wm.ps1
+wm completions powershell > ~/.config/waymark/completions/wm.ps1
 Add-Content $PROFILE "`n. ~/.config/waymark/completions/wm.ps1"
 ```
 
-Run `wm complete` with no arguments to see the supported shells.
+Run `wm completions` with no arguments to see the supported shells. Note: `wm complete` is also supported as a backward-compatible alias.
 
 ## Documentation
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1222,6 +1222,18 @@ See 'wm --prompt' for agent-facing documentation.
 
   tab(program);
 
+  // Rename 'complete' command to 'completions' with backward-compatible alias (WAY-32)
+  // The tab library adds a 'complete' command automatically, but we want 'completions' as primary
+  const completeCommand = program.commands.find(
+    (cmd) => cmd.name() === "complete"
+  );
+  if (completeCommand) {
+    // Update the name to 'completions' and add 'complete' as an alias
+    // biome-ignore lint/suspicious/noExplicitAny: accessing internal Commander.js structure to rename command
+    (completeCommand as any)._name = "completions";
+    completeCommand.alias("complete");
+  }
+
   return program;
 }
 


### PR DESCRIPTION
- Rename 'complete' command to 'completions' as the primary command name
- Keep 'complete' as a backward-compatible alias
- Update all documentation (README.md, docs/cli/README.md, packages/cli/README.md)
- Help output now shows 'completions|complete [shell]'
- Both commands generate shell completion scripts correctly