### PR TITLE
feat(cli): remove --keep-comment-markers flag (WAY-39)

### DIFF
--- a/CLI_READOUT.md
+++ b/CLI_READOUT.md
@@ -7,8 +7,8 @@
 
 ## General thoughts
 
-- Let's adopt a cleaner output format for non-JSON output, unless --keep-comment-markers is flagged (or a config option is enabled)
-- Let's strip the comment artifacts (`//`, `<!-- ... -->`, etc.)
+- Let's adopt a cleaner output format for non-JSON output
+- Let's strip the comment artifacts (`//`, `<!-- ... -->`, etc.) - this is now the default behavior
 - Any content OUTSIDE of the comment markers should be stripped
   - e.g. `yaml_key: value # todo ::: fix this` would be reduced to `todo ::: fix this`
 - Let's ensure that any leading and trailing whitespace is removed from the output

--- a/packages/cli/src/commands/help/registry.ts
+++ b/packages/cli/src/commands/help/registry.ts
@@ -69,11 +69,6 @@ const commonFlags = {
     type: "boolean",
     description: "Show flat list output",
   },
-  keepCommentMarkers: {
-    name: "keep-comment-markers",
-    type: "boolean",
-    description: "Keep comment syntax in output",
-  },
   compact: {
     name: "compact",
     type: "boolean",
@@ -631,7 +626,6 @@ queries, filtering by type/tag/mention, and multiple output formats.
     commonFlags.long,
     commonFlags.tree,
     commonFlags.flat,
-    commonFlags.keepCommentMarkers,
     commonFlags.compact,
     commonFlags.noColor,
     commonFlags.group,

--- a/packages/cli/src/commands/unified/flag-handlers.ts
+++ b/packages/cli/src/commands/unified/flag-handlers.ts
@@ -31,7 +31,6 @@ export type ParseState = {
   reverse: boolean;
   limit: number | undefined;
   page: number | undefined;
-  keepCommentMarkers: boolean;
   compact: boolean;
   noColor: boolean;
 };
@@ -124,10 +123,6 @@ export function handlePaginationFlags(
  * Handle formatting flags
  */
 function handleFormattingFlags(token: string, state: ParseState): boolean {
-  if (token === "--keep-comment-markers") {
-    state.keepCommentMarkers = true;
-    return true;
-  }
   if (token === "--compact") {
     state.compact = true;
     return true;

--- a/packages/cli/src/commands/unified/parser.ts
+++ b/packages/cli/src/commands/unified/parser.ts
@@ -49,7 +49,6 @@ export function createParseState(): ParseState {
     limit: undefined as number | undefined,
     page: undefined as number | undefined,
     // Formatting
-    keepCommentMarkers: false,
     compact: false,
     noColor: false,
   };
@@ -218,9 +217,6 @@ export function buildOptions(state: ParseState): UnifiedCommandOptions {
   }
 
   // Formatting
-  if (state.keepCommentMarkers) {
-    options.keepCommentMarkers = state.keepCommentMarkers;
-  }
   // Always pass compact through (it's a boolean, not optional)
   options.compact = state.compact;
   // Always pass noColor through (it's a boolean, not optional)

--- a/packages/cli/src/commands/unified/types.ts
+++ b/packages/cli/src/commands/unified/types.ts
@@ -53,7 +53,6 @@ export type UnifiedCommandOptions = {
   json?: boolean;
   summary?: boolean;
   // Formatting
-  keepCommentMarkers?: boolean;
   compact?: boolean;
   noColor?: boolean;
 };

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -590,7 +590,6 @@ const BOOLEAN_OPTION_FLAGS = [
   { key: "long", flag: "--long" },
   { key: "tree", flag: "--tree" },
   { key: "flat", flag: "--flat" },
-  { key: "keepCommentMarkers", flag: "--keep-comment-markers" },
   { key: "compact", flag: "--compact" },
   { key: "noColor", flag: "--no-color" },
 ] as const;
@@ -1184,7 +1183,6 @@ See 'wm migrate --prompt' for agent-facing documentation.
     .option("--long", "show detailed record information")
     .option("--tree", "group output by directory structure")
     .option("--flat", "show flat list (default)")
-    .option("--keep-comment-markers", "keep comment syntax in output")
     .option("--compact", "compact output format")
     .option("--no-color", "disable colored output")
     .option("--group <by>", "group by: file, dir, type")

--- a/packages/cli/src/utils/display/formatters/enhanced.ts
+++ b/packages/cli/src/utils/display/formatters/enhanced.ts
@@ -75,13 +75,10 @@ function formatWaymarkLine(
   longestTypeLength: number,
   options: DisplayOptions
 ): string {
-  const keepMarkers = options.keepCommentMarkers ?? false;
   const compact = options.compact ?? false;
 
-  // Extract the waymark content
-  const content = keepMarkers
-    ? record.raw
-    : stripCommentMarkers(record.raw, record.commentLeader);
+  // Extract the waymark content (always strip comment markers)
+  const content = stripCommentMarkers(record.raw, record.commentLeader);
 
   // Calculate spacing for alignment
   const typeWithSignal = getTypeWithSignal(record);
@@ -208,7 +205,6 @@ function formatMultiLineWaymark(
   options: DisplayOptions
 ): string[] {
   const lines: string[] = [];
-  const keepMarkers = options.keepCommentMarkers ?? false;
 
   // Split raw text into lines if multi-line
   const rawLines = record.raw.split("\n");
@@ -229,9 +225,8 @@ function formatMultiLineWaymark(
     const lineNum = String(currentLine).padStart(lineWidth, " ");
     const lineNumStr = styleLineNumber(lineNum);
 
-    const content = keepMarkers
-      ? rawLine
-      : stripCommentMarkers(rawLine, record.commentLeader || "");
+    // Always strip comment markers
+    const content = stripCommentMarkers(rawLine, record.commentLeader);
 
     // Determine line type and format accordingly
     if (i === 0) {

--- a/packages/cli/src/utils/display/types.ts
+++ b/packages/cli/src/utils/display/types.ts
@@ -13,7 +13,6 @@ export type DisplayOptions = Pick<
   | "reverse"
   | "limit"
   | "page"
-  | "keepCommentMarkers"
   | "compact"
   | "noColor"
 >;


### PR DESCRIPTION
Removes the --keep-comment-markers flag entirely. Comment markers
are now always stripped from output, which provides cleaner, more
consistent display for end users.

Changes:
- Remove flag definition from index.ts and help registry
- Remove keepCommentMarkers from all type definitions
- Remove flag handler logic
- Update enhanced formatter to always strip comment markers
- Update CLI_READOUT.md to reflect default behavior
- All 249 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>