### PR TITLE
fix(cli): support positional add tokens

### DIFF
--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -216,9 +216,7 @@ function handlePositionalToken(token: string, state: InsertParseState): void {
     state.content = token;
     return;
   }
-  if (state.fileLine) {
-    throw new Error(`Unexpected positional argument: ${token}`);
-  }
+  throw new Error(`Unexpected positional argument: ${token}`);
 }
 
 function validateFromMode(state: InsertParseState): void {


### PR DESCRIPTION
## Summary
- allow positional file/type/content tokens in add command parsing

## Testing
- turbo run lint
- turbo run typecheck
- turbo run test
