### PR TITLE
docs: archive MCP prompt content for future skill development

### DIFF
--- a/docs/.archive/mcp-prompts/README.md
+++ b/docs/.archive/mcp-prompts/README.md
@@ -1,0 +1,21 @@
+<!-- tldr ::: archived MCP prompt content for future skill development -->
+
+# Archived MCP Prompts
+
+This directory contains the prompt content from the waymark MCP server's
+`waymark.tldr` and `waymark.todo` prompts. These prompts were removed as part of
+simplifying the MCP interface to a single-tool pattern.
+
+The content here serves as guidance for future skill development.
+
+## Files
+
+- `tldr-prompt.md` - Guidance for drafting TLDR waymarks
+- `todo-prompt.md` - Guidance for drafting TODO waymarks
+
+## Migration Context
+
+- **Issue**: #95 (Move CLI help/prompt text to raw files)
+- **Related**: #117 (skills), #118 (CLI), #119 (MCP single-tool)
+- **Pattern**: Moving from MCP prompts to Claude Code skills
+- **Date**: 2025-01-05

--- a/docs/.archive/mcp-prompts/tldr-prompt.md
+++ b/docs/.archive/mcp-prompts/tldr-prompt.md
@@ -1,0 +1,36 @@
+<!-- tldr ::: archived tldr prompt guidance for skill development -->
+
+# TLDR Waymark Drafting Guidance
+
+Archived from `apps/mcp/src/prompts/tldr.ts`.
+
+## Prompt Text
+
+Write a single-sentence TLDR waymark that summarizes the file.
+Use active voice, cite the primary capability, and end with key technologies or domains.
+
+## Context Provided
+
+- File path (normalized for output)
+- File snippet (truncated to max lines, default 200, max 2000)
+
+## Implementation Notes
+
+- Reads file content via `safeReadFile`
+- Truncates to bounded limit (1-2000 lines)
+- Returns as MCP prompt with `role: "user"`
+
+## Example Output Pattern
+
+```typescript
+// tldr ::: Stripe webhook handler verifying signatures and queuing retries #payments
+```
+
+## Skill Development Notes
+
+When converting to a skill:
+
+1. Load the file content as context
+2. Reference `.waymark/rules/TLDRs.md` for detailed guidance
+3. Check existing waymarks in the file to avoid duplicates
+4. Use the formatter to normalize the output

--- a/docs/.archive/mcp-prompts/todo-prompt.md
+++ b/docs/.archive/mcp-prompts/todo-prompt.md
@@ -1,0 +1,36 @@
+<!-- tldr ::: archived todo prompt guidance for skill development -->
+
+# TODO Waymark Drafting Guidance
+
+Archived from `apps/mcp/src/prompts/todo.ts`.
+
+## Prompt Text
+
+Write a TODO waymark content line (no marker) that captures the essential follow-up work.
+Keep it short, actionable, and mention owners or references if provided.
+
+## Context Provided
+
+- Summary (required) - Brief description of the work
+- File path (optional) - Where the TODO should be placed
+- Context (optional) - Additional context about the work
+
+## Implementation Notes
+
+- Simple text assembly, no file reading
+- Returns as MCP prompt with `role: "user"`
+
+## Example Output Pattern
+
+```typescript
+// todo ::: @agent implement rate limiting for auth endpoints #sec:boundary
+```
+
+## Skill Development Notes
+
+When converting to a skill:
+
+1. Accept summary/context from user or infer from conversation
+2. Reference `.waymark/rules/CONVENTIONS.md` for tag patterns
+3. Suggest appropriate signals (^ for WIP, * for priority)
+4. Include relevant mentions (@agent, @username) when ownership matters


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for archived prompt guidance, including TLDR waymark and TODO waymark instructions with implementation and skill development notes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->