### PR TITLE
docs: clarify docstrings and line-comment policy

### DIFF
--- a/.waymark/rules/WAYMARKS.md
+++ b/.waymark/rules/WAYMARKS.md
@@ -27,6 +27,8 @@ A waymark is a single comment line (or continuation block) built from the follow
 
 Multi-line waymarks use markerless `:::` continuation lines, with optional alignment to the parent waymark's `:::` position for improved readability.
 
+Line comments are preferred whenever the language supports them. Use block comments only in languages without line-comment support (for example, CSS).
+
 ## 2. Blessed Markers
 
 Only the following markers are considered first-class by the toolchain. Custom markers are possible but require explicit configuration and may trigger lint warnings.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,30 @@ Waymark defines and maintains the `:::` comment sigil plus supporting tooling so
 
 Read the full background in [Historical Priors for Waymark-Style Anchors](docs/about/priors.md).
 
+### Waymarks Are Not Docstrings
+
+Waymarks **complement** docstrings; they never replace them.
+
+| Purpose | Use |
+| --- | --- |
+| Public API contracts | Docstrings (JSDoc/TSDoc/docstrings) |
+| Internal intent + ownership | Waymarks |
+
+Place waymarks adjacent to docstrings, never inside them:
+
+```typescript
+/**
+ * Authenticates a user and returns a session token.
+ * @param request - User login credentials
+ * @returns Session token or throws AuthError
+ */
+// this ::: orchestrates OAuth flow with PKCE #auth/login
+// todo ::: @agent add rate limiting #sec:boundary
+export async function authenticate(request: AuthRequest) {
+  // ...
+}
+```
+
 ### Waymarks in Practice
 
 ```typescript
@@ -26,11 +50,13 @@ export async function authenticate(request: AuthRequest) {
   const user = await fetchUser(request.email)
   // question ::: should we allow social login here? @product
 
-  /* ^todo ::: @agent implement refresh token rotation once backend ships */
+  // ^todo ::: @agent implement refresh token rotation once backend ships
   return issueSession(user, request) // note ::: returns JWT signed with HS256
 }
 
 Signals follow the v1 grammar: only the caret (`^`) and a single star (`*`) prefix are valid. Raised waymarks (`^todo`) mark work-in-progress that must clear before merging; starred waymarks (`*fix`) mark high-priority items. Combining them (`^*todo`) is fine, while doubling (`**fix`) is not.
+
+Line comments are preferred for waymarks. Use block comments only in languages without line-comment support (for example, CSS).
 ```
 
 ## Start Here

--- a/docs/GRAMMAR.md
+++ b/docs/GRAMMAR.md
@@ -72,6 +72,28 @@ A waymark is a structured comment that embeds machine-readable context directly 
 
 **Core principle**: Everything after the `:::` sigil is free-form content, but we extract structured data (properties, tags, mentions) using simple token patterns.
 
+## Waymarks Are Not Docstrings
+
+Waymarks **complement** docstrings; they never replace them. Docstrings describe public APIs for external consumers, while waymarks capture internal intent, ownership, and next steps.
+
+- **Docstrings**: API contracts, parameters, return values, examples.
+- **Waymarks**: why/ownership/next steps, operational notes, migration cues.
+
+Place waymarks adjacent to docstrings, never inside them:
+
+```typescript
+/**
+ * Authenticates a user and returns a session token.
+ * @param request - User login credentials
+ * @returns Session token or throws AuthError
+ */
+// this ::: orchestrates OAuth flow with PKCE #auth/login
+// todo ::: @agent add rate limiting #sec:boundary
+export async function authenticate(request: AuthRequest) {
+  // ...
+}
+```
+
 ---
 
 ## Basic Syntax
@@ -112,9 +134,10 @@ Waymarks work with any comment syntax:
 | Python, Ruby, Shell, YAML | `#` | `# note ::: assumes UTC` |
 | SQL | `--` | `-- fix ::: escape quotes` |
 | HTML, XML, Markdown | `<!-- -->` | `<!-- tldr ::: API guide -->` |
-| CSS, C-style | `/* */` | `/* warn ::: deprecated */` |
+| CSS (and other languages without line comments) | `/* */` | `/* warn ::: deprecated */` |
 
-**Block comments**: Allowed for waymarks when not rendered as documentation. Avoid placing waymarks inside docstrings.
+**Block comments**: Allowed for waymarks only in languages without line-comment support. Avoid placing waymarks inside docstrings.
+Line comments are preferred whenever available.
 
 ### The `:::` Sigil
 


### PR DESCRIPTION
## Summary\n- Clarify docstring vs waymark guidance and line-comment policy.\n\n## Testing\n- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guidance distinguishing waymarks from docstrings, clarifying their complementary roles with placement recommendations.
  * Updated recommendations to prefer line comments over block comments for waymarks when language support permits.
  * Included practical examples demonstrating proper waymark usage alongside docstrings and improved documentation clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->