### PR TITLE
chore(cli): drop unused lint suppressions

### DIFF
--- a/packages/cli/src/commands/modify.ts
+++ b/packages/cli/src/commands/modify.ts
@@ -737,7 +737,6 @@ function createKeypressHandler(
   };
 }
 
-// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Interactive prompt coordination requires managing keypress state, TTY setup, abort handling, and cleanup
 async function promptStep(
   promptModule: ReturnType<typeof inquirer.createPromptModule>,
   step: InteractiveStep,

--- a/packages/cli/src/commands/remove.ts
+++ b/packages/cli/src/commands/remove.ts
@@ -406,7 +406,6 @@ type LoadedRemovePayload = {
   options?: Partial<RemoveCommandOptions>;
 };
 
-// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: JSON parsing requires branching
 async function loadSpecsFromSource(path: string): Promise<LoadedRemovePayload> {
   const source =
     path === "-" ? await readFromStdin() : await readFile(path, "utf8");

--- a/packages/cli/src/commands/unified/parser.ts
+++ b/packages/cli/src/commands/unified/parser.ts
@@ -146,7 +146,6 @@ export function processToken(
 /**
  * Build final options from parse state
  */
-// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: option builder with many conditional fields
 export function buildOptions(state: ParseState): UnifiedCommandOptions {
   const options: UnifiedCommandOptions = {
     filePaths: state.positional.length > 0 ? state.positional : ["."],

--- a/packages/cli/src/commands/unified/query-parser.ts
+++ b/packages/cli/src/commands/unified/query-parser.ts
@@ -35,7 +35,6 @@ export type ParsedQuery = {
  *   "fix !@alice" → types: [fix], exclusions.mentions: [@alice]
  *   "owner:@alice" → properties: { owner: "@alice" }
  */
-// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: token classification requires multiple branches
 export function parseQuery(query: string): ParsedQuery {
   const tokens = tokenize(query);
   const result: ParsedQuery = {
@@ -78,7 +77,6 @@ export function parseQuery(query: string): ParsedQuery {
 /**
  * Tokenize a query string into individual tokens
  */
-// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: quote handling and state machine requires complex branching
 function tokenize(query: string): QueryToken[] {
   const tokens: QueryToken[] = [];
   let current = "";

--- a/packages/cli/src/utils/display/formatters/wrapping.ts
+++ b/packages/cli/src/utils/display/formatters/wrapping.ts
@@ -57,7 +57,6 @@ function getTerminalWidth(): number {
 /**
  * Tokenize content into breakable chunks
  */
-// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: tokenization requires conditional branching
 function tokenize(content: string): Token[] {
   const tokens: Token[] = [];
   let i = 0;
@@ -243,7 +242,6 @@ function tokenize(content: string): Token[] {
  * @param config - Wrapping configuration
  * @returns Array of wrapped lines
  */
-// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: wrapping algorithm requires complex conditional logic
 export function wrapContent(content: string, config: WrapConfig): string[] {
   // Handle empty/whitespace-only content early
   if (content.trim() === "") {


### PR DESCRIPTION
## Summary
- remove unused biome suppression comments

## Testing
- turbo run lint
- bun run lint:md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed internal lint configuration comments from CLI code. No functional changes or impact to end-user experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->