### PR TITLE
feat(mcp): consolidate into single waymark tool

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,9 +45,9 @@ When working on this project:
 
 ### MCP Server Expectations
 
-- Use `waymark-mcp` when an agent needs to interact with waymarks programmatically. The server exposes `waymark.scan`, `waymark.graph`, and `waymark.insert`, plus TLDR/TODO drafting prompts and a todos resource.
+- Use `waymark-mcp` when an agent needs to interact with waymarks programmatically. The server exposes a single `waymark` tool (`action: scan | graph | add`) and a `waymark://todos` resource.
 - Commands accept `configPath` and `scope` options; always pass repository-specific settings so behavior matches the CLI.
-- `waymark.insert` formats the target file automatically—run the server tool instead of writing raw strings when adding waymarks.
+- `waymark` with `action: "add"` formats the target file automatically—run the server tool instead of writing raw strings when adding waymarks.
 - Treat MCP responses as the source of truth for agent-visible state; avoid duplicating parsing logic outside of `@waymarks/core`.
 
 ### Pre-Push Quality Checks

--- a/README.md
+++ b/README.md
@@ -167,16 +167,11 @@ waymark-mcp
 The server advertises a compact surface area:
 
 - **Tools**
-  - `waymark.scan` – parse files/directories and return waymark records in `text`, `json`, `jsonl`, or `pretty` formats.
-  - `waymark.graph` – emit relation edges (ref/depends/needs/etc.).
-  - `waymark.insert` – insert any waymark (including `tldr`, `this`, `todo`, or custom markers) into a file, normalize it with the formatter, and return the inserted record metadata.
+  - `waymark` – single tool for waymark actions. Set `action` to `scan`, `graph`, or `add` and provide the corresponding inputs (`paths`/`format`, `paths`, or `filePath` + `type` + `content`).
 - **Resources**
   - `waymark://todos` – filtered list of every `todo` waymark detected.
-- **Prompts**
-  - `waymark.tldr` – drafts a TLDR sentence for a file given an optional snippet window.
-  - `waymark.todo` – drafts actionable TODO content based on a summary/context payload.
 
-Tools accept the same configuration options as the CLI (`configPath`, `scope`) so agents respect local project settings. The server streams JSON over stdout/stdin; see `apps/mcp/src/index.ts` for the exact schemas.
+Drafting TLDR/TODO guidance now lives in agent skills; MCP prompts were removed. Tools accept the same configuration options as the CLI (`configPath`, `scope`) so agents respect local project settings. The server streams JSON over stdout/stdin; see `apps/mcp/src/index.ts` for the exact schemas.
 
 ### Code Structure
 

--- a/apps/mcp/README.md
+++ b/apps/mcp/README.md
@@ -19,7 +19,6 @@ waymark-mcp
 The server communicates over stdio and implements the Model Context Protocol, allowing AI agents to:
 
 - Scan and parse waymarks from files
-- Generate TLDR summaries
 - Extract dependency graphs
 - Insert waymarks with proper formatting
 - Access repository-wide waymark data
@@ -28,19 +27,13 @@ The server communicates over stdio and implements the Model Context Protocol, al
 
 ### Tools
 
-- `waymark.scan` - Parse files/directories and return waymark records (supports text, json, jsonl, pretty formats)
-- `waymark.graph` - Extract dependency graph from relations
-- `waymark.add` - Add formatted waymarks into files
-- `waymark.insert` - (deprecated, use `waymark.add` instead)
+- `waymark` - Single tool for scan/graph/add actions (set `action` and pass the corresponding inputs)
 
 ### Resources
 
 - `waymark://todos` - Filtered list of all TODO waymarks
 
-### Prompts
-
-- `waymark.tldr` - Draft TLDR sentence for a file
-- `waymark.todo` - Draft actionable TODO content
+Drafting TLDR/TODO guidance now lives in agent skills; MCP prompts were removed.
 
 ## Configuration
 
@@ -65,21 +58,15 @@ const client = new Client({
 
 // Scan waymarks
 const result = await client.callTool({
-  name: 'waymark.scan',
+  name: 'waymark',
   arguments: {
+    action: 'scan',
     paths: ['src/'],
     format: 'json'
   }
 });
 
-// Generate TLDR
-const tldr = await client.callPrompt({
-  name: 'waymark.tldr',
-  arguments: {
-    filePath: 'src/auth.ts',
-    snippet: '...'
-  }
-});
+// Drafting guidance lives in agent skills (no MCP prompts).
 ```
 
 ## Documentation

--- a/apps/mcp/src/tools/add.ts
+++ b/apps/mcp/src/tools/add.ts
@@ -1,4 +1,4 @@
-// tldr ::: add tool handler for waymark MCP server (formerly insert)
+// tldr ::: add tool handler for waymark MCP server
 
 import { existsSync } from "node:fs";
 import { readFile, writeFile } from "node:fs/promises";
@@ -331,7 +331,7 @@ function toJsonResponse(value: unknown): CallToolResult {
 }
 
 export const addToolDefinition = {
-  title: "Insert a waymark",
+  title: "Add a waymark",
   description:
     "Creates a new waymark (e.g., tldr/this/todo) at the requested location and normalizes the file.",
   inputSchema: addWaymarkInputSchema.shape,
@@ -350,6 +350,3 @@ export function handleAddWaymark(params: {
 }): Promise<CallToolResult> {
   return handleAdd(params, params.server);
 }
-
-// Deprecated alias for backward compatibility
-export const handleInsertWaymark = handleAddWaymark;

--- a/apps/mcp/src/tools/index.ts
+++ b/apps/mcp/src/tools/index.ts
@@ -1,18 +1,10 @@
 // tldr ::: tool registry for waymark MCP server
 
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { addToolDefinition, handleAdd } from "./add";
-import { graphToolDefinition, handleGraph } from "./graph";
-import { handleScan, scanToolDefinition } from "./scan";
+import { handleWaymarkTool, waymarkToolDefinition } from "./waymark";
 
 export function registerTools(server: McpServer): void {
-  server.registerTool("waymark.scan", scanToolDefinition, handleScan);
-  server.registerTool("waymark.graph", graphToolDefinition, handleGraph);
-  server.registerTool("waymark.add", addToolDefinition, (input: unknown) =>
-    handleAdd(input, server)
-  );
-  // Deprecated alias for backward compatibility
-  server.registerTool("waymark.insert", addToolDefinition, (input: unknown) =>
-    handleAdd(input, server)
+  server.registerTool("waymark", waymarkToolDefinition, (input: unknown) =>
+    handleWaymarkTool(input, server)
   );
 }

--- a/apps/mcp/src/tools/waymark.ts
+++ b/apps/mcp/src/tools/waymark.ts
@@ -1,0 +1,35 @@
+// tldr ::: single MCP tool handler for waymark actions
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { waymarkToolInputSchema, waymarkToolInputShape } from "../types";
+import { handleAdd } from "./add";
+import { handleGraph } from "./graph";
+import { handleScan } from "./scan";
+
+export function handleWaymarkTool(
+  input: unknown,
+  server: Pick<McpServer, "sendResourceListChanged">
+): Promise<CallToolResult> {
+  const parsed = waymarkToolInputSchema.parse(input);
+
+  switch (parsed.action) {
+    case "scan":
+      return handleScan(parsed);
+    case "graph":
+      return handleGraph(parsed);
+    case "add":
+      return handleAdd(parsed, server);
+    default: {
+      const action = (parsed as { action: string }).action;
+      return Promise.reject(new Error(`Unsupported waymark action: ${action}`));
+    }
+  }
+}
+
+export const waymarkToolDefinition = {
+  title: "Waymark",
+  description:
+    "Single tool for waymark actions. Use action=scan, graph, or add.",
+  inputSchema: waymarkToolInputShape,
+} as const;

--- a/apps/mcp/src/types.ts
+++ b/apps/mcp/src/types.ts
@@ -30,10 +30,29 @@ export const addWaymarkInputSchema = configOptionsSchema.extend({
     .optional(),
 });
 
-// Deprecated alias for backward compatibility
-export const insertWaymarkInputSchema = addWaymarkInputSchema;
+const waymarkActionSchema = z.enum(["scan", "graph", "add"]);
+
+export const waymarkToolInputSchema = z.discriminatedUnion("action", [
+  scanInputSchema.extend({ action: z.literal("scan") }),
+  graphInputSchema.extend({ action: z.literal("graph") }),
+  addWaymarkInputSchema.extend({ action: z.literal("add") }),
+]);
+
+export const waymarkToolInputShape = {
+  action: waymarkActionSchema,
+  configPath: configOptionsSchema.shape.configPath,
+  scope: configOptionsSchema.shape.scope,
+  paths: scanInputSchema.shape.paths.optional(),
+  format: scanInputSchema.shape.format.optional(),
+  filePath: addWaymarkInputSchema.shape.filePath.optional(),
+  type: addWaymarkInputSchema.shape.type.optional(),
+  content: addWaymarkInputSchema.shape.content.optional(),
+  line: addWaymarkInputSchema.shape.line.optional(),
+  signals: addWaymarkInputSchema.shape.signals.optional(),
+};
 
 export type ScanInput = z.infer<typeof scanInputSchema>;
+export type WaymarkToolInput = z.infer<typeof waymarkToolInputSchema>;
 export type RenderFormat = ScanInput["format"];
 
 export type SignalFlags = {
@@ -54,5 +73,3 @@ export type ExpandedConfig = {
 };
 
 export const TODOS_RESOURCE_URI = "waymark://todos";
-export const DEFAULT_TLDR_PROMPT_LINES = 200;
-export const MAX_TLDR_PROMPT_LINES = 2000;

--- a/docs/howto/README.md
+++ b/docs/howto/README.md
@@ -218,9 +218,10 @@ wm src/ --mention @claude
 
 **Agent can now**:
 
-- `waymark.scan` - Read all waymarks
-- `waymark.insert` - Add new waymarks
-- `waymark.graph` - Analyze dependencies
+- `waymark` - Single tool for actions:
+  - `action: "scan"` - Read all waymarks
+  - `action: "add"` - Add new waymarks
+  - `action: "graph"` - Analyze dependencies
 
 See [MCP Server Documentation](../../README.md#mcp-server) for integration details.
 


### PR DESCRIPTION
## Summary
- consolidate MCP operations into a single waymark tool with action dispatch
- define shared input schema/types for scan/graph/add and update registration
- update MCP docs and guidance for the single-tool workflow

## Testing
- Not run (not requested)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated MCP tool interface from multiple separate commands into a single unified "waymark" tool with an action parameter (scan, graph, add).
  * Renamed "insert" operation to "add" terminology throughout.

* **Documentation**
  * Updated all documentation and usage examples to reflect the new unified tool interface and revised terminology.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->