### PR TITLE
fix(cli): align scan format flags

### DIFF
--- a/packages/cli/src/commands/scan.ts
+++ b/packages/cli/src/commands/scan.ts
@@ -43,7 +43,7 @@ export function parseScanArgs(argv: string[]): ParsedScanArgs {
     "--json": "json",
     "--jsonl": "jsonl",
     "--text": "text",
-    "--pretty": "pretty", // Pretty-printed JSON (deprecated - use --json with jq for formatting)
+    "--pretty": "json", // Pretty-printed JSON (deprecated - use --json with jq for formatting)
   };
 
   for (const arg of argv) {


### PR DESCRIPTION
## Summary
- map deprecated scan --pretty to JSON output
- polish doctor output helpers and constants

## Testing
- turbo run lint
- turbo run typecheck
- turbo run test