### PR TITLE
chore(cli): clarify mb constant

### DIFF
--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -19,8 +19,8 @@ const CANONICAL_RELATIONS: WaymarkRecord["relations"][number]["kind"][] = [
   "rel",
 ];
 const TLDR_TOP_LINES_MAX = 20;
-const KIBIBYTE = 1024;
-const BYTES_PER_MB = KIBIBYTE * KIBIBYTE;
+// biome-ignore lint/style/noMagicNumbers: bytes per megabyte conversion
+const BYTES_PER_MB = 1024 * 1024;
 const MAX_INDEX_MB = 10;
 
 // this ::: diagnostic issue severity and metadata structure


### PR DESCRIPTION
## Summary
- document the bytes-per-megabyte constant for Biome

## Testing
- turbo run lint
- turbo run typecheck
- turbo run test