### PR TITLE
feat(mcp): add help action and defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ waymark-mcp
 The server advertises a compact surface area:
 
 - **Tools**
-  - `waymark` – single tool for waymark actions. Set `action` to `scan`, `graph`, or `add` and provide the corresponding inputs (`paths`/`format`, `paths`, or `filePath` + `type` + `content`).
+  - `waymark` – single tool for waymark actions. Set `action` to `scan`, `graph`, `add`, or `help` and provide the corresponding inputs. `scan`/`graph` default to the current directory when `paths` is omitted.
 - **Resources**
   - `waymark://todos` – filtered list of every `todo` waymark detected.
 

--- a/apps/mcp/README.md
+++ b/apps/mcp/README.md
@@ -27,7 +27,7 @@ The server communicates over stdio and implements the Model Context Protocol, al
 
 ### Tools
 
-- `waymark` - Single tool for scan/graph/add actions (set `action` and pass the corresponding inputs)
+- `waymark` - Single tool for scan/graph/add/help actions (set `action` and pass the corresponding inputs). `scan` and `graph` default to the current directory when `paths` is omitted.
 
 ### Resources
 
@@ -61,7 +61,6 @@ const result = await client.callTool({
   name: 'waymark',
   arguments: {
     action: 'scan',
-    paths: ['src/'],
     format: 'json'
   }
 });

--- a/apps/mcp/src/tools/help.ts
+++ b/apps/mcp/src/tools/help.ts
@@ -1,0 +1,103 @@
+// tldr ::: help action handler for waymark MCP tool
+
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type { HelpInput } from "../types";
+
+type HelpActionInput = HelpInput & { action: "help" };
+
+type HelpTopic = {
+  title: string;
+  body: string;
+};
+
+const HELP_TOPICS: Record<string, HelpTopic> = {
+  scan: {
+    title: "scan",
+    body: [
+      "Action: scan",
+      "Find waymarks in files or directories.",
+      "",
+      "Inputs:",
+      '- paths?: string[] (defaults to ["."])',
+      "- format?: text | json | jsonl | pretty (default: json)",
+      "- configPath?: string",
+      "- scope?: default | project | user",
+      "",
+      "Example:",
+      '{"action":"scan","paths":["src/"]}',
+    ].join("\n"),
+  },
+  graph: {
+    title: "graph",
+    body: [
+      "Action: graph",
+      "Build relation edges from waymark references.",
+      "",
+      "Inputs:",
+      '- paths?: string[] (defaults to ["."])',
+      "- configPath?: string",
+      "- scope?: default | project | user",
+      "",
+      "Example:",
+      '{"action":"graph","paths":["src/"]}',
+    ].join("\n"),
+  },
+  add: {
+    title: "add",
+    body: [
+      "Action: add",
+      "Insert a new waymark into a file.",
+      "",
+      "Inputs:",
+      "- filePath: string",
+      "- type: string",
+      "- content: string",
+      "- line?: number",
+      "- signals?: { raised?: boolean; important?: boolean }",
+      "- configPath?: string",
+      "- scope?: default | project | user",
+      "",
+      "Example:",
+      '{"action":"add","filePath":"src/app.ts","type":"todo","content":"add retry"}',
+    ].join("\n"),
+  },
+};
+
+const DEFAULT_HELP = [
+  "Waymark MCP Tool",
+  "",
+  "Single tool with action dispatch.",
+  "",
+  "Actions:",
+  "- scan  (paths?, format?, configPath?, scope?)",
+  "- graph (paths?, configPath?, scope?)",
+  "- add   (filePath, type, content, line?, signals?)",
+  "- help  (topic?)",
+  "",
+  "Defaults:",
+  '- scan/graph paths default to ["."]',
+  "- scan format defaults to json",
+  "- scope defaults to default",
+  "",
+  "Examples:",
+  '{"action":"scan"}',
+  '{"action":"graph","paths":["src/"]}',
+  '{"action":"add","filePath":"src/app.ts","type":"todo","content":"add retry"}',
+  '{"action":"help","topic":"scan"}',
+].join("\n");
+
+export function handleHelp(input: HelpActionInput): CallToolResult {
+  const topic = input.topic?.trim().toLowerCase();
+  const selected = topic ? HELP_TOPICS[topic] : undefined;
+  const text = selected ? selected.body : DEFAULT_HELP;
+
+  return {
+    content: [
+      {
+        type: "text",
+        mimeType: "text/plain",
+        text,
+      },
+    ],
+  };
+}

--- a/apps/mcp/src/tools/waymark.test.ts
+++ b/apps/mcp/src/tools/waymark.test.ts
@@ -1,0 +1,40 @@
+// tldr ::: tests for waymark MCP tool help action and validation
+
+import { describe, expect, test } from "bun:test";
+
+import { handleWaymarkTool } from "./waymark";
+
+const VALID_ACTIONS_REGEX = /Valid actions:/u;
+
+class TestServer {
+  sendResourceListChanged(): void {
+    // no-op
+  }
+}
+
+describe("handleWaymarkTool", () => {
+  test("returns help text", async () => {
+    const response = await handleWaymarkTool(
+      { action: "help" },
+      new TestServer()
+    );
+    const text = String(response.content?.[0]?.text ?? "");
+    expect(text).toContain("Waymark MCP Tool");
+    expect(text).toContain("scan");
+  });
+
+  test("returns topic-specific help", async () => {
+    const response = await handleWaymarkTool(
+      { action: "help", topic: "scan" },
+      new TestServer()
+    );
+    const text = String(response.content?.[0]?.text ?? "");
+    expect(text).toContain("Action: scan");
+  });
+
+  test("rejects unknown action with valid list", async () => {
+    await expect(
+      handleWaymarkTool({ action: "bogus" }, new TestServer())
+    ).rejects.toThrow(VALID_ACTIONS_REGEX);
+  });
+});

--- a/apps/mcp/src/tools/waymark.ts
+++ b/apps/mcp/src/tools/waymark.ts
@@ -2,16 +2,44 @@
 
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
-import { waymarkToolInputSchema, waymarkToolInputShape } from "../types";
+import {
+  WAYMARK_ACTIONS,
+  waymarkToolInputSchema,
+  waymarkToolInputShape,
+} from "../types";
 import { handleAdd } from "./add";
 import { handleGraph } from "./graph";
+import { handleHelp } from "./help";
 import { handleScan } from "./scan";
+
+type WaymarkAction = (typeof WAYMARK_ACTIONS)[number];
+
+function isWaymarkAction(value: string): value is WaymarkAction {
+  return (WAYMARK_ACTIONS as readonly string[]).includes(value);
+}
 
 export function handleWaymarkTool(
   input: unknown,
   server: Pick<McpServer, "sendResourceListChanged">
 ): Promise<CallToolResult> {
-  const parsed = waymarkToolInputSchema.parse(input);
+  const parsedResult = waymarkToolInputSchema.safeParse(input);
+  if (!parsedResult.success) {
+    const action =
+      typeof input === "object" && input !== null && "action" in input
+        ? String((input as { action?: unknown }).action)
+        : undefined;
+    if (action && !isWaymarkAction(action)) {
+      const valid = WAYMARK_ACTIONS.join(", ");
+      return Promise.reject(
+        new Error(
+          `Unsupported waymark action: ${action}. Valid actions: ${valid}`
+        )
+      );
+    }
+    return Promise.reject(parsedResult.error);
+  }
+
+  const parsed = parsedResult.data;
 
   switch (parsed.action) {
     case "scan":
@@ -20,9 +48,16 @@ export function handleWaymarkTool(
       return handleGraph(parsed);
     case "add":
       return handleAdd(parsed, server);
+    case "help":
+      return Promise.resolve(handleHelp(parsed));
     default: {
       const action = (parsed as { action: string }).action;
-      return Promise.reject(new Error(`Unsupported waymark action: ${action}`));
+      const valid = WAYMARK_ACTIONS.join(", ");
+      return Promise.reject(
+        new Error(
+          `Unsupported waymark action: ${action}. Valid actions: ${valid}`
+        )
+      );
     }
   }
 }
@@ -30,6 +65,6 @@ export function handleWaymarkTool(
 export const waymarkToolDefinition = {
   title: "Waymark",
   description:
-    "Single tool for waymark actions. Use action=scan, graph, or add.",
+    "Single tool for waymark actions. Use action=scan, graph, add, or help. scan/graph default to the current directory when paths are omitted.",
   inputSchema: waymarkToolInputShape,
 } as const;

--- a/apps/mcp/src/types.ts
+++ b/apps/mcp/src/types.ts
@@ -9,12 +9,12 @@ export const configOptionsSchema = z.object({
 });
 
 export const scanInputSchema = configOptionsSchema.extend({
-  paths: z.array(z.string().min(1)).nonempty(),
+  paths: z.array(z.string().min(1)).nonempty().default(["."]),
   format: z.enum(["text", "json", "jsonl", "pretty"]).default("json"),
 });
 
 export const graphInputSchema = configOptionsSchema.extend({
-  paths: z.array(z.string().min(1)).nonempty(),
+  paths: z.array(z.string().min(1)).nonempty().default(["."]),
 });
 
 export const addWaymarkInputSchema = configOptionsSchema.extend({
@@ -30,12 +30,18 @@ export const addWaymarkInputSchema = configOptionsSchema.extend({
     .optional(),
 });
 
-const waymarkActionSchema = z.enum(["scan", "graph", "add"]);
+export const helpInputSchema = configOptionsSchema.extend({
+  topic: z.string().min(1).optional(),
+});
+
+export const WAYMARK_ACTIONS = ["scan", "graph", "add", "help"] as const;
+export const waymarkActionSchema = z.enum(WAYMARK_ACTIONS);
 
 export const waymarkToolInputSchema = z.discriminatedUnion("action", [
   scanInputSchema.extend({ action: z.literal("scan") }),
   graphInputSchema.extend({ action: z.literal("graph") }),
   addWaymarkInputSchema.extend({ action: z.literal("add") }),
+  helpInputSchema.extend({ action: z.literal("help") }),
 ]);
 
 export const waymarkToolInputShape = {
@@ -49,9 +55,11 @@ export const waymarkToolInputShape = {
   content: addWaymarkInputSchema.shape.content.optional(),
   line: addWaymarkInputSchema.shape.line.optional(),
   signals: addWaymarkInputSchema.shape.signals.optional(),
+  topic: helpInputSchema.shape.topic.optional(),
 };
 
 export type ScanInput = z.infer<typeof scanInputSchema>;
+export type HelpInput = z.infer<typeof helpInputSchema>;
 export type WaymarkToolInput = z.infer<typeof waymarkToolInputSchema>;
 export type RenderFormat = ScanInput["format"];
 

--- a/docs/cli/waymark_editing.md
+++ b/docs/cli/waymark_editing.md
@@ -2084,12 +2084,13 @@ Expose a single MCP tool for waymark operations:
 // apps/mcp/src/tools/waymark.ts
 {
   name: "waymark",
-  description: "Single tool for scan, graph, or add actions",
+  description: "Single tool for scan, graph, add, or help actions",
   inputSchema: {
-    action: { type: "string", enum: ["scan", "graph", "add"] },
+    action: { type: "string", enum: ["scan", "graph", "add", "help"] },
     // scan: paths[], format?
     // graph: paths[]
     // add: filePath, type, content, line?, signals?, configPath?, scope?
+    // help: topic?
   }
 }
 ```
@@ -2204,7 +2205,7 @@ jobs:
 
 ### Phase 4: MCP Extension
 
-1. **Extend MCP server** with `waymark` tool (action: scan|graph|add)
+1. **Extend MCP server** with `waymark` tool (action: scan|graph|add|help)
 2. **Add `action: remove`** to the `waymark` MCP tool
 3. **Test MCP integration** with Claude Code and other agents
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -917,7 +917,7 @@ export async function createProgram(): Promise<Command> {
   program
     .name("wm")
     .description(
-        "Waymark CLI - scan, filter, format, and manage waymarks\n\n" +
+      "Waymark CLI - scan, filter, format, and manage waymarks\n\n" +
         "Quick Start:\n" +
         "  wm [paths...]             Scan and filter waymarks (default: current directory)\n" +
         "  wm find --graph           Show dependency graph\n" +


### PR DESCRIPTION
## Summary
- add MCP `help` action with topic-aware responses
- default scan/graph `paths` to the current directory and improve action validation errors
- document new action defaults in MCP docs and waymark_editing
- add MCP tool tests and fix a CLI help string indent for formatter compliance

## Testing
- `bun test apps/mcp/src/tools/waymark.test.ts`
- `turbo run lint`
- `turbo run typecheck`
- `turbo run test`
