### PR TITLE
fix(cli): remove duplicate global option definitions

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -872,10 +872,6 @@ async function createProgram(): Promise<Command> {
     .option("--verbose", "enable verbose logging (info level)")
     .option("--debug", "enable debug logging")
     .option("--quiet, -q", "only show errors")
-    .option("--json", "output as JSON")
-    .option("--jsonl", "output as JSON Lines")
-    .option("--text", "output as human-readable formatted text")
-    .option("--no-color", "disable colored output")
     .addHelpText(
       "afterAll",
       "\nNote: Use --prompt flag with any command to see agent-facing documentation"


### PR DESCRIPTION
Removes duplicate --json, --jsonl, --text, --no-color option definitions
from global program level (lines 875-878). These conflicted with
command-specific definitions, causing Commander.js to store them in
parent program.opts() instead of command options.

Fixes: WAY-48, WAY-49, WAY-50, WAY-51
Partial fix for WAY-52 (--no-color works, --jsonl needs parser impl)

Tested:
- wm find --json: ✅ outputs valid JSON
- wm find --map --json: ✅ outputs valid JSON map
- wm find --graph --json: ✅ outputs valid JSON (empty array)
- wm add/modify/remove --json: ✅ all output valid JSON
- wm find --no-color: ✅ no ANSI codes

🤖 Generated with Claude Code (https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>