### PR TITLE
fix(cli): drop duplicate raised flag handler

### DIFF
--- a/packages/cli/src/commands/remove.ts
+++ b/packages/cli/src/commands/remove.ts
@@ -79,9 +79,6 @@ const SIMPLE_FLAG_HANDLERS: Record<string, (state: RemoveParseState) => void> =
     "-R": (state) => {
       state.criteria.signals.raised = true;
     },
-    "-R": (state) => {
-      state.criteria.signals.raised = true;
-    },
     "--raised": (state) => {
       state.criteria.signals.raised = true;
     },


### PR DESCRIPTION
## Summary
- remove duplicate -R handler in remove command options

## Testing
- turbo run lint