### PR TITLE
feat(core): add editWaymark API and Linear rules

### DIFF
--- a/.agents/rules/LINEAR.md
+++ b/.agents/rules/LINEAR.md
@@ -5,12 +5,37 @@
 ## Project
 
 - Team: Waymark (subteam of Outfitter)
-- ID: `WAY`
-- Project: `Waymark v1.0.0-beta.1`
+- Key: `WAY`
+- Workspace: Outfitter
+
+## Streamlinear MCP
+
+This project uses the `streamlinear` MCP server for Linear integration. All actions use a single tool: `mcp__linear__linear`.
+
+### Default Team Filter
+
+Always filter by team `WAY` when searching:
+
+```json
+{ "action": "search", "query": { "team": "WAY" } }
+```
+
+### Common Actions
+
+| Action | Example |
+|--------|---------|
+| Search team issues | `{ "action": "search", "query": { "team": "WAY" } }` |
+| Search in progress | `{ "action": "search", "query": { "team": "WAY", "state": "In Progress" } }` |
+| Get issue | `{ "action": "get", "id": "WAY-123" }` |
+| Update status | `{ "action": "update", "id": "WAY-123", "state": "Done" }` |
+| Add comment | `{ "action": "comment", "id": "WAY-123", "body": "Comment text" }` |
+| Create issue | `{ "action": "create", "title": "Issue title", "team": "WAY" }` |
+| GraphQL query | `{ "action": "graphql", "graphql": "query { ... }" }` |
 
 ## Rules
 
-- This project uses Linear for project management. By default, issues should be created in Linear first. Creating GitHub issues is also important, but should come secondary to Linear.
+- Linear is the authoritative tracker. Log or locate an issue before meaningful work.
+- Always use team filter `WAY` when searching to scope results to this project.
 - When working on Linear issues, reference them in commits and PRs using the format below.
 
 ## Linear Issue References
@@ -24,7 +49,7 @@ feat: implement authentication flow
 
 Implements user login with OAuth 2.0 and session management.
 
-Linear: WAY-123
+Fixes: WAY-123
 ```
 
 ### Multiple Issues
@@ -36,7 +61,7 @@ fix: resolve validation bugs
 
 Fixes multiple edge cases in input validation.
 
-Linear: WAY-45, WAY-46
+Fixes: WAY-45, WAY-46
 ```
 
 ### Branch Naming
@@ -53,15 +78,15 @@ gt create -m "feat: implement auth"
 Include the issue ID in PR titles for traceability:
 
 ```plaintext
-[WAY-123] feat: implement authentication flow
+feat: implement authentication flow [WAY-123]
 ```
 
 ### Alternative Keywords
 
 You can use any of these keywords in commit footers:
 
-- `Linear: WAY-123`
-- `Refs: WAY-123`
-- `Related: WAY-123`
+- `Fixes: WAY-123` (closing)
+- `Refs: WAY-123` (non-closing)
+- `Related: WAY-123` (non-closing)
 
 The important part is including the issue ID (e.g., `WAY-123`) for linking.

--- a/packages/core/src/edit.test.ts
+++ b/packages/core/src/edit.test.ts
@@ -1,0 +1,180 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+
+import {
+  DEFAULT_CONFIG,
+  editWaymark,
+  fingerprintContent,
+  fingerprintContext,
+  JsonIdIndex,
+  WaymarkIdManager,
+} from "./index.ts";
+
+async function ensureDir(path: string): Promise<void> {
+  await mkdir(path, { recursive: true });
+}
+
+describe("editWaymark", () => {
+  let workspace: string;
+
+  beforeEach(async () => {
+    workspace = await mkdtemp(join(tmpdir(), "waymark-edit-"));
+  });
+
+  afterEach(async () => {
+    await rm(workspace, { recursive: true, force: true });
+  });
+
+  function createManager() {
+    const index = new JsonIdIndex({ workspaceRoot: workspace });
+    const manager = new WaymarkIdManager(
+      { ...DEFAULT_CONFIG.ids, mode: "auto" },
+      index
+    );
+    return { index, manager };
+  }
+
+  it("updates the waymark type", async () => {
+    const filePath = join(workspace, "src/auth.ts");
+    await ensureDir(dirname(filePath));
+    await writeFile(filePath, "// todo ::: handle auth\n", "utf8");
+
+    const result = await editWaymark(
+      { file: filePath, line: 1, type: "fix", write: true },
+      DEFAULT_CONFIG
+    );
+
+    expect(result.after.type).toBe("fix");
+    const contents = await readFile(filePath, "utf8");
+    expect(contents).toContain("// fix ::: handle auth");
+  });
+
+  it("updates content and preserves IDs", async () => {
+    const filePath = join(workspace, "src/rate.ts");
+    await ensureDir(dirname(filePath));
+    await writeFile(
+      filePath,
+      "// todo ::: add rate limiting wm:test123\n",
+      "utf8"
+    );
+
+    const result = await editWaymark(
+      {
+        file: filePath,
+        line: 1,
+        content: "add retry budget",
+        write: true,
+      },
+      DEFAULT_CONFIG
+    );
+
+    expect(result.after.raw).toContain("wm:test123");
+    const contents = await readFile(filePath, "utf8");
+    expect(contents).toContain("add retry budget wm:test123");
+  });
+
+  it("preserves IDs found outside the header line", async () => {
+    const filePath = join(workspace, "src/continuation.ts");
+    await ensureDir(dirname(filePath));
+    await writeFile(
+      filePath,
+      [
+        "// todo ::: add rate limiting",
+        "//      ::: wm:test999 #auth",
+        "",
+      ].join("\n"),
+      "utf8"
+    );
+
+    const result = await editWaymark(
+      {
+        file: filePath,
+        line: 1,
+        content: "add retry budget",
+        write: true,
+      },
+      DEFAULT_CONFIG
+    );
+
+    expect(result.after.raw).toContain("wm:test999");
+    const contents = await readFile(filePath, "utf8");
+    expect(contents).toContain("add retry budget wm:test999");
+  });
+
+  it("sets and clears signals", async () => {
+    const filePath = join(workspace, "src/signals.ts");
+    await ensureDir(dirname(filePath));
+    await writeFile(filePath, "// todo ::: audit\n", "utf8");
+
+    await editWaymark(
+      { file: filePath, line: 1, raised: true, starred: true, write: true },
+      DEFAULT_CONFIG
+    );
+
+    let contents = await readFile(filePath, "utf8");
+    expect(contents).toContain("// ^*todo ::: audit");
+
+    await editWaymark(
+      { file: filePath, line: 1, clearSignals: true, write: true },
+      DEFAULT_CONFIG
+    );
+
+    contents = await readFile(filePath, "utf8");
+    expect(contents).toContain("// todo ::: audit");
+  });
+
+  it("edits by id and refreshes the index", async () => {
+    const filePath = join(workspace, "src/by-id.ts");
+    await ensureDir(dirname(filePath));
+    await writeFile(
+      filePath,
+      "// todo ::: implement OAuth wm:abc123\n",
+      "utf8"
+    );
+
+    const { index, manager } = createManager();
+    await index.set({
+      id: "wm:abc123",
+      file: filePath,
+      line: 1,
+      type: "todo",
+      content: "implement OAuth wm:abc123",
+      contentHash: fingerprintContent("implement OAuth wm:abc123"),
+      contextHash: fingerprintContext(`${filePath}:1`),
+      updatedAt: Date.now(),
+    });
+
+    await editWaymark(
+      {
+        id: "wm:abc123",
+        content: "implement OAuth + PKCE",
+        write: true,
+        idManager: manager,
+      },
+      DEFAULT_CONFIG
+    );
+
+    const refreshed = await index.get("wm:abc123");
+    expect(refreshed?.content).toBe("implement OAuth + PKCE wm:abc123");
+
+    const contents = await readFile(filePath, "utf8");
+    expect(contents).toContain("implement OAuth + PKCE wm:abc123");
+  });
+
+  it("previews edits without writing", async () => {
+    const filePath = join(workspace, "src/preview.ts");
+    await ensureDir(dirname(filePath));
+    await writeFile(filePath, "// todo ::: preview\n", "utf8");
+
+    const result = await editWaymark(
+      { file: filePath, line: 1, type: "note" },
+      DEFAULT_CONFIG
+    );
+
+    expect(result.written).toBe(false);
+    const contents = await readFile(filePath, "utf8");
+    expect(contents).toContain("// todo ::: preview");
+  });
+});

--- a/packages/core/src/edit.ts
+++ b/packages/core/src/edit.ts
@@ -1,0 +1,646 @@
+// tldr ::: edit waymarks in place while preserving IDs and formatting
+
+import { existsSync } from "node:fs";
+import { readFile, writeFile } from "node:fs/promises";
+
+import { parse, SIGIL, type WaymarkRecord } from "@waymarks/grammar";
+import { z } from "zod";
+
+import { formatText } from "./format.ts";
+import {
+  fingerprintContent,
+  fingerprintContext,
+  type WaymarkIdManager,
+} from "./ids.ts";
+import type { CoreLogger, WaymarkConfig } from "./types.ts";
+
+const LINE_SPLIT_REGEX = /\r?\n/;
+const CARRIAGE_RETURN_REGEX = /\r$/;
+const HTML_COMMENT_LEADER = "<!--";
+const HTML_COMMENT_CLOSE_REGEX = /\s*--!?>\s*$/;
+const CONTEXT_BEFORE_LINES = 2;
+const CONTEXT_AFTER_LINES = 3;
+
+export const EditSpecSchema = z
+  .object({
+    file: z.string().min(1).optional(),
+    line: z.number().int().positive().optional(),
+    id: z.string().trim().min(1).optional(),
+    type: z.string().trim().min(1).optional(),
+    content: z.string().optional(),
+    raised: z.boolean().optional(),
+    starred: z.boolean().optional(),
+    clearSignals: z.boolean().optional(),
+    write: z.boolean().optional(),
+  })
+  .refine(
+    (data) => {
+      const hasId = Boolean(data.id);
+      const hasFileLine =
+        typeof data.file === "string" && typeof data.line === "number";
+      return hasId || hasFileLine;
+    },
+    {
+      message: "Must provide a target via id or file + line",
+      path: ["file"],
+    }
+  )
+  .refine(
+    (data) => {
+      const hasId = Boolean(data.id);
+      const hasFileLine =
+        typeof data.file === "string" && typeof data.line === "number";
+      return !(hasId && hasFileLine);
+    },
+    { message: "Cannot specify both id and file + line", path: ["id"] }
+  )
+  .refine(
+    (data) =>
+      data.type !== undefined ||
+      data.content !== undefined ||
+      data.raised !== undefined ||
+      data.starred !== undefined ||
+      data.clearSignals === true,
+    {
+      message:
+        "Must provide at least one modification (type, content, signals)",
+      path: ["type"],
+    }
+  );
+
+export type EditSpec = z.infer<typeof EditSpecSchema>;
+
+export type EditOptions = EditSpec & {
+  idManager?: WaymarkIdManager;
+  logger?: CoreLogger;
+};
+
+export type EditResult = {
+  file: string;
+  before: WaymarkRecord;
+  after: WaymarkRecord;
+  written: boolean;
+};
+
+type FileSnapshot = {
+  text: string;
+  lines: string[];
+  eol: string;
+  endsWithFinalEol: boolean;
+  records: WaymarkRecord[];
+};
+
+type ResolvedTarget = {
+  file: string;
+  line: number;
+  id?: string;
+};
+
+export async function editWaymark(
+  options: EditOptions,
+  config?: WaymarkConfig
+): Promise<EditResult> {
+  const spec = EditSpecSchema.parse({
+    file: options.file,
+    line: options.line,
+    id: options.id,
+    type: options.type,
+    content: options.content,
+    raised: options.raised,
+    starred: options.starred,
+    clearSignals: options.clearSignals,
+    write: options.write,
+  });
+
+  const target = await resolveTarget(spec, options.idManager);
+  options.logger?.debug("Editing waymark", {
+    file: target.file,
+    line: target.line,
+    id: target.id,
+  });
+
+  const snapshot = await loadFileSnapshot(target.file);
+  if (!snapshot) {
+    throw new Error(`File not found: ${target.file}`);
+  }
+
+  const { record, originalContent, existingId } = resolveRecordContext(
+    snapshot,
+    target
+  );
+  assertIdMatches({
+    ...(target.id === undefined ? {} : { targetId: target.id }),
+    ...(existingId === undefined ? {} : { existingId }),
+    file: target.file,
+    line: record.startLine,
+  });
+
+  const nextType = resolveType(record.type, spec.type);
+  const signalOverrides = {
+    ...(spec.raised === undefined ? {} : { raised: spec.raised }),
+    ...(spec.starred === undefined ? {} : { starred: spec.starred }),
+    ...(spec.clearSignals === undefined
+      ? {}
+      : { clearSignals: spec.clearSignals }),
+  };
+  const nextSignals = resolveSignals(record.signals, signalOverrides);
+
+  const draftLines = buildDraftLines({
+    record,
+    spec,
+    existingId,
+    originalContent,
+    type: nextType,
+    signals: nextSignals,
+  });
+
+  const { updatedText, updatedLines, written } = await applyDraftEdits({
+    snapshot,
+    record,
+    draftLines,
+    file: target.file,
+    ...(config === undefined ? {} : { config }),
+    ...(spec.write === undefined ? {} : { write: spec.write }),
+  });
+
+  const afterRecord = resolveUpdatedRecord({
+    updatedText,
+    file: target.file,
+    record,
+    existingId,
+    ...(target.id === undefined ? {} : { targetId: target.id }),
+  });
+
+  if (written && options.idManager && (existingId || target.id)) {
+    const normalizedId = normalizeId(existingId ?? target.id ?? "");
+    await updateIdIndex({
+      idManager: options.idManager,
+      id: normalizedId,
+      record: afterRecord,
+      lines: updatedLines,
+      file: target.file,
+    });
+  }
+
+  return {
+    file: target.file,
+    before: record,
+    after: afterRecord,
+    written,
+  };
+}
+
+function resolveRecordContext(
+  snapshot: FileSnapshot,
+  target: ResolvedTarget
+): {
+  record: WaymarkRecord;
+  originalContent: string;
+  existingId: string | undefined;
+} {
+  const record = resolveRecord(snapshot.records, target);
+  if (!record) {
+    throw new Error(`No waymark found at ${target.file}:${target.line}`);
+  }
+
+  const originalLines = record.raw.split(LINE_SPLIT_REGEX);
+  const firstLine = originalLines[0] ?? "";
+  const originalContent = stripHtmlClosure(
+    extractFirstLineContent(firstLine),
+    record.commentLeader
+  );
+  const existingId = extractExistingId(record.contentText);
+
+  return { record, originalContent, existingId };
+}
+
+function assertIdMatches(args: {
+  targetId?: string;
+  existingId?: string;
+  file: string;
+  line: number;
+}): void {
+  const { targetId, existingId, file, line } = args;
+  if (!targetId) {
+    return;
+  }
+  const normalizedTargetId = normalizeId(targetId);
+  if (!existingId) {
+    throw new Error(
+      `Waymark id ${normalizedTargetId} not found in ${file}:${line}`
+    );
+  }
+  const normalizedExisting = normalizeId(existingId);
+  if (normalizedExisting !== normalizedTargetId) {
+    throw new Error(`Waymark id mismatch at ${file}:${line}`);
+  }
+}
+
+function buildDraftLines(args: {
+  record: WaymarkRecord;
+  spec: EditSpec;
+  existingId: string | undefined;
+  originalContent: string;
+  type: string;
+  signals: WaymarkRecord["signals"];
+}): string[] {
+  if (args.spec.content !== undefined) {
+    return buildLinesFromContent({
+      record: args.record,
+      type: args.type,
+      signals: args.signals,
+      content: applyIdToContent(
+        args.spec.content ?? "",
+        args.existingId,
+        args.record.commentLeader
+      ),
+    });
+  }
+
+  return buildLinesFromExisting({
+    record: args.record,
+    type: args.type,
+    signals: args.signals,
+    content: args.originalContent,
+  });
+}
+
+async function applyDraftEdits(args: {
+  snapshot: FileSnapshot;
+  record: WaymarkRecord;
+  draftLines: string[];
+  config?: WaymarkConfig;
+  file: string;
+  write?: boolean;
+}): Promise<{
+  updatedText: string;
+  updatedLines: string[];
+  written: boolean;
+}> {
+  const draftText = args.draftLines.join("\n");
+  const formatOptions = {
+    file: args.file,
+    ...(args.config === undefined ? {} : { config: args.config }),
+  };
+  const { formattedText } = formatText(draftText, formatOptions);
+  const formattedLines = formattedText.split(LINE_SPLIT_REGEX);
+
+  const updatedLines = [...args.snapshot.lines];
+  const startIndex = args.record.startLine - 1;
+  const removeCount = args.record.endLine - args.record.startLine + 1;
+  updatedLines.splice(startIndex, removeCount, ...formattedLines);
+
+  const updatedText = buildFileText(
+    updatedLines,
+    args.snapshot.eol,
+    args.snapshot.endsWithFinalEol
+  );
+
+  const changed = updatedText !== args.snapshot.text;
+  const written = Boolean(args.write && changed);
+
+  if (written) {
+    await writeFile(args.file, updatedText, "utf8");
+  }
+
+  return { updatedText, updatedLines, written };
+}
+
+function resolveUpdatedRecord(args: {
+  updatedText: string;
+  file: string;
+  record: WaymarkRecord;
+  existingId: string | undefined;
+  targetId?: string;
+}): WaymarkRecord {
+  const updatedRecords = parse(args.updatedText, { file: args.file });
+  const resolvedId = args.existingId ?? args.targetId;
+  const afterRecord = resolveRecord(updatedRecords, {
+    file: args.file,
+    line: args.record.startLine,
+    ...(resolvedId === undefined ? {} : { id: resolvedId }),
+  });
+  if (!afterRecord) {
+    throw new Error(
+      `Failed to resolve updated waymark at ${args.file}:${args.record.startLine}`
+    );
+  }
+  return afterRecord;
+}
+
+async function resolveTarget(
+  spec: EditSpec,
+  idManager?: WaymarkIdManager
+): Promise<ResolvedTarget> {
+  if (spec.id) {
+    if (!idManager) {
+      throw new Error("ID-based edits require an ID manager");
+    }
+    const normalized = normalizeId(spec.id);
+    const entry = await idManager.get(normalized);
+    if (!entry) {
+      throw new Error(`Unknown waymark id: ${normalized}`);
+    }
+    return { file: entry.file, line: entry.line, id: normalized };
+  }
+
+  if (!spec.file || typeof spec.line !== "number") {
+    throw new Error("File and line are required for line-based edits");
+  }
+
+  return { file: spec.file, line: spec.line };
+}
+
+async function loadFileSnapshot(file: string): Promise<FileSnapshot | null> {
+  if (!existsSync(file)) {
+    return null;
+  }
+
+  const text = await readFile(file, "utf8");
+  const eol = text.includes("\r\n") ? "\r\n" : "\n";
+  const endsWithFinalEol = text.endsWith(eol);
+  const lines = text.split(LINE_SPLIT_REGEX);
+  if (lines.length > 0 && lines.at(-1) === "") {
+    lines.pop();
+  }
+  const records = parse(text, { file });
+  return { text, lines, eol, endsWithFinalEol, records };
+}
+
+function resolveRecord(
+  records: WaymarkRecord[],
+  target: ResolvedTarget
+): WaymarkRecord | undefined {
+  if (target.id) {
+    const byId = findRecordById(records, target.id);
+    if (byId) {
+      return byId;
+    }
+  }
+  return findRecordByLine(records, target.line);
+}
+
+function findRecordByLine(
+  records: WaymarkRecord[],
+  line: number
+): WaymarkRecord | undefined {
+  return records.find(
+    (record) => line >= record.startLine && line <= record.endLine
+  );
+}
+
+function findRecordById(
+  records: WaymarkRecord[],
+  id: string
+): WaymarkRecord | undefined {
+  const normalized = normalizeId(id);
+  return records.find((record) => record.raw.includes(normalized));
+}
+
+function resolveType(current: string, override?: string): string {
+  if (override === undefined) {
+    return current;
+  }
+  const trimmed = override.trim();
+  if (!trimmed) {
+    throw new Error("Waymark type cannot be empty");
+  }
+  return trimmed;
+}
+
+// `current` mirrors the raised signal unless we are explicitly clearing signals,
+// so the active display state stays aligned with the persisted raised flag.
+function resolveSignals(
+  current: WaymarkRecord["signals"],
+  overrides: {
+    raised?: boolean;
+    starred?: boolean;
+    clearSignals?: boolean;
+  }
+): WaymarkRecord["signals"] {
+  if (overrides.clearSignals) {
+    return { ...current, raised: false, important: false, current: false };
+  }
+
+  const nextRaised =
+    overrides.raised !== undefined ? overrides.raised : current.raised;
+  const nextImportant =
+    overrides.starred !== undefined ? overrides.starred : current.important;
+
+  return {
+    ...current,
+    raised: nextRaised,
+    important: nextImportant,
+    current: nextRaised,
+  };
+}
+
+function buildLinesFromExisting(args: {
+  record: WaymarkRecord;
+  type: string;
+  signals: WaymarkRecord["signals"];
+  content: string;
+}): string[] {
+  const originalLines = args.record.raw.split(LINE_SPLIT_REGEX);
+  const header = renderHeaderLine({
+    record: args.record,
+    type: args.type,
+    signals: args.signals,
+    content: args.content,
+  });
+  const lines = [header, ...originalLines.slice(1)];
+  if (args.record.commentLeader === HTML_COMMENT_LEADER) {
+    ensureHtmlClosure(lines);
+  }
+  return lines;
+}
+
+function buildLinesFromContent(args: {
+  record: WaymarkRecord;
+  type: string;
+  signals: WaymarkRecord["signals"];
+  content: string;
+}): string[] {
+  const segments = splitContentSegments(args.content);
+  const [firstSegment = "", ...continuations] = segments;
+  const header = renderHeaderLine({
+    record: args.record,
+    type: args.type,
+    signals: args.signals,
+    content: firstSegment,
+  });
+  const lines = [
+    header,
+    ...continuations.map((segment) =>
+      renderContinuationLine(args.record, segment)
+    ),
+  ];
+
+  if (args.record.commentLeader === HTML_COMMENT_LEADER) {
+    ensureHtmlClosure(lines);
+  }
+
+  return lines;
+}
+
+function splitContentSegments(content: string): string[] {
+  const trimmed = content.trim();
+  if (!trimmed) {
+    return [""];
+  }
+  return trimmed.split(LINE_SPLIT_REGEX);
+}
+
+function renderHeaderLine(args: {
+  record: WaymarkRecord;
+  type: string;
+  signals: WaymarkRecord["signals"];
+  content: string;
+}): string {
+  const leader = args.record.commentLeader ?? "//";
+  const indent = " ".repeat(args.record.indent);
+  const leaderSeparator = leader.length > 0 ? " " : "";
+  const signalPrefix = buildSignalPrefix(args.signals);
+  const markerToken = `${signalPrefix}${args.type}`.trim();
+  const content = args.content.trim();
+  let line = `${indent}${leader}${leaderSeparator}${markerToken} ${SIGIL}`;
+  if (content.length > 0) {
+    line += ` ${content}`;
+  }
+  return line.trimEnd();
+}
+
+function renderContinuationLine(
+  record: WaymarkRecord,
+  content: string
+): string {
+  const leader = record.commentLeader ?? "//";
+  const indent = " ".repeat(record.indent);
+  const leaderSeparator = leader.length > 0 ? " " : "";
+  const trimmed = content.trim();
+  let line = `${indent}${leader}${leaderSeparator}${SIGIL}`;
+  if (trimmed.length > 0) {
+    line += ` ${trimmed}`;
+  }
+  return line.trimEnd();
+}
+
+function buildSignalPrefix(signals: WaymarkRecord["signals"]): string {
+  let prefix = "";
+  if (signals.raised) {
+    prefix += "^";
+  }
+  if (signals.important) {
+    prefix += "*";
+  }
+  return prefix;
+}
+
+function extractFirstLineContent(firstLine: string): string {
+  const sigilIndex = firstLine.indexOf(SIGIL);
+  if (sigilIndex === -1) {
+    return "";
+  }
+  const after = firstLine.slice(sigilIndex + SIGIL.length);
+  const trimmedStart = after.trimStart();
+  return trimmedStart.replace(CARRIAGE_RETURN_REGEX, "");
+}
+
+function stripHtmlClosure(
+  content: string,
+  commentLeader: string | null
+): string {
+  if (commentLeader === HTML_COMMENT_LEADER) {
+    return content.replace(HTML_COMMENT_CLOSE_REGEX, "");
+  }
+  return content;
+}
+
+const ID_REGEX = /\bwm:[a-z0-9-]+\b/gi;
+const ID_TRAIL_REGEX = /(wm:[a-z0-9-]+)$/i;
+
+function extractExistingId(content: string): string | undefined {
+  const matches = content.match(ID_REGEX);
+  if (!matches || matches.length === 0) {
+    return;
+  }
+  return matches.at(-1);
+}
+
+function stripTrailingId(content: string): string {
+  return content.replace(ID_TRAIL_REGEX, "").trimEnd();
+}
+
+function applyIdToContent(
+  content: string,
+  existingId: string | undefined,
+  commentLeader: string | null
+): string {
+  const trimmed = stripHtmlClosure(content, commentLeader).trim();
+  if (!existingId) {
+    return trimmed;
+  }
+
+  const segments = splitContentSegments(trimmed);
+  const first = stripTrailingId(segments[0] ?? "").trimEnd();
+  segments[0] = first.length > 0 ? `${first} ${existingId}` : existingId;
+  return segments.join("\n").trimEnd();
+}
+
+function ensureHtmlClosure(lines: string[]): void {
+  if (lines.length === 0) {
+    return;
+  }
+  const lastIndex = lines.length - 1;
+  const line = lines[lastIndex]?.trimEnd() ?? "";
+  if (HTML_COMMENT_CLOSE_REGEX.test(line)) {
+    return;
+  }
+  lines[lastIndex] = line.endsWith(" ") ? `${line}-->` : `${line} -->`;
+}
+
+function normalizeId(id: string): string {
+  return id.startsWith("wm:") ? id : `wm:${id}`;
+}
+
+function buildFileText(
+  lines: string[],
+  eol: string,
+  endsWithFinalEol: boolean
+): string {
+  const joined = lines.join(eol);
+  const suffix = endsWithFinalEol && lines.length > 0 ? eol : "";
+  return joined + suffix;
+}
+
+function buildContextWindow(lines: string[], lineIndex: number): string {
+  const start = Math.max(0, lineIndex - CONTEXT_BEFORE_LINES);
+  const end = Math.min(lines.length, lineIndex + CONTEXT_AFTER_LINES + 1);
+  return lines.slice(start, end).join("\n");
+}
+
+async function updateIdIndex(args: {
+  idManager: WaymarkIdManager;
+  id: string;
+  record: WaymarkRecord;
+  lines: string[];
+  file: string;
+}): Promise<void> {
+  const { idManager, id, record, lines, file } = args;
+  const existing = await idManager.get(id);
+  if (!existing) {
+    throw new Error(`Unknown waymark id: ${id}`);
+  }
+
+  const contextWindow = buildContextWindow(lines, record.startLine - 1);
+  await idManager.updateLocation(id, {
+    file,
+    line: record.startLine,
+    type: record.type,
+    content: record.contentText,
+    contentHash: fingerprintContent(record.contentText),
+    contextHash: fingerprintContext(contextWindow),
+    ...(existing.source ? { source: existing.source } : {}),
+    ...(existing.sourceType ? { sourceType: existing.sourceType } : {}),
+  });
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -20,6 +20,8 @@ export {
   loadConfigFromDisk,
   resolveConfig,
 } from "./config";
+export type { EditOptions, EditResult, EditSpec } from "./edit";
+export { EditSpecSchema, editWaymark } from "./edit";
 export type { FormatEdit, FormatOptions, FormatResult } from "./format";
 export { formatText } from "./format";
 export type { GraphEdge, WaymarkGraph } from "./graph";


### PR DESCRIPTION
## Summary
- add editWaymark core API for updating waymarks by target or id
- add editWaymark test coverage for content/type/signals and dry-run edits
- update Linear agent rules for streamlinear usage and issue references

## Testing
- Not run (not requested)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * In-place waymark editing: change type, content, and signals; edit by ID or file+line; preview mode to validate edits before saving.
* **Tests**
  * Comprehensive tests covering editing flows, preview behavior, ID preservation, and index refreshes.
* **Documentation**
  * Issue-tracking guidance updated: use "Fixes" as primary reference; branch/PR naming and default team filter guidance revised.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->