### PR TITLE
fix(cli): accept positional add args

### DIFF
--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -204,10 +204,21 @@ function handlePositionalToken(token: string, state: InsertParseState): void {
   if (state.from !== undefined) {
     throw new Error("Cannot mix positional arguments with --from");
   }
+  if (!state.fileLine) {
+    state.fileLine = token;
+    return;
+  }
+  if (!state.type) {
+    state.type = token;
+    return;
+  }
+  if (!state.content) {
+    state.content = token;
+    return;
+  }
   if (state.fileLine) {
     throw new Error(`Unexpected positional argument: ${token}`);
   }
-  state.fileLine = token;
 }
 
 function validateFromMode(state: InsertParseState): void {


### PR DESCRIPTION
## Summary
- allow positional <type> and <content> for wm add (backward compatible)

## Testing
- bun test packages/cli/src/index.test.ts