### PR TITLE
feat(grammar): add sym: property for symbol binding

### DIFF
--- a/packages/grammar/src/constants.test.ts
+++ b/packages/grammar/src/constants.test.ts
@@ -44,6 +44,7 @@ describe("PROPERTY_KEYS contract", () => {
       "affects",
       "priority",
       "status",
+      "sym",
     ].sort();
 
     expect(Array.from(PROPERTY_KEYS).sort()).toEqual(expectedKeys);

--- a/packages/grammar/src/constants.ts
+++ b/packages/grammar/src/constants.ts
@@ -210,4 +210,5 @@ export const PROPERTY_KEYS = new Set([
   "affects",
   "priority",
   "status",
+  "sym",
 ]);

--- a/packages/grammar/src/parser.test.ts
+++ b/packages/grammar/src/parser.test.ts
@@ -445,4 +445,43 @@ describe("parse", () => {
       owner: "@alice",
     });
   });
+
+  test("parses sym: property for symbol binding", () => {
+    const record = parseLine(
+      "// about ::: authentication handler sym:handleAuth #auth",
+      LINE_ONE,
+      { file: "src/auth.ts" }
+    );
+
+    expect(record).not.toBeNull();
+    expect(record?.type).toBe("about");
+    expect(record?.properties).toEqual({
+      sym: "handleAuth",
+    });
+    expect(record?.tags).toContain("#auth");
+  });
+
+  test("parses sym: as property-as-marker in continuation context", () => {
+    const source = [
+      "// about ::: user authentication service",
+      "// sym   ::: AuthService",
+      "// owner ::: @alice",
+    ].join("\n");
+
+    const records = parse(source, { file: "src/auth.ts" });
+    expect(records).toHaveLength(1);
+    const record = records[0];
+
+    expect(record).toBeDefined();
+    if (!record) {
+      throw new Error("expected waymark record");
+    }
+
+    expect(record.type).toBe("about");
+    expect(record.contentText).toBe("user authentication service");
+    expect(record.properties).toEqual({
+      sym: "AuthService",
+      owner: "@alice",
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Adds the `sym:` property key for binding waymarks to specific code symbols (functions, classes, variables). This enables more precise waymark-to-code associations beyond line-based positioning.

## Changes

### Grammar (`packages/grammar`)
- Add `sym` to `PROPERTY_KEYS` set in `constants.ts`
- Add tests for inline and continuation context parsing

## Usage

The `sym:` property binds a waymark to a named symbol:

```typescript
// about ::: authentication handler sym:handleAuth #auth
export async function handleAuth(req: Request) {
  // ...
}

// todo ::: add rate limiting sym:rateLimiter
// note ::: applies to all API endpoints sym:apiMiddleware
```

## Notes

- `sym:` is a regular property, not a relation — it does not create graph edges
- Values should match actual symbol names in the code
- Tooling can use this for symbol-aware navigation and refactoring

---
Closes #132 (relations & properties)

Part of [v1 Syntax Changes](#129)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the new "sym" property in the parser.

* **Tests**
  * Added comprehensive test coverage for "sym" property parsing across different contexts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->