### PR TITLE
fix(cli): address doctor review feedback [WAY-47]

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -12,16 +12,25 @@
   },
   "linter": {
     "rules": {
-      "suspicious": {
-        "useAwait": "off"
-      },
-      "complexity": {
-        "noExcessiveCognitiveComplexity": "off"
-      },
       "style": {
         "noMagicNumbers": "warn",
         "noNestedTernary": "warn"
       }
     }
-  }
+  },
+  "overrides": [
+    {
+      "includes": ["packages/cli/src/commands/doctor.ts"],
+      "linter": {
+        "rules": {
+          "suspicious": {
+            "useAwait": "off"
+          },
+          "complexity": {
+            "noExcessiveCognitiveComplexity": "off"
+          }
+        }
+      }
+    }
+  ]
 }

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -1,14 +1,10 @@
 // tldr ::: health check diagnostics validating config integrity and waymark structure #cli
 
 import { existsSync } from "node:fs";
-import { readFile } from "node:fs/promises";
+import { readFile, stat } from "node:fs/promises";
+import { homedir } from "node:os";
 import { join } from "node:path";
-import {
-  buildRelationGraph,
-  isValidType,
-  parse,
-  type WaymarkRecord,
-} from "@waymarks/core";
+import { isValidType, parse, type WaymarkRecord } from "@waymarks/core";
 import chalk from "chalk";
 import type { CommandContext } from "../types";
 import { expandInputPaths } from "../utils/fs";
@@ -181,7 +177,8 @@ async function checkConfiguration(
 
   // Check 3: Cache directory writable
   try {
-    const cacheDir = join(context.workspaceRoot, "cache");
+    const cacheHome = process.env.XDG_CACHE_HOME || join(homedir(), ".cache");
+    const cacheDir = join(cacheHome, "waymark");
     if (!existsSync(cacheDir)) {
       issues.push({
         severity: "info",
@@ -217,7 +214,7 @@ async function checkEnvironment(
 
   // Check 1: Git repository
   try {
-    const gitDir = join(process.cwd(), ".git");
+    const gitDir = join(context.workspaceRoot, ".git");
     if (!existsSync(gitDir)) {
       issues.push({
         severity: "info",
@@ -231,7 +228,7 @@ async function checkEnvironment(
 
   // Check 2: Index files
   try {
-    const indexPath = join(context.workspaceRoot, "index.json");
+    const indexPath = join(context.workspaceRoot, ".waymark", "index.json");
     if (existsSync(indexPath)) {
       const indexContent = await readFile(indexPath, "utf-8");
       try {
@@ -253,7 +250,7 @@ async function checkEnvironment(
 
   // Check 3: Gitignore patterns
   try {
-    const gitignorePath = join(process.cwd(), ".gitignore");
+    const gitignorePath = join(context.workspaceRoot, ".gitignore");
     if (existsSync(gitignorePath)) {
       const gitignoreContent = await readFile(gitignorePath, "utf-8");
       if (!gitignoreContent.includes(".waymark/index.json")) {
@@ -353,7 +350,6 @@ async function checkWaymarkIntegrity(
   }
 
   // Check 2: Dangling relations
-  const _graph = buildRelationGraph(allRecords);
   for (const record of allRecords) {
     for (const relation of record.relations || []) {
       if (CANONICAL_RELATIONS.includes(relation.kind)) {
@@ -517,11 +513,9 @@ async function checkPerformance(
   const issues: DiagnosticIssue[] = [];
 
   try {
-    const indexPath = join(context.workspaceRoot, "index.json");
+    const indexPath = join(context.workspaceRoot, ".waymark", "index.json");
     if (existsSync(indexPath)) {
-      const stats = await import("node:fs/promises").then((fs) =>
-        fs.stat(indexPath)
-      );
+      const stats = await stat(indexPath);
       const sizeMb = stats.size / BYTES_PER_MB;
 
       if (sizeMb > MAX_INDEX_MB) {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -704,15 +704,14 @@ async function handleDoctorCommand(
   program: Command,
   options: DoctorCommandOptions
 ): Promise<void> {
-  const scopeValue = program.opts().scope as string;
-  const globalOpts = { scope: normalizeScope(scopeValue) };
+  const programOpts = program.opts();
+  const globalOpts = { scope: normalizeScope(programOpts.scope as string) };
   const context = await createContext(globalOpts);
 
   const report = await runDoctorCommand(context, options);
 
   // Output based on format (check both local and global options)
-  const globalOpts2 = program.opts();
-  if (options.json || globalOpts2.json) {
+  if (options.json || programOpts.json) {
     writeStdout(JSON.stringify(report, null, 2));
   } else {
     const formatted = formatDoctorReport(report);


### PR DESCRIPTION
## Summary
- scope Biome overrides to the doctor command and align cache/index checks
- simplify doctor output formatting and remove unused relation graph work
- normalize global option handling for doctor output

## Testing
- turbo run lint
- turbo run typecheck
- turbo run test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Doctor command now uses standard system cache directories (XDG_CACHE_HOME or home directory) instead of workspace-local caching
  * Improved workspace root path resolution for diagnostics checks
  * Performance optimizations for file integrity validation

* **Chores**
  * Configuration adjustments for linting rules

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->