### PR TITLE
feat(grammar): stricter @mention parsing to reject decorators

### DIFF
--- a/packages/grammar/src/parser.test.ts
+++ b/packages/grammar/src/parser.test.ts
@@ -70,6 +70,62 @@ describe("parseLine", () => {
     expect(record?.mentions).toEqual([]);
   });
 
+  test("does not treat decorator-like patterns as mentions", () => {
+    const record = parseLine(
+      "// about ::: uses @Injectable pattern for DI",
+      LINE_ONE,
+      { file: "src/di.ts" }
+    );
+
+    expect(record).not.toBeNull();
+    expect(record?.mentions).toEqual([]);
+  });
+
+  test("does not treat decorator calls as mentions", () => {
+    const record = parseLine(
+      "// note ::: decorated with @Component() and @Input()",
+      LINE_ONE,
+      { file: "src/component.ts" }
+    );
+
+    expect(record).not.toBeNull();
+    expect(record?.mentions).toEqual([]);
+  });
+
+  test("extracts mention after email in same content", () => {
+    const record = parseLine(
+      "// todo ::: email user@foo.com then @alice reviews",
+      LINE_ONE,
+      { file: "src/workflow.ts" }
+    );
+
+    expect(record).not.toBeNull();
+    expect(record?.mentions).toEqual(["@alice"]);
+  });
+
+  test("extracts valid lowercase mentions", () => {
+    const record = parseLine(
+      "// todo ::: @alice and @agent should review this #task",
+      LINE_ONE,
+      { file: "src/review.ts" }
+    );
+
+    expect(record).not.toBeNull();
+    expect(record?.mentions).toContain("@alice");
+    expect(record?.mentions).toContain("@agent");
+  });
+
+  test("extracts team/group mentions with slash", () => {
+    const record = parseLine(
+      "// todo ::: assign to @team/frontend for implementation",
+      LINE_ONE,
+      { file: "src/feature.ts" }
+    );
+
+    expect(record).not.toBeNull();
+    expect(record?.mentions).toEqual(["@team/frontend"]);
+  });
+
   test("handles HTML comment waymarks", () => {
     const record = parseLine(
       "<!-- tldr ::: overview for automation workflows #docs/guide -->",

--- a/packages/grammar/src/parser.test.ts
+++ b/packages/grammar/src/parser.test.ts
@@ -92,6 +92,18 @@ describe("parseLine", () => {
     expect(record?.mentions).toEqual([]);
   });
 
+  test("does not treat lowercase decorator calls as mentions", () => {
+    const record = parseLine(
+      "// note ::: uses @dataclass() and @staticmethod() decorators",
+      LINE_ONE,
+      { file: "src/model.py" }
+    );
+
+    expect(record).not.toBeNull();
+    // Both rejected due to trailing parens - regex prevents backtracking
+    expect(record?.mentions).toEqual([]);
+  });
+
   test("extracts mention after email in same content", () => {
     const record = parseLine(
       "// todo ::: email user@foo.com then @alice reviews",

--- a/packages/grammar/src/properties.ts
+++ b/packages/grammar/src/properties.ts
@@ -6,9 +6,10 @@ import type { WaymarkRecord } from "./types";
 // note ::: No space allowed after colon for unquoted values (key:value not key: value)
 export const PROPERTY_REGEX =
   /(?:^|[\s])([A-Za-z][A-Za-z0-9_-]*)\s*:(?:"([^"\\]*(?:\\.[^"\\]*)*)"|([^\s,]+(?:,[^\s,]+)*))/gm;
-// note ::: requires lowercase first char to reject decorators (@Component), negative lookahead rejects calls (@Foo())
+// note ::: requires lowercase first char to reject decorators (@Component)
+// note ::: lookahead rejects both continuations and parens to prevent backtracking on @dataclass()
 export const MENTION_REGEX =
-  /(?:^|[^A-Za-z0-9/_-])(@[a-z][A-Za-z0-9/_-]*)(?!\()/gm;
+  /(?:^|[^A-Za-z0-9/_-])(@[a-z][A-Za-z0-9/_-]*)(?![A-Za-z0-9/_(-])/gm;
 export const TAG_REGEX = /(?:^|[^A-Za-z0-9._/:%-])(#[A-Za-z0-9._/:%-]+)/gm;
 
 export const RELATION_KIND_MAP: Record<

--- a/packages/grammar/src/properties.ts
+++ b/packages/grammar/src/properties.ts
@@ -6,7 +6,9 @@ import type { WaymarkRecord } from "./types";
 // note ::: No space allowed after colon for unquoted values (key:value not key: value)
 export const PROPERTY_REGEX =
   /(?:^|[\s])([A-Za-z][A-Za-z0-9_-]*)\s*:(?:"([^"\\]*(?:\\.[^"\\]*)*)"|([^\s,]+(?:,[^\s,]+)*))/gm;
-export const MENTION_REGEX = /(?:^|[^A-Za-z0-9/_-])(@[A-Za-z0-9/_-]+)/gm;
+// note ::: requires lowercase first char to reject decorators (@Component), negative lookahead rejects calls (@Foo())
+export const MENTION_REGEX =
+  /(?:^|[^A-Za-z0-9/_-])(@[a-z][A-Za-z0-9/_-]*)(?!\()/gm;
 export const TAG_REGEX = /(?:^|[^A-Za-z0-9._/:%-])(#[A-Za-z0-9._/:%-]+)/gm;
 
 export const RELATION_KIND_MAP: Record<


### PR DESCRIPTION
## Summary

Tightens the `@mention` regex to reduce false positives from TypeScript/Python decorators and other `@`-prefixed patterns. Mentions now require a lowercase first character after `@`.

## Changes

### Grammar (`packages/grammar`)
- Update `MENTION_REGEX` in `properties.ts`
- Add tests for decorator rejection and edge cases

## New Mention Rules

**Valid mentions** (parsed):
- `@alice`, `@bob`, `@agent`
- `@team/frontend`, `@devops`

**Rejected patterns** (not parsed as mentions):
- `@Component`, `@Injectable` — TypeScript/Angular decorators
- `@Foo()` — Decorator with call syntax
- `user@domain.com` — Email addresses (already rejected)

## Regex Change

```typescript
// Before (permissive)
/(?:^|[^A-Za-z0-9/_-])(@[A-Za-z0-9/_-]+)/gm

// After (stricter)
/(?:^|[^A-Za-z0-9/_-])(@[a-z][A-Za-z0-9/_-]*)(?!\()/gm
```

## Limitations

The regex cannot distinguish between:
- `@scope/package` (npm scoped package)
- `@team/project` (team mention)

Context-aware parsing would be needed for these edge cases.

---
Closes #133 (tags & mentions)

Part of [v1 Syntax Changes](#129)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for mention and decorator handling to ensure decorators and other edge cases are properly distinguished from valid mentions.

* **Bug Fixes**
  * Improved mention detection to correctly identify valid mentions while avoiding false positives from decorator patterns and other syntax.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->