### PR TITLE
feat(cli): simplify command names and flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,10 +109,10 @@ wm find src/ --jsonl                      # newline-delimited JSON
 wm find src/ --text                       # human-readable formatted text
 
 # Standalone commands
-wm format src/ --write               # format waymarks in a directory
+wm fmt src/ --write               # format waymarks in a directory
 wm lint src/ --json                  # validate waymark types
-wm remove src/auth.ts:42 --write     # remove a waymark
-wm modify src/auth.ts:42 --raise --write # adjust an existing waymark
+wm rm src/auth.ts:42 --write     # remove a waymark
+wm edit src/auth.ts:42 --raised --write # adjust an existing waymark
 ```
 
 To include legacy codetags (TODO/FIXME/NOTE/etc.) in scans, enable:
@@ -122,7 +122,7 @@ To include legacy codetags (TODO/FIXME/NOTE/etc.) in scans, enable:
 include_codetags = true
 ```
 
-When ID history tracking is enabled (`ids.track_history = true`), removals are recorded in `.waymark/history.json` with `removedAt`, `removedBy`, and optional `reason` metadata (via `wm remove --reason`).
+When ID history tracking is enabled (`ids.track_history = true`), removals are recorded in `.waymark/history.json` with `removedAt`, `removedBy`, and optional `reason` metadata (via `wm rm --reason`).
 
 The CLI relies on the core formatter and parser helpers exported from `@waymarks/core`. Cache refresh happens implicitly when `waymark scan` touches a file; no separate cache command is required.
 

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -91,13 +91,13 @@ wm src/ --graph                      # dependency graph
 wm src/ --graph --json               # JSON output
 
 # Formatting and validation
-wm format src/example.ts --write     # normalize syntax
+wm fmt src/example.ts --write     # normalize syntax
 wm lint src/                         # validate waymarks
 
 # Waymark management
 wm add src/auth.ts:42 todo "add rate limiting" --write
-wm remove src/auth.ts:42 --write
-wm modify src/auth.ts:42 --raise --write
+wm rm src/auth.ts:42 --write
+wm edit src/auth.ts:42 --raised --write
 
 # Output formats
 wm src/ --json                       # compact JSON
@@ -186,7 +186,7 @@ wm src/ --tag "#sec"
 ## Next Steps
 
 - **[Commands Reference](./commands.md)** - Learn all commands in depth
-- **[Waymark Editing](./waymark_editing.md)** - Master insert/remove/modify
+- **[Waymark Editing](./waymark_editing.md)** - Master add/edit/rm
 - **[How-To Guides](../howto/README.md)** - See practical workflows
 - **[Grammar](../GRAMMAR.md)** - Understand waymark syntax
 
@@ -199,8 +199,8 @@ wm src/ --tag "#sec"
 wm help
 
 # Command-specific help
-wm help format
-wm help insert
+wm help fmt
+wm help add
 ```
 
 **Resources**:

--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -20,13 +20,13 @@ wm src/ --graph                      # extract dependencies
 wm src/ --graph --json               # JSON output
 
 # Formatting and validation
-wm format src/example.ts --write     # normalize waymark syntax
+wm fmt src/example.ts --write     # normalize waymark syntax
 wm lint src/                         # validate waymarks
 
 # Waymark management
 wm add src/auth.ts:42 todo "add rate limiting" --write
-wm remove src/auth.ts:42 --write             # or: wm rm
-wm modify src/auth.ts:42 --raise --write
+wm rm src/auth.ts:42 --write             # or: wm rm
+wm edit src/auth.ts:42 --raised --write
 
 # Output formats
 wm src/ --json                       # compact JSON
@@ -270,19 +270,19 @@ Normalize waymark syntax (spacing, case, property order):
 
 ```bash
 # Preview changes
-wm format src/example.ts
+wm fmt src/example.ts
 
 # Apply changes
-wm format src/example.ts --write
+wm fmt src/example.ts --write
 
 # Format multiple files
-wm format src/**/*.ts --write
+wm fmt src/**/*.ts --write
 
 # Format directories (filters to files containing :::)
-wm format src/ --write
+wm fmt src/ --write
 
 # Format with specific config
-wm format src/ --write --config-path .waymark/config.toml
+wm fmt src/ --write --config-path .waymark/config.toml
 ```
 
 **What it does:**
@@ -354,13 +354,13 @@ For detailed documentation on waymark management commands, see [Waymark Editing 
 wm add src/auth.ts:42 todo "add rate limiting" --write
 
 # Remove waymark
-wm remove src/auth.ts:42 --write              # or: wm rm src/auth.ts:42 --write
-wm remove src/auth.ts:42 --reason "cleanup" --write
+wm rm src/auth.ts:42 --write              # or: wm rm src/auth.ts:42 --write
+wm rm src/auth.ts:42 --reason "cleanup" --write
 
 # Modify waymark signals
-wm modify src/auth.ts:42 --raise --write
-wm modify src/auth.ts:42 --star --write
-wm modify src/auth.ts:42 --unraise --unstar --write
+wm edit src/auth.ts:42 --raised --write
+wm edit src/auth.ts:42 --star --write
+wm edit src/auth.ts:42 --unraise --unstar --write
 ```
 
 ### Help
@@ -784,7 +784,7 @@ wm src/ --mention @agents             # matches all agent handles
 
 ### Format Not Working
 
-**Symptom**: `wm format --write` doesn't change files
+**Symptom**: `wm fmt --write` doesn't change files
 
 **Solutions**:
 

--- a/docs/cli/waymark_editing.md
+++ b/docs/cli/waymark_editing.md
@@ -305,7 +305,7 @@ wm update wm:a3k9m2p --content "add rate limiting with exponential backoff" --wr
 **Remove by ID:**
 
 ```bash
-wm remove --id wm:a3k9m2p --write
+wm rm --id wm:a3k9m2p --write
 ```
 
 **Query by ID:**
@@ -448,7 +448,7 @@ wm find --id wm:x7k2n4m
 }
 
 // Later, after fixes, remove by ID
-wm remove --id wm:gh42-rev1 --write
+wm rm --id wm:gh42-rev1 --write
 ```
 
 **4. Task Management Integration**
@@ -463,7 +463,7 @@ wm add src/api.ts --line 100 \
   --write
 
 # When task completes, remove by ID
-wm remove --id wm:lin-1234 --write
+wm rm --id wm:lin-1234 --write
 ```
 
 **5. Code Generation Markers**
@@ -1211,7 +1211,7 @@ Should inserted waymarks auto-format via `formatText()`?
 
 **Option A**: Always format (ensures consistency)
 **Option B**: Only if `--format` flag (user control)
-**Option C**: Never format (user runs `wm format` separately)
+**Option C**: Never format (user runs `wm fmt` separately)
 
 **Decision**: Option A (always format)
 
@@ -1299,7 +1299,7 @@ Should `file` field support globs?
 
 ### Overview
 
-The `wm remove` command (alias: `wm rm`) enables programmatic removal of waymarks based on various criteria. This complements `wm add` and enables cleanup workflows, task completion automation, and maintenance operations.
+The `wm rm` command enables programmatic removal of waymarks based on various criteria. This complements `wm add` and enables cleanup workflows, task completion automation, and maintenance operations.
 
 ### Motivation
 
@@ -1317,51 +1317,51 @@ Teams need to remove waymarks when:
 
 ```bash
 # Remove waymark at specific line
-wm remove src/auth.ts --line 42
+wm rm src/auth.ts --line 42
 
 # Remove from multiple files
-wm remove src/auth.ts --line 42 src/db.ts --line 15 --write
+wm rm src/auth.ts --line 42 src/db.ts --line 15 --write
 
 # Remove with an audit reason (stored in history when enabled)
-wm remove src/auth.ts --line 42 --reason "cleanup obsolete marker" --write
+wm rm src/auth.ts --line 42 --reason "cleanup obsolete marker" --write
 
 # Dry run (default - shows what would be removed)
-wm remove src/auth.ts --line 42
+wm rm src/auth.ts --line 42
 ```
 
 ### By Query Criteria
 
 ```bash
 # Remove all waymarks of a specific type
-wm remove --type todo --write
+wm rm --type todo --write
 
 # Remove by type in specific files
-wm remove src/**/*.ts --type todo --write
+wm rm src/**/*.ts --type todo --write
 
 # Remove by tag
-wm remove --tag "#deprecated" --write
+wm rm --tag "#deprecated" --write
 
 # Remove by owner
-wm remove --property owner:@alice --write
+wm rm --property owner:@alice --write
 
 # Remove by multiple criteria (AND logic)
-wm remove --type todo --tag "#old" --owner @alice --write
+wm rm --type todo --tag "#old" --owner @alice --write
 
 # Remove completed waymarks
-wm remove --type done --write
+wm rm --type done --write
 ```
 
 ### Batch Removal (JSON)
 
 ```bash
 # From JSON file
-wm remove --from removals.json --write
+wm rm --from removals.json --write
 
 # From stdin
-cat removals.json | wm remove --from - --write
+cat removals.json | wm rm --from - --write
 
 # With confirmation for large operations
-wm remove --from removals.json --confirm --write
+wm rm --from removals.json --confirm --write
 ```
 
 ### Interactive Selection (Future)
@@ -1707,28 +1707,28 @@ function matchesCriteria(waymark: WaymarkRecord, criteria: RemovalSpec['criteria
 
 ```bash
 # Remove all completed todos
-wm remove --type done --write
+wm rm --type done --write
 
 # Remove specific completed task
-wm remove src/auth.ts --line 42 --write
+wm rm src/auth.ts --line 42 --write
 ```
 
 ### 2. Cleanup After Refactor
 
 ```bash
 # Remove all temporary/wip markers
-wm remove --type temp --write
-wm remove --type wip --write
+wm rm --type temp --write
+wm rm --type wip --write
 
 # Remove stale review comments
-wm remove --type review --property "owner:@former-employee" --write
+wm rm --type review --property "owner:@former-employee" --write
 ```
 
 ### 3. Compliance Workflow
 
 ```bash
 # Remove check markers after audit
-wm remove --tag "#pci-audit" --type check --write
+wm rm --tag "#pci-audit" --type check --write
 ```
 
 ### 4. Bulk Cleanup
@@ -1770,7 +1770,7 @@ jobs:
       - uses: oven-sh/setup-bun@v1
       - name: Remove completed waymarks
         run: |
-          wm remove --type done --write
+          wm rm --type done --write
           if [[ -n $(git status -s) ]]; then
             git config user.name "waymark-bot"
             git commit -am "chore: cleanup completed waymarks"
@@ -1786,10 +1786,10 @@ Same as insert - show what would be removed without modifying files.
 
 ```bash
 # Shows preview
-wm remove --type todo
+wm rm --type todo
 
 # Actually removes
-wm remove --type todo --write
+wm rm --type todo --write
 ```
 
 ### 2. Confirmation Prompts
@@ -1797,7 +1797,7 @@ wm remove --type todo --write
 For large operations, prompt user:
 
 ```bash
-wm remove --type todo --confirm --write
+wm rm --type todo --confirm --write
 
 # Output:
 # Found 47 waymarks matching criteria.
@@ -1807,7 +1807,7 @@ wm remove --type todo --confirm --write
 ### 3. Backup Option
 
 ```bash
-wm remove --type todo --backup --write
+wm rm --type todo --backup --write
 
 # Creates .waymark/backups/{timestamp}/
 ```
@@ -1816,10 +1816,10 @@ wm remove --type todo --backup --write
 
 ```bash
 # Show recent removals
-wm remove --show-history
+wm rm --show-history
 
 # Undo last removal operation
-wm remove --undo
+wm rm --undo
 ```
 
 ### Edge Cases
@@ -1975,7 +1975,7 @@ Should we prevent/warn when removing TLDR waymarks?
 Should we support undo for remove operations?
 
 **Option A**: No undo (use git for versioning)
-**Option B**: Track in .waymark/history/ for `wm remove --undo`
+**Option B**: Track in .waymark/history/ for `wm rm --undo`
 **Option C**: Optional backup directory with `--backup` flag
 
 **Recommendation**: Option C (explicit backup when needed)
@@ -2219,7 +2219,7 @@ jobs:
 ### Phase 3: CLI Integration
 
 1. **Add `wm add` command** in `packages/cli/src/commands/insert.ts`
-2. **Add `wm remove` command** in `packages/cli/src/commands/remove.ts`
+2. **Add `wm rm` command** in `packages/cli/src/commands/remove.ts`
 3. **Add CLI integration tests** covering all usage modes
 4. **Update CLI help** and usage documentation
 

--- a/docs/howto/README.md
+++ b/docs/howto/README.md
@@ -52,7 +52,7 @@ wm src/
 wm lint src/
 
 # Normalize updated waymarks after edits
-wm format src/ --write
+wm fmt src/ --write
 ```
 
 **What to convert**:
@@ -368,7 +368,7 @@ wm add src/legacy.ts:1 note "depends:#new-api/client" --write
 wm src/ --raised --mention @yourname
 
 # 4. Clear signals when done
-wm modify src/legacy.ts:1 --unraise --write
+wm edit src/legacy.ts:1 --unraise --write
 ```
 
 ### Security Audit

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -39,16 +39,16 @@ wm src/ --type todo --mention @agent --tag "#perf"
 wm src/ --graph
 
 # Format files
-wm format src/auth.ts --write
+wm fmt src/auth.ts --write
 
 # Insert waymarks
 wm add src/auth.ts:42 todo "implement rate limiting"
 
 # Remove waymarks
-wm remove src/auth.ts:42 --write
+wm rm src/auth.ts:42 --write
 
 # Modify existing waymarks
-wm modify src/auth.ts:42 --raise --write
+wm edit src/auth.ts:42 --raised --write
 
 # Lint waymarks
 wm lint src/
@@ -57,10 +57,10 @@ wm lint src/
 ## Key Commands
 
 - `wm [paths...]` - Scan and filter waymarks (default command)
-- `wm format [paths...]` - Format and normalize waymark syntax
+- `wm fmt [paths...]` - Format and normalize waymark syntax
 - `wm add <file:line> <type> <content>` - Insert waymarks into files
-- `wm modify <file:line>` - Modify existing waymarks
-- `wm remove <file:line>` - Remove waymarks from files
+- `wm edit <file:line>` - Modify existing waymarks
+- `wm rm <file:line>` - Remove waymarks from files
 - `wm lint [paths...]` - Validate waymark structure and surface legacy codetags
 - `wm init` - Initialize waymark configuration
 - `wm update` - Check for and install CLI updates

--- a/packages/cli/src/commands/edit.prompt.ts
+++ b/packages/cli/src/commands/edit.prompt.ts
@@ -1,0 +1,7 @@
+// tldr ::: agent prompt for wm edit command workflows
+
+import content from "./edit.prompt.txt";
+
+const text = content;
+
+export default text;

--- a/packages/cli/src/commands/edit.prompt.txt
+++ b/packages/cli/src/commands/edit.prompt.txt
@@ -1,10 +1,10 @@
 
-You are helping a user update an existing waymark with the wm modify command.
+You are helping a user update an existing waymark with the wm edit command.
 
 Key capabilities:
 - Target by file:line or by waymark ID (wm:xxxxx)
 - Update the marker type (todo, fix, note, etc.)
-- Toggle signals: --raise adds ^, --starred adds *, --no-signal clears both
+- Toggle signals: --raised adds ^, --starred adds *, --clear-signals clears both
 - Replace the first-line content via --content <text> or stdin with --content -
 - Preview changes by default; add --write to apply them atomically
 - Interactive prompts run automatically when no positional arguments are supplied; use --no-interactive to skip them
@@ -13,11 +13,11 @@ Key capabilities:
 Workflow tips:
 1. Always require a target: either FILE:LINE or --id wm:...
 2. Preserve trailing wm: identifiers when editing content.
-3. Combine --raise and --starred to set both signals in one pass.
+3. Combine --raised and --starred to set both signals in one pass.
 4. After applying changes the CLI automatically refreshes the waymark index.
 
 Examples:
-- Preview a type change: wm modify api/auth.ts:120 --type fix
-- Remove signals via ID: wm modify --id wm:a3k9m2p --no-signal --write
-- Supply content from stdin: printf "validate JWT" | wm modify src/auth.ts:42 --content - --write
-- Skip prompts: wm modify --no-interactive
+- Preview a type change: wm edit api/auth.ts:120 --type fix
+- Remove signals via ID: wm edit --id wm:a3k9m2p --clear-signals --write
+- Supply content from stdin: printf "validate JWT" | wm edit src/auth.ts:42 --content - --write
+- Skip prompts: wm edit --no-interactive

--- a/packages/cli/src/commands/format.help.ts
+++ b/packages/cli/src/commands/format.help.ts
@@ -1,4 +1,4 @@
-// tldr ::: human-facing help text for format command
+// tldr ::: human-facing help text for fmt command
 
 import content from "./format.help.txt";
 

--- a/packages/cli/src/commands/format.help.txt
+++ b/packages/cli/src/commands/format.help.txt
@@ -1,6 +1,6 @@
 
 USAGE
-  wm format <paths...> [options]
+  wm fmt <paths...> [options]
 
 DESCRIPTION
   Format and normalize waymark syntax in files.
@@ -22,14 +22,14 @@ FORMATTING RULES
 
 EXAMPLES
   # Preview formatting changes (dry-run)
-  wm format src/auth.ts
+  wm fmt src/auth.ts
 
   # Apply formatting changes
-  wm format src/auth.ts --write
+  wm fmt src/auth.ts --write
 
   # Format multiple files or directories
-  wm format src/**/*.ts --write
-  wm format src/ --write
+  wm fmt src/**/*.ts --write
+  wm fmt src/ --write
 
 NOTES
   Files beginning with a `waymark-ignore-file` comment are skipped.
@@ -46,4 +46,4 @@ AFTER FORMATTING
   // tldr ::: payment processor
   //      ::: handles Stripe webhooks
 
-For agent-focused guidance, use: wm format --prompt
+For agent-focused guidance, use: wm fmt --prompt

--- a/packages/cli/src/commands/format.prompt.ts
+++ b/packages/cli/src/commands/format.prompt.ts
@@ -1,4 +1,4 @@
-// tldr ::: agent-facing usage guide for format command
+// tldr ::: agent-facing usage guide for fmt command
 
 import content from "./format.prompt.txt";
 

--- a/packages/cli/src/commands/format.prompt.txt
+++ b/packages/cli/src/commands/format.prompt.txt
@@ -5,7 +5,7 @@ PURPOSE
   Normalize waymark syntax to ensure consistent formatting across files.
 
 COMMAND SYNTAX
-  wm format <paths...> [--write]
+  wm fmt <paths...> [--write]
 
 MODES
   Default (dry-run):  Preview changes without modifying files
@@ -39,28 +39,28 @@ FORMATTING RULES
 AGENT WORKFLOWS
 
   1. Preview formatting before committing:
-     wm format src/auth.ts
+     wm fmt src/auth.ts
      → Shows diff of what would change
 
   2. Apply formatting to file:
-     wm format src/auth.ts --write
+     wm fmt src/auth.ts --write
      → Normalizes waymarks in place
 
   3. Format multiple files:
-     wm format src/**/*.ts --write
+     wm fmt src/**/*.ts --write
      → Batch format all TypeScript files
 
   3b. Format an entire directory:
-     wm format src/ --write
+     wm fmt src/ --write
      → Format all waymark files under src/
 
   4. Integrate with pre-commit hooks:
-     git diff --name-only | grep '\\.ts$' | xargs wm format --write
+     git diff --name-only | grep '\\.ts$' | xargs wm fmt --write
      → Format only changed TypeScript files
 
 EXAMPLE OUTPUT (dry-run)
 
-  $ wm format src/auth.ts
+  $ wm fmt src/auth.ts
 
   src/auth.ts:
   - //todo:::implement OAuth
@@ -73,20 +73,20 @@ EXAMPLE OUTPUT (dry-run)
 
 EXAMPLE OUTPUT (--write)
 
-  $ wm format src/auth.ts --write
+  $ wm fmt src/auth.ts --write
 
   Formatted 2 waymarks in src/auth.ts
 
 INTEGRATION PATTERNS
 
   # Format before committing
-  wm format $(git diff --name-only --cached) --write
+  wm fmt $(git diff --name-only --cached) --write
 
   # Verify formatting in CI
-  wm format src/**/*.ts && echo "All waymarks formatted correctly"
+  wm fmt src/**/*.ts && echo "All waymarks formatted correctly"
 
   # Format specific file types
-  find src -name "*.ts" -o -name "*.tsx" | xargs wm format --write
+  find src -name "*.ts" -o -name "*.tsx" | xargs wm fmt --write
 
 CONFIGURATION
 
@@ -112,9 +112,9 @@ TIPS FOR AGENTS
 COMBINING WITH OTHER COMMANDS
 
   # Format then lint
-  wm format src/auth.ts --write && wm lint src/auth.ts
+  wm fmt src/auth.ts --write && wm lint src/auth.ts
 
   # Scan for waymarks, then format files
-  wm src/ --type todo --json | jq -r '.file' | sort -u | xargs wm format --write
+  wm src/ --type todo --json | jq -r '.file' | sort -u | xargs wm fmt --write
 
-For human-facing help, use: wm format --help
+For human-facing help, use: wm fmt --help

--- a/packages/cli/src/commands/help/registry.ts
+++ b/packages/cli/src/commands/help/registry.ts
@@ -135,9 +135,9 @@ const commonFlags = {
 
 // Command-specific configurations
 export const commands: HelpRegistry = {
-  format: {
-    name: "format",
-    usage: "wm format <paths...> [options]",
+  fmt: {
+    name: "fmt",
+    usage: "wm fmt <paths...> [options]",
     description:
       "Format waymark comments in a file, normalizing spacing, case, and alignment.",
     flags: [
@@ -147,10 +147,10 @@ export const commands: HelpRegistry = {
       commonFlags.help,
     ],
     examples: [
-      "wm format src/index.ts             # Preview formatting changes",
-      "wm format src/index.ts --write     # Apply formatting changes",
-      "wm format src/index.ts -w          # Apply formatting (short form)",
-      "wm format src/ --write             # Format all waymarks in a directory",
+      "wm fmt src/index.ts                # Preview formatting changes",
+      "wm fmt src/index.ts --write        # Apply formatting changes",
+      "wm fmt src/index.ts -w             # Apply formatting (short form)",
+      "wm fmt src/ --write                # Format all waymarks in a directory",
     ],
   },
   lint: {
@@ -176,7 +176,7 @@ export const commands: HelpRegistry = {
     description: "Show help for a specific command or general usage.",
     examples: [
       "wm help                            # Show general help",
-      "wm help format                     # Show format command help",
+      "wm help fmt                        # Show format command help",
       "wm help lint                       # Show lint command help",
     ],
   },
@@ -317,9 +317,9 @@ export const commands: HelpRegistry = {
     flags: [],
     examples: ["wm add src/auth.ts:42 todo \"use 'add' instead of 'insert'\""],
   },
-  modify: {
-    name: "modify",
-    usage: "wm modify [file:line] [options]",
+  edit: {
+    name: "edit",
+    usage: "wm edit [file:line] [options]",
     description:
       "Update existing waymarks in place by adjusting type, signals, or content.",
     flags: [
@@ -355,7 +355,7 @@ export const commands: HelpRegistry = {
         description: "Add raised signal (^)",
       },
       {
-        name: "mark-starred",
+        name: "starred",
         type: "boolean",
         description: "Add starred signal (*)",
       },
@@ -371,16 +371,16 @@ export const commands: HelpRegistry = {
       commonFlags.help,
     ],
     examples: [
-      "wm modify src/auth.ts:42 --type fix",
-      "wm modify --id wm:a3k9m2p --starred --write",
-      'printf "new copy" | wm modify src/auth.ts:42 --content - --write',
-      "wm modify                                # Interactive prompts (no args)",
-      "wm modify --no-interactive --id wm:a3k9m2p",
+      "wm edit src/auth.ts:42 --type fix",
+      "wm edit --id wm:a3k9m2p --starred --write",
+      'printf "new copy" | wm edit src/auth.ts:42 --content - --write',
+      "wm edit                                 # Interactive prompts (no args)",
+      "wm edit --no-interactive --id wm:a3k9m2p",
     ],
   },
-  remove: {
-    name: "remove",
-    usage: "wm remove <file:line> [options]",
+  rm: {
+    name: "rm",
+    usage: "wm rm <file:line> [options]",
     description: "Remove waymarks from files programmatically.",
     flags: [
       commonFlags.write,
@@ -474,11 +474,11 @@ export const commands: HelpRegistry = {
       commonFlags.help,
     ],
     examples: [
-      "wm remove src/auth.ts:42              # Preview removal",
-      "wm remove src/auth.ts:42 --write      # Actually remove",
-      "wm remove --id wm:a3k9m2p --write     # Remove by ID",
-      "wm remove --type todo --tag #wip --write --yes  # Batch removal",
-      'wm remove src/auth.ts:42 --write --reason "cleanup"',
+      "wm rm src/auth.ts:42                  # Preview removal",
+      "wm rm src/auth.ts:42 --write          # Actually remove",
+      "wm rm --id wm:a3k9m2p --write         # Remove by ID",
+      "wm rm --type todo --tag #wip --write --yes  # Batch removal",
+      'wm rm src/auth.ts:42 --write --reason "cleanup"',
     ],
   },
   init: {

--- a/packages/cli/src/commands/lint.prompt.txt
+++ b/packages/cli/src/commands/lint.prompt.txt
@@ -135,7 +135,7 @@ TIPS FOR AGENTS
 COMBINING WITH OTHER COMMANDS
 
   # Format then lint
-  wm format src/auth.ts --write && wm lint src/auth.ts
+  wm fmt src/auth.ts --write && wm lint src/auth.ts
 
   # Scan for issues, then lint for structure
   wm src/ --type todo --raised && wm lint src/

--- a/packages/cli/src/commands/modify.prompt.ts
+++ b/packages/cli/src/commands/modify.prompt.ts
@@ -1,7 +1,0 @@
-// tldr ::: agent prompt for wm modify command workflows
-
-import content from "./modify.prompt.txt";
-
-const text = content;
-
-export default text;

--- a/packages/cli/src/commands/modify.ts
+++ b/packages/cli/src/commands/modify.ts
@@ -1,4 +1,4 @@
-// tldr ::: modify command implementation for wm CLI
+// tldr ::: edit command implementation for wm CLI
 
 import { readFile, writeFile } from "node:fs/promises";
 import readline from "node:readline";
@@ -143,7 +143,7 @@ export async function runModifyCommand(
     } catch (error) {
       if (error instanceof InteractiveCancelError) {
         return {
-          output: "Modify cancelled.",
+          output: "Edit cancelled.",
           payload: {
             preview: true,
             applied: false,
@@ -853,7 +853,7 @@ function ensureModificationsSpecified(options: ModifyOptions): void {
 
   if (!(hasType || hasSignals || hasContent)) {
     throw new Error(
-      "No modifications specified. Use --type, --raise, --mark-starred, --clear-signals, --content, or run without arguments for interactive prompts."
+      "No modifications specified. Use --type, --raised, --starred, --clear-signals, --content, or run without arguments for interactive prompts."
     );
   }
 }
@@ -889,8 +889,8 @@ function formatOutput(args: OutputArgs): string {
 
   const lines: string[] = [];
   const heading = payload.applied
-    ? `Modified ${target.file}:${target.line}`
-    : `Preview modification for ${target.file}:${target.line}`;
+    ? `Edited ${target.file}:${target.line}`
+    : `Preview edit for ${target.file}:${target.line}`;
   lines.push(heading, "");
   lines.push("Before:");
   lines.push(`  ${formatLine(record.startLine, payload.before.raw)}`);

--- a/packages/cli/src/commands/remove.prompt.ts
+++ b/packages/cli/src/commands/remove.prompt.ts
@@ -1,4 +1,4 @@
-// tldr ::: agent-facing usage guide for remove command
+// tldr ::: agent-facing usage guide for rm command
 
 import content from "./remove.prompt.txt";
 

--- a/packages/cli/src/commands/remove.prompt.txt
+++ b/packages/cli/src/commands/remove.prompt.txt
@@ -5,11 +5,11 @@ PURPOSE
   Programmatically remove waymarks from files with safety checks and audit logging.
 
 COMMAND SYNTAX
-  wm remove <file:line> [--write]
-  wm remove --id <wm-id> [--write]
-  wm remove --from <json-file> [--write]
-  wm remove [filter-flags] <paths> [--write]
-  wm remove <file:line> [--write] [--reason "<text>"]
+  wm rm <file:line> [--write]
+  wm rm --id <wm-id> [--write]
+  wm rm --from <json-file> [--write]
+  wm rm [filter-flags] <paths> [--write]
+  wm rm <file:line> [--write] [--reason "<text>"]
 
 REMOVAL MODES
 
@@ -31,19 +31,19 @@ SAFETY MODEL
 INPUT METHODS
 
   1. By Location:
-     wm remove src/auth.ts:42 --write
+     wm rm src/auth.ts:42 --write
      → Removes waymark at line 42 in src/auth.ts
 
   2. By Waymark ID:
-     wm remove --id wm:a3k9m2p --write
+     wm rm --id wm:a3k9m2p --write
      → Removes waymark with ID wm:a3k9m2p
 
   3. By Filter Flags:
-     wm remove --type todo --mention @agent src/ --write
+     wm rm --type todo --mention @agent src/ --write
      → Removes all todos mentioning @agent in src/
 
   4. From JSON Input:
-     cat removals.json | wm remove --from - --write
+     cat removals.json | wm rm --from - --write
      → Batch removal from JSON
 
 FILTER FLAGS
@@ -56,7 +56,7 @@ FILTER FLAGS
   --contains <text>     Match content containing text
 
   Combine flags with AND logic:
-  wm remove --type todo --mention @agent --tag "#deprecated" src/ --write
+  wm rm --type todo --mention @agent --tag "#deprecated" src/ --write
 
 OUTPUT FORMATS
 
@@ -67,55 +67,55 @@ OUTPUT FORMATS
 EXAMPLES
 
   1. Preview removal by location:
-     wm remove src/auth.ts:42
+     wm rm src/auth.ts:42
      → Shows waymark that would be removed
 
   2. Execute removal:
-     wm remove src/auth.ts:42 --write
+     wm rm src/auth.ts:42 --write
      → Actually removes the waymark
 
   3. Remove by ID:
-     wm remove --id wm:a3k9m2p --write
+     wm rm --id wm:a3k9m2p --write
 
   4. Remove all completed todos:
-     wm remove --type done . --write
+     wm rm --type done . --write
 
   5. Remove stale agent todos:
-     wm remove --type todo --mention @agent --raised src/ --write
+     wm rm --type todo --mention @agent --raised src/ --write
 
   6. Batch remove from analysis:
      echo '[
        {"file":"src/a.ts","line":42},
        {"id":"wm:xyz123"}
-     ]' | wm remove --from - --write --json
+     ]' | wm rm --from - --write --json
 
   7. Remove deprecated waymarks:
-     wm remove --type deprecated . --write
+     wm rm --type deprecated . --write
 
   8. Record a removal reason:
-     wm remove src/auth.ts:42 --write --reason "obsolete"
+     wm rm src/auth.ts:42 --write --reason "obsolete"
 
 AGENT WORKFLOWS
 
   1. Clean up completed work:
      # Agent finds done waymarks and removes them
      wm scan --type done --json | jq -r '.file + ":" + (.startLine|tostring)' \
-       | while read loc; do wm remove "$loc" --write; done
+       | while read loc; do wm rm "$loc" --write; done
 
   2. Remove raised waymarks after merge:
      # Agent removes ^ waymarks after PR merges
-     wm remove --raised . --write
+     wm rm --raised . --write
 
   3. Archive deprecated markers:
      # Agent removes deprecated waymarks after refactor
-     wm remove --type deprecated --tag "#old-api" . --write
+     wm rm --type deprecated --tag "#old-api" . --write
 
   4. Conditional removal based on analysis:
      # Agent analyzes codebase and removes outdated waymarks
      wm scan --type todo --json \
        | jq 'map(select(.properties.since < "2024-01-01"))
            | map({file, line: .startLine})' \
-       | wm remove --from - --write
+       | wm rm --from - --write
 
 JSON INPUT SCHEMA
 
@@ -178,23 +178,23 @@ ERROR HANDLING
 VERIFICATION
 
   After removal, verify with scan:
-  wm remove src/auth.ts:42 --write
+  wm rm src/auth.ts:42 --write
   wm scan src/auth.ts --type todo
   → Confirm waymark was removed
 
 COMBINING WITH OTHER COMMANDS
 
   # Remove all todos, then verify
-  wm remove --type todo . --write && wm scan --type todo
+  wm rm --type todo . --write && wm scan --type todo
 
   # Find and remove specific waymarks
   wm scan --type deprecated --json \
     | jq -r '.file + ":" + (.startLine|tostring)' \
-    | xargs -I {} wm remove {} --write
+    | xargs -I {} wm rm {} --write
 
   # Clean up before release
-  wm remove --raised . --write  # Remove raised
-  wm remove --type wip . --write  # Remove WIP
+  wm rm --raised . --write  # Remove raised
+  wm rm --type wip . --write  # Remove WIP
 
 TIPS FOR AGENTS
 
@@ -212,4 +212,4 @@ UNDO CAPABILITY (future)
 
   (This feature may be added in future versions)
 
-For human-facing help, use: wm remove --help
+For human-facing help, use: wm rm --help

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -1036,7 +1036,7 @@ describe("Commander integration", () => {
     }
   });
 
-  test("modify command forwards --json option", async () => {
+  test("edit command forwards --json option", async () => {
     const modifyModule = await import("./commands/modify");
     const contextModule = await import("./utils/context");
     const mockPayload: ModifyPayload = {
@@ -1070,7 +1070,7 @@ describe("Commander integration", () => {
 
     try {
       const result = await runCliCaptured([
-        "modify",
+        "edit",
         "src/sample.ts:1",
         "--json",
       ]);
@@ -1084,7 +1084,7 @@ describe("Commander integration", () => {
     }
   });
 
-  test("remove command forwards --json flag to parser", async () => {
+  test("rm command forwards --json flag to parser", async () => {
     const removeModule = await import("./commands/remove");
     const contextModule = await import("./utils/context");
     const parseSpy = spyOn(removeModule, "parseRemoveArgs");
@@ -1104,11 +1104,7 @@ describe("Commander integration", () => {
     );
 
     try {
-      const result = await runCliCaptured([
-        "remove",
-        "src/sample.ts:1",
-        "--json",
-      ]);
+      const result = await runCliCaptured(["rm", "src/sample.ts:1", "--json"]);
       expect(result.exitCode).toBe(0);
       expect(parseSpy).toHaveBeenCalled();
       const tokens = parseSpy.mock.calls[0]?.[0] ?? [];
@@ -1140,18 +1136,18 @@ describe("Commander integration", () => {
   });
 
   test("other commands do not list find filters", async () => {
-    const result = await runCliCaptured(["format", "--help"]);
+    const result = await runCliCaptured(["fmt", "--help"]);
     expect(result.exitCode).toBe(0);
     expect(result.stdout).not.toContain("--type <types...>");
   });
 
-  test("implicit command emits deprecation warning", async () => {
+  test("implicit command runs without deprecation warning", async () => {
     const { file, cleanup } = await withTempFile("// todo ::: legacy\n");
 
     try {
       const result = await runCliCaptured([file]);
       expect(result.exitCode).toBe(0);
-      expect(result.stderr).toContain("Implicit command syntax is deprecated");
+      expect(result.stderr).not.toContain("deprecated");
       expect(result.stdout.length).toBeGreaterThan(0);
     } finally {
       await cleanup();

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -228,7 +228,7 @@ async function handleRemoveCommand(
 }
 
 function handlePromptOption(
-  key: "insert" | "remove" | "modify",
+  key: "insert" | "remove" | "edit",
   options: { prompt?: boolean }
 ): boolean {
   if (!options.prompt) {
@@ -298,8 +298,8 @@ type ModifyCliOptions = {
   id?: string;
   type?: string;
   content?: string;
-  raise?: boolean;
-  markStarred?: boolean;
+  raised?: boolean;
+  starred?: boolean;
   clearSignals?: boolean;
   write?: boolean;
   json?: boolean;
@@ -316,7 +316,7 @@ async function resolveInteractiveTarget(
 ): Promise<{ target: string; id?: string | undefined }> {
   const records = await scanRecords([workspaceRoot], config);
   if (records.length === 0) {
-    writeStderr("No waymarks found to modify.");
+    writeStderr("No waymarks found to edit.");
     process.exit(1);
   }
 
@@ -370,10 +370,10 @@ function buildModifyOptions(
   if (interactiveOverride !== undefined) {
     options.interactive = interactiveOverride;
   }
-  if (rawOptions.raise) {
+  if (rawOptions.raised) {
     options.raised = true;
   }
-  if (rawOptions.markStarred) {
+  if (rawOptions.starred) {
     options.starred = true;
   }
 
@@ -400,8 +400,8 @@ function determineInteractiveOverride(
   const hasMutationFlag = Boolean(
     rawOptions.type ||
       rawOptions.content ||
-      rawOptions.raise ||
-      rawOptions.markStarred ||
+      rawOptions.raised ||
+      rawOptions.starred ||
       rawOptions.clearSignals
   );
   const hasOutputFlag = Boolean(rawOptions.json || rawOptions.jsonl);
@@ -420,7 +420,7 @@ async function handleModifyCommand(
   target: string | undefined,
   rawOptions: ModifyCliOptions
 ): Promise<void> {
-  if (handlePromptOption("modify", rawOptions)) {
+  if (handlePromptOption("edit", rawOptions)) {
     return;
   }
 
@@ -706,15 +706,18 @@ const _DEFAULT_HELP_WIDTH = 80;
 const COMMAND_ORDER = [
   "find",
   "add",
-  "modify",
-  "remove",
+  "edit",
+  "rm",
+  "fmt",
+  "lint",
   "init",
+  "doctor",
   "completions",
   "update",
   "help",
 ];
 
-const HIDDEN_COMMANDS = ["format", "lint"];
+const HIDDEN_COMMANDS = ["fmt", "lint"];
 
 /**
  * Sort comparator for commands based on predefined order.
@@ -906,11 +909,12 @@ export async function createProgram(): Promise<Command> {
   program
     .name("wm")
     .description(
-      "Waymark CLI - scan, filter, format, and manage waymarks\n\n" +
+        "Waymark CLI - scan, filter, format, and manage waymarks\n\n" +
         "Quick Start:\n" +
-        "  wm find [paths...]        Scan and filter waymarks (default: current directory)\n" +
+        "  wm [paths...]             Scan and filter waymarks (default: current directory)\n" +
         "  wm find --graph           Show dependency graph\n" +
-        "  wm format <file> --write  Format waymarks in file\n" +
+        "  wm fmt <file> --write     Format waymarks in file\n" +
+        "  wm rm <file:line> --write Remove waymark from file\n" +
         "  wm init                   Initialize waymark configuration"
     )
     .version(version, "--version, -v", "output the current version")
@@ -980,7 +984,7 @@ export async function createProgram(): Promise<Command> {
 
   // Format command
   program
-    .command("format")
+    .command("fmt")
     .argument("[paths...]", "files or directories to format")
     .option("--write, -w", "write changes to file", false)
     .option("--prompt", "show agent-facing prompt instead of help")
@@ -989,10 +993,10 @@ export async function createProgram(): Promise<Command> {
       "after",
       `
 Examples:
-  $ wm format src/auth.ts              # Preview formatting single file
-  $ wm format src/auth.ts --write      # Apply formatting to single file
-  $ wm format src/**/*.ts --write      # Format multiple files
-  $ wm format src/ --write             # Format all files in directory
+  $ wm fmt src/auth.ts                 # Preview formatting single file
+  $ wm fmt src/auth.ts --write         # Apply formatting to single file
+  $ wm fmt src/**/*.ts --write         # Format multiple files
+  $ wm fmt src/ --write                # Format all files in directory
 
 Notes:
   - Files beginning with a \`waymark-ignore-file\` comment are skipped
@@ -1012,7 +1016,7 @@ After Formatting:
   // todo ::: implement auth
   // *fix ::: validate input
 
-See 'wm format --prompt' for agent-facing documentation.
+See 'wm fmt --prompt' for agent-facing documentation.
     `
     )
     .action(
@@ -1088,14 +1092,14 @@ See 'wm add --prompt' for agent-facing documentation.
       await handleAddCommand(program, this, options);
     });
 
-  const modifyCmd = program
-    .command("modify")
+  const editCmd = program
+    .command("edit")
     .argument("[target]", "waymark location (file:line)")
-    .option("--id <id>", "waymark ID to modify")
+    .option("--id <id>", "waymark ID to edit")
     .option("--type <marker>", "change waymark type")
-    .option("--raise", "add ^ (raised) signal", false)
+    .option("--raised, -R", "add ^ (raised) signal", false)
     .option(
-      "--mark-starred",
+      "--starred",
       "add * (starred) signal to mark as important/valuable",
       false
     )
@@ -1112,21 +1116,21 @@ See 'wm add --prompt' for agent-facing documentation.
     .option("--json", "output as JSON")
     .option("--jsonl", "output as JSON Lines")
     .option("--prompt", "show agent-facing prompt instead of help")
-    .description("modify existing waymarks");
+    .description("edit existing waymarks");
 
-  modifyCmd
+  editCmd
     .addHelpText(
       "after",
       `
 Examples:
-  $ wm modify src/auth.ts:42 --type fix                    # Preview type change
-  $ wm modify src/auth.ts:42 --raise --mark-starred       # Preview signal updates
-  $ wm modify --id wm:a3k9m2p --mark-starred --write      # Apply starred flag by ID
-  $ wm modify src/auth.ts:42 --clear-signals --write       # Remove all signals
-  $ wm modify src/auth.ts:42 --content "new text" --write
-  $ printf "new text" | wm modify src/auth.ts:42 --content - --write
-  $ wm modify                                          # Interactive workflow (default when no args)
-  $ wm modify --no-interactive                         # Skip prompts if default interactive would trigger
+  $ wm edit src/auth.ts:42 --type fix                    # Preview type change
+  $ wm edit src/auth.ts:42 --raised --starred           # Preview signal updates
+  $ wm edit --id wm:a3k9m2p --starred --write           # Apply starred flag by ID
+  $ wm edit src/auth.ts:42 --clear-signals --write       # Remove all signals
+  $ wm edit src/auth.ts:42 --content "new text" --write
+  $ printf "new text" | wm edit src/auth.ts:42 --content - --write
+  $ wm edit                                           # Interactive workflow (default when no args)
+  $ wm edit --no-interactive                          # Skip prompts if default interactive would trigger
 
 Notes:
   - Provide either FILE:LINE or --id (not both)
@@ -1154,8 +1158,7 @@ Notes:
     });
 
   program
-    .command("remove")
-    .alias("rm")
+    .command("rm")
     .allowUnknownOption(true)
     .allowExcessArguments(true)
     .option("--id <id>", "remove waymark by ID (wm:xxxxx)")
@@ -1176,18 +1179,18 @@ Notes:
       "after",
       `
 Removal Methods:
-  1. By Location:     wm remove src/auth.ts:42
-  2. By ID:           wm remove --id wm:a3k9m2p
-  3. By Criteria:     wm remove --criteria "type:todo mention:@agent" src/
-  4. From JSON Input: wm remove --from waymarks.json
+  1. By Location:     wm rm src/auth.ts:42
+  2. By ID:           wm rm --id wm:a3k9m2p
+  3. By Criteria:     wm rm --criteria "type:todo mention:@agent" src/
+  4. From JSON Input: wm rm --from waymarks.json
 
 Examples:
-  $ wm remove src/auth.ts:42                  # Preview removal
-  $ wm remove src/auth.ts:42 --write          # Actually remove
-  $ wm remove --id wm:a3k9m2p --write         # Remove by ID
-  $ wm remove --criteria "type:todo mention:@agent" src/ --write
-  $ wm remove --from removals.json --write
-  $ wm remove src/auth.ts:42 --write --reason "cleanup"
+  $ wm rm src/auth.ts:42                      # Preview removal
+  $ wm rm src/auth.ts:42 --write              # Actually remove
+  $ wm rm --id wm:a3k9m2p --write             # Remove by ID
+  $ wm rm --criteria "type:todo mention:@agent" src/ --write
+  $ wm rm --from removals.json --write
+  $ wm rm src/auth.ts:42 --write --reason "cleanup"
 
 Filter Criteria Syntax:
   type:<marker>         Match waymark type (todo, fix, note, etc.)
@@ -1204,7 +1207,7 @@ Safety Features:
   - Multi-line waymarks removed atomically
   - Removed waymarks tracked in .waymark/history.json (with optional --reason)
 
-See 'wm remove --prompt' for agent-facing documentation.
+See 'wm rm --prompt' for agent-facing documentation.
     `
     )
     .action(async function (this: Command, ...actionArgs: unknown[]) {
@@ -1482,31 +1485,23 @@ See 'wm find --prompt' for agent-facing documentation.
       }
     });
 
-  // Default action - unified command (deprecated implicit behavior, use 'wm find' instead)
+  // Default action - unified command
   program
     .argument("[paths...]", "files or directories to scan")
     .addHelpText(
       "after",
       `
-DEPRECATION NOTICE:
-  The implicit scan syntax (e.g., 'wm src/') is deprecated.
-  Use 'wm find [paths...]' instead. This will be removed in v2.0.
-
 Examples:
-  $ wm find                                   # Scan current directory
+  $ wm                                      # Scan current directory
   $ wm find src/ --type todo --mention @agent
-  $ wm find --graph --json                   # Export dependency graph as JSON
-  $ wm find --starred --tag "#sec"           # Find high-priority security issues
+  $ wm find --graph --json                  # Export dependency graph as JSON
+  $ wm find --starred --tag "#sec"          # Find high-priority security issues
 
 See 'wm find --help' for all available options and comprehensive documentation.
     `
     )
     .action(async (paths: string[], options: Record<string, unknown>) => {
       try {
-        // Show deprecation warning to STDERR (won't interfere with piped output)
-        writeStderr(
-          "Warning: Implicit command syntax is deprecated. Use 'wm find [paths...]' instead. This will be removed in v2.0"
-        );
         const mergedOptions = { ...program.opts(), ...options };
         await handleUnifiedCommand(program, paths, mergedOptions);
       } catch (error) {

--- a/packages/cli/src/utils/content-loader.ts
+++ b/packages/cli/src/utils/content-loader.ts
@@ -1,20 +1,22 @@
 // tldr ::: convention-based loader for agent-facing prompt content files
 
 import addPrompt from "../commands/add.prompt.ts";
+import editPrompt from "../commands/edit.prompt.ts";
 import formatPrompt from "../commands/format.prompt.ts";
 import lintPrompt from "../commands/lint.prompt.ts";
-import modifyPrompt from "../commands/modify.prompt.ts";
 import removePrompt from "../commands/remove.prompt.ts";
 import unifiedPrompt from "../commands/unified/index.prompt.ts";
 
 const promptRegistry: Record<string, string> = {
   unified: unifiedPrompt,
   format: formatPrompt,
+  fmt: formatPrompt,
   add: addPrompt,
   insert: addPrompt, // deprecated alias
-  modify: modifyPrompt,
+  edit: editPrompt,
   lint: lintPrompt,
   remove: removePrompt,
+  rm: removePrompt,
 };
 
 /**


### PR DESCRIPTION
## Summary
- rename CLI commands to shorter forms (fmt, rm, edit)
- update edit/remove flags and messaging to match new naming
- refresh CLI docs, help text, and prompts for the renamed commands

## Testing
- Not run (not requested)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated all CLI documentation, help text, and examples to reflect new command names and flags.

* **Refactor**
  * Shortened command aliases: `format` → `fmt`, `remove` → `rm`, `modify` → `edit`.
  * Updated flag names: `--raise` → `--raised`, `--mark-starred` → `--starred`.

* **Tests**
  * Updated test suite to verify renamed commands and flags.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->