### PR TITLE
feat(core)!: change ID format from wm:xxx to [[hash]] wikilinks

### DIFF
--- a/packages/cli/src/commands/add.prompt.txt
+++ b/packages/cli/src/commands/add.prompt.txt
@@ -137,7 +137,7 @@ AUTOMATIC BEHAVIORS
   1. ID Management:
      - Checks if ID system is enabled in config
      - Reserves unique ID if configured
-     - Adds wm:xxxxx to waymark content automatically
+     - Adds [[xxxxx]] to waymark content automatically
 
   2. Formatting:
      - Applies standard formatting rules

--- a/packages/cli/src/commands/add.test.ts
+++ b/packages/cli/src/commands/add.test.ts
@@ -10,7 +10,7 @@ import { parseAddArgs, runAddCommand } from "./add";
 
 const SAMPLE_LINE = 42;
 const TODO_HANDLER_REGEX = /todo ::: document handler/;
-const ANY_ID_REGEX = /wm:/;
+const ANY_ID_REGEX = /\[\[[a-z0-9]+\]\]/;
 const JSON_VALIDATION_ERROR_REGEX = /JSON validation failed/;
 
 describe("parseAddArgs", () => {
@@ -34,7 +34,7 @@ describe("parseAddArgs", () => {
       "--order",
       "2",
       "--id",
-      "wm:custom123",
+      "[[custom123]]",
     ]);
 
     expect(parsed.options.write).toBe(false);
@@ -56,7 +56,7 @@ describe("parseAddArgs", () => {
     expect(spec.signals).toEqual({ raised: true, important: true });
     expect(spec.continuations).toEqual(["follow up with team"]);
     expect(spec.order).toBe(2);
-    expect(spec.id).toBe("wm:custom123");
+    expect(spec.id).toBe("[[custom123]]");
   });
 
   test("supports --from for batch insert", () => {
@@ -203,7 +203,7 @@ describe("runAddCommand", () => {
       tags: ["#test", "#validation"],
       mentions: ["@alice", "@bob"],
       continuations: ["first continuation", "second continuation"],
-      id: "wm:custom-id",
+      id: "[[custom-id]]",
     });
     await writeFile(validJsonPath, validJson, "utf8");
 

--- a/packages/cli/src/commands/edit.prompt.txt
+++ b/packages/cli/src/commands/edit.prompt.txt
@@ -2,7 +2,7 @@
 You are helping a user update an existing waymark with the wm edit command.
 
 Key capabilities:
-- Target by file:line or by waymark ID (wm:xxxxx)
+- Target by file:line or by waymark ID ([[xxxxx]])
 - Update the marker type (todo, fix, note, etc.)
 - Toggle signals: --raised adds ^, --starred adds *, --clear-signals clears both
 - Replace the first-line content via --content <text> or stdin with --content -
@@ -11,13 +11,13 @@ Key capabilities:
 - Structured output available with --json or --jsonl
 
 Workflow tips:
-1. Always require a target: either FILE:LINE or --id wm:...
-2. Preserve trailing wm: identifiers when editing content.
+1. Always require a target: either FILE:LINE or --id [[...]]
+2. Preserve trailing [[id]] identifiers when editing content.
 3. Combine --raised and --starred to set both signals in one pass.
 4. After applying changes the CLI automatically refreshes the waymark index.
 
 Examples:
 - Preview a type change: wm edit api/auth.ts:120 --type fix
-- Remove signals via ID: wm edit --id wm:a3k9m2p --clear-signals --write
+- Remove signals via ID: wm edit --id [[a3k9m2p]] --clear-signals --write
 - Supply content from stdin: printf "validate JWT" | wm edit src/auth.ts:42 --content - --write
 - Skip prompts: wm edit --no-interactive

--- a/packages/cli/src/commands/help/registry.ts
+++ b/packages/cli/src/commands/help/registry.ts
@@ -295,7 +295,7 @@ export const commands: HelpRegistry = {
       {
         name: "id",
         type: "string",
-        placeholder: "wm:abcdef",
+        placeholder: "[[abcdef]]",
         description: "Reserve specific ID for waymark",
       },
       commonFlags.json,
@@ -327,7 +327,7 @@ export const commands: HelpRegistry = {
       {
         name: "id",
         type: "string",
-        placeholder: "wm:abcdef",
+        placeholder: "[[abcdef]]",
         description: "Target waymark by ID instead of file:line",
       },
       {
@@ -366,10 +366,10 @@ export const commands: HelpRegistry = {
     ],
     examples: [
       "wm edit src/auth.ts:42 --type fix",
-      "wm edit --id wm:a3k9m2p --starred --write",
+      "wm edit --id [[a3k9m2p]] --starred --write",
       'printf "new copy" | wm edit src/auth.ts:42 --content - --write',
       "wm edit                                 # Interactive prompts (no args)",
-      "wm edit --no-interactive --id wm:a3k9m2p",
+      "wm edit --no-interactive --id [[a3k9m2p]]",
     ],
   },
   rm: {
@@ -393,7 +393,7 @@ export const commands: HelpRegistry = {
       {
         name: "id",
         type: "string",
-        placeholder: "wm:abcdef",
+        placeholder: "[[abcdef]]",
         description: "Remove by ID (repeatable)",
       },
       {
@@ -470,7 +470,7 @@ export const commands: HelpRegistry = {
     examples: [
       "wm rm src/auth.ts:42                  # Preview removal",
       "wm rm src/auth.ts:42 --write          # Actually remove",
-      "wm rm --id wm:a3k9m2p --write         # Remove by ID",
+      "wm rm --id [[a3k9m2p]] --write        # Remove by ID",
       "wm rm --type todo --tag #wip --write --yes  # Batch removal",
       'wm rm src/auth.ts:42 --write --reason "cleanup"',
     ],

--- a/packages/cli/src/commands/modify.test.ts
+++ b/packages/cli/src/commands/modify.test.ts
@@ -40,16 +40,16 @@ function createRecord(source: string): WaymarkRecord {
 
 describe("preserveId", () => {
   test("preserves ID at end of content", () => {
-    const result = preserveId("implement OAuth wm:a3k9m2p", "validate JWT");
-    expect(result).toBe("validate JWT wm:a3k9m2p");
+    const result = preserveId("implement OAuth [[a3k9m2p]]", "validate JWT");
+    expect(result).toBe("validate JWT [[a3k9m2p]]");
   });
 
   test("removes duplicate ID from new content", () => {
     const result = preserveId(
-      "old content wm:a3k9m2p",
-      "new content wm:a3k9m2p"
+      "old content [[a3k9m2p]]",
+      "new content [[a3k9m2p]]"
     );
-    expect(result).toBe("new content wm:a3k9m2p");
+    expect(result).toBe("new content [[a3k9m2p]]");
   });
 
   test("returns content as-is when no ID present", () => {
@@ -165,7 +165,7 @@ describe("runModifyCommand integration", () => {
     const filePath = join(workspace, "auth.ts");
     await writeFile(
       filePath,
-      "// todo ::: implement OAuth wm:a3k9m2p\n",
+      "// todo ::: implement OAuth [[a3k9m2p]]\n",
       "utf8"
     );
 
@@ -176,9 +176,9 @@ describe("runModifyCommand integration", () => {
       { stdin: Readable.from([]) }
     );
 
-    expect(result.payload.after.content).toBe("validate JWT wm:a3k9m2p");
+    expect(result.payload.after.content).toBe("validate JWT [[a3k9m2p]]");
     const text = await readFile(filePath, "utf8");
-    expect(text).toBe("// todo ::: validate JWT wm:a3k9m2p\n");
+    expect(text).toBe("// todo ::: validate JWT [[a3k9m2p]]\n");
   });
 
   test("preserves multi-line structure when adding signals", async () => {
@@ -223,18 +223,18 @@ describe("runModifyCommand integration", () => {
     const filePath = join(workspace, "auth.ts");
     await writeFile(
       filePath,
-      "// todo ::: implement OAuth wm:test123\n",
+      "// todo ::: implement OAuth [[test123]]\n",
       "utf8"
     );
 
     const index = new JsonIdIndex({ workspaceRoot: workspace });
     await index.set({
-      id: "wm:test123",
+      id: "[[test123]]",
       file: filePath,
       line: 1,
       type: "todo",
-      content: "// todo ::: implement OAuth wm:test123",
-      contentHash: fingerprintContent("// todo ::: implement OAuth wm:test123"),
+      content: "// todo ::: implement OAuth [[test123]]",
+      contentHash: fingerprintContent("// todo ::: implement OAuth [[test123]]"),
       contextHash: fingerprintContext(
         `${filePath}:1:// todo ::: implement OAuth`
       ),
@@ -249,31 +249,31 @@ describe("runModifyCommand integration", () => {
     );
 
     const refreshedIndex = new JsonIdIndex({ workspaceRoot: workspace });
-    const updated = await refreshedIndex.get("wm:test123");
+    const updated = await refreshedIndex.get("[[test123]]");
     expect(updated).not.toBeNull();
     expect(updated?.type).toBe("todo");
-    expect(updated?.content).toBe("implement OAuth wm:test123");
+    expect(updated?.content).toBe("implement OAuth [[test123]]");
 
     const modifiedFile = await readFile(filePath, "utf8");
-    expect(modifiedFile).toContain("// *todo ::: implement OAuth wm:test123");
+    expect(modifiedFile).toContain("// *todo ::: implement OAuth [[test123]]");
   });
 
   test("resolves target via ID", async () => {
     const filePath = join(workspace, "auth.ts");
     await writeFile(
       filePath,
-      "// todo ::: implement OAuth wm:abc123\n",
+      "// todo ::: implement OAuth [[abc123]]\n",
       "utf8"
     );
 
     const index = new JsonIdIndex({ workspaceRoot: workspace });
     await index.set({
-      id: "wm:abc123",
+      id: "[[abc123]]",
       file: filePath,
       line: 1,
       type: "todo",
-      content: "// todo ::: implement OAuth wm:abc123",
-      contentHash: fingerprintContent("// todo ::: implement OAuth wm:abc123"),
+      content: "// todo ::: implement OAuth [[abc123]]",
+      contentHash: fingerprintContent("// todo ::: implement OAuth [[abc123]]"),
       contextHash: fingerprintContext(
         `${filePath}:1:// todo ::: implement OAuth`
       ),
@@ -283,11 +283,11 @@ describe("runModifyCommand integration", () => {
     await runModifyCommand(
       context,
       undefined,
-      { id: "wm:abc123", noSignal: true, write: true },
+      { id: "[[abc123]]", noSignal: true, write: true },
       { stdin: Readable.from([]) }
     );
 
     const text = await readFile(filePath, "utf8");
-    expect(text).toBe("// todo ::: implement OAuth wm:abc123\n");
+    expect(text).toBe("// todo ::: implement OAuth [[abc123]]\n");
   });
 });

--- a/packages/cli/src/commands/modify.test.ts
+++ b/packages/cli/src/commands/modify.test.ts
@@ -234,7 +234,9 @@ describe("runModifyCommand integration", () => {
       line: 1,
       type: "todo",
       content: "// todo ::: implement OAuth [[test123]]",
-      contentHash: fingerprintContent("// todo ::: implement OAuth [[test123]]"),
+      contentHash: fingerprintContent(
+        "// todo ::: implement OAuth [[test123]]"
+      ),
       contextHash: fingerprintContext(
         `${filePath}:1:// todo ::: implement OAuth`
       ),

--- a/packages/cli/src/commands/modify.ts
+++ b/packages/cli/src/commands/modify.ts
@@ -78,7 +78,8 @@ export type ModifyPayload = {
 };
 
 const LINE_SPLIT_REGEX = /\r?\n/;
-const ID_TRAIL_REGEX = /(wm:[a-z0-9-]+)$/i;
+// Match [[hash]], [[hash|alias]], or [[alias]] at end of content
+const ID_TRAIL_REGEX = /(\[\[[^\]]+\]\])$/i;
 const DEFAULT_MARKERS = ["todo", "fix", "note", "warn", "tldr", "done"];
 
 const DEFAULT_IO: ModifyIo = {
@@ -484,7 +485,13 @@ async function resolveTargetFromId(
 }
 
 function normalizeId(id: string): string {
-  return id.startsWith("wm:") ? id : `wm:${id}`;
+  // Already in [[hash]] or [[hash|alias]] format
+  if (id.startsWith("[[") && id.endsWith("]]")) {
+    return id;
+  }
+  // Strip wm: prefix if present (legacy format)
+  const hash = id.startsWith("wm:") ? id.slice(3) : id;
+  return `[[${hash}]]`;
 }
 
 async function runInteractiveSession(

--- a/packages/cli/src/commands/remove.prompt.txt
+++ b/packages/cli/src/commands/remove.prompt.txt
@@ -6,7 +6,7 @@ PURPOSE
 
 COMMAND SYNTAX
   wm rm <file:line> [--write]
-  wm rm --id <wm-id> [--write]
+  wm rm --id <waymark-id> [--write]
   wm rm --from <json-file> [--write]
   wm rm [filter-flags] <paths> [--write]
   wm rm <file:line> [--write] [--reason "<text>"]
@@ -35,8 +35,8 @@ INPUT METHODS
      → Removes waymark at line 42 in src/auth.ts
 
   2. By Waymark ID:
-     wm rm --id wm:a3k9m2p --write
-     → Removes waymark with ID wm:a3k9m2p
+     wm rm --id [[a3k9m2p]] --write
+     → Removes waymark with ID [[a3k9m2p]]
 
   3. By Filter Flags:
      wm rm --type todo --mention @agent src/ --write
@@ -75,7 +75,7 @@ EXAMPLES
      → Actually removes the waymark
 
   3. Remove by ID:
-     wm rm --id wm:a3k9m2p --write
+     wm rm --id [[a3k9m2p]] --write
 
   4. Remove all completed todos:
      wm rm --type done . --write
@@ -86,7 +86,7 @@ EXAMPLES
   6. Batch remove from analysis:
      echo '[
        {"file":"src/a.ts","line":42},
-       {"id":"wm:xyz123"}
+       {"id":"[[xyz123]]"}
      ]' | wm rm --from - --write --json
 
   7. Remove deprecated waymarks:
@@ -125,14 +125,14 @@ JSON INPUT SCHEMA
 
   OR
 
-    id: string - Waymark ID (wm:xxxxx)
+    id: string - Waymark ID ([[xxxxx]])
 
   Optional fields:
     confirm: boolean - Force confirmation prompt
 
   Examples:
   {"file": "src/auth.ts", "line": 42}
-  {"id": "wm:a3k9m2p"}
+  {"id": "[[a3k9m2p]]"}
 
 AUTOMATIC BEHAVIORS
 
@@ -208,7 +208,7 @@ TIPS FOR AGENTS
 UNDO CAPABILITY (future)
 
   Removed waymarks in history can potentially be restored:
-  wm restore --id wm:a3k9m2p --from-history
+  wm restore --id [[a3k9m2p]] --from-history
 
   (This feature may be added in future versions)
 

--- a/packages/cli/src/commands/remove.test.ts
+++ b/packages/cli/src/commands/remove.test.ts
@@ -19,7 +19,7 @@ describe("parseRemoveArgs", () => {
     const parsed = parseRemoveArgs([
       "src/auth.ts:10",
       "--id",
-      "wm:abc",
+      "[[abc]]",
       "--type",
       "todo",
       "--tag",
@@ -34,7 +34,7 @@ describe("parseRemoveArgs", () => {
     expect(parsed.specs).toHaveLength(ExpectedSpecCount);
     const [byLine, byId, criteria] = parsed.specs;
     expect(byLine).toEqual({ file: "src/auth.ts", line: 10 });
-    expect(byId).toEqual({ id: "wm:abc" });
+    expect(byId).toEqual({ id: "[[abc]]" });
     expect(criteria).toEqual({
       files: ["src/auth.ts"],
       criteria: { type: "todo", tags: ["#cleanup"], contains: "cleanup" },
@@ -99,7 +99,7 @@ describe("runRemoveCommand", () => {
   test("removes waymarks by id and updates the JSON index", async () => {
     const filePath = join(workspace, "src/module.ts");
     await ensureDir(join(workspace, "src"));
-    const waymarkLine = "// todo ::: needs docs wm:test-456";
+    const waymarkLine = "// todo ::: needs docs [[test-456]]";
     await writeFile(
       filePath,
       ["function noop() {}", waymarkLine, ""].join("\n"),
@@ -111,7 +111,7 @@ describe("runRemoveCommand", () => {
       trackHistory: false,
     });
     await index.set({
-      id: "wm:test-456",
+      id: "[[test-456]]",
       file: filePath,
       line: 2,
       type: "todo",
@@ -121,7 +121,7 @@ describe("runRemoveCommand", () => {
       updatedAt: Date.now(),
     });
 
-    const parsed = parseRemoveArgs(["--write", "--id", "wm:test-456"]);
+    const parsed = parseRemoveArgs(["--write", "--id", "[[test-456]]"]);
 
     const actual = await runRemoveCommand(parsed, context, {
       writeOverride: true,
@@ -129,7 +129,7 @@ describe("runRemoveCommand", () => {
 
     expect(actual.summary.successful).toBe(1);
     const remaining = await readFile(filePath, "utf8");
-    expect(remaining).not.toContain("wm:test-456");
+    expect(remaining).not.toContain("[[test-456]]");
 
     const freshIndex = new JsonIdIndex({
       workspaceRoot: workspace,
@@ -235,7 +235,7 @@ describe("runRemoveCommand", () => {
     const validJson = JSON.stringify({
       file: filePath,
       line: 1,
-      id: "wm:test-id",
+      id: "[[test-id]]",
       files: [filePath],
       criteria: {
         type: "todo",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -309,7 +309,8 @@ type ModifyCliOptions = {
   prompt?: boolean;
 };
 
-const ID_PATTERN_REGEX = /wm:[a-z0-9-]+/i;
+// Match [[hash]], [[hash|alias]], or [[alias]]
+const ID_PATTERN_REGEX = /\[\[[^\]]+\]\]/i;
 
 async function resolveInteractiveTarget(
   workspaceRoot: string,
@@ -330,7 +331,7 @@ async function resolveInteractiveTarget(
   const target = `${selected.file}:${selected.startLine}`;
   let id: string | undefined;
 
-  if (selected.raw.includes("wm:")) {
+  if (selected.raw.includes("[[")) {
     const idMatch = selected.raw.match(ID_PATTERN_REGEX);
     if (idMatch) {
       id = idMatch[0];
@@ -1143,7 +1144,7 @@ See 'wm add --prompt' for agent-facing documentation.
 Examples:
   $ wm edit src/auth.ts:42 --type fix                    # Preview type change
   $ wm edit src/auth.ts:42 --raised --starred           # Preview signal updates
-  $ wm edit --id wm:a3k9m2p --starred --write           # Apply starred flag by ID
+  $ wm edit --id [[a3k9m2p]] --starred --write          # Apply starred flag by ID
   $ wm edit src/auth.ts:42 --clear-signals --write       # Remove all signals
   $ wm edit src/auth.ts:42 --content "new text" --write
   $ printf "new text" | wm edit src/auth.ts:42 --content - --write
@@ -1179,7 +1180,7 @@ Notes:
     .command("rm")
     .allowUnknownOption(true)
     .allowExcessArguments(true)
-    .option("--id <id>", "remove waymark by ID (wm:xxxxx)")
+    .option("--id <id>", "remove waymark by ID ([[hash]])")
     .option(
       "--from <file>",
       "read removal targets from JSON file (use - for stdin)"
@@ -1198,14 +1199,14 @@ Notes:
       `
 Removal Methods:
   1. By Location:     wm rm src/auth.ts:42
-  2. By ID:           wm rm --id wm:a3k9m2p
+  2. By ID:           wm rm --id [[a3k9m2p]]
   3. By Criteria:     wm rm --criteria "type:todo mention:@agent" src/
   4. From JSON Input: wm rm --from waymarks.json
 
 Examples:
   $ wm rm src/auth.ts:42                      # Preview removal
   $ wm rm src/auth.ts:42 --write              # Actually remove
-  $ wm rm --id wm:a3k9m2p --write             # Remove by ID
+  $ wm rm --id [[a3k9m2p]] --write            # Remove by ID
   $ wm rm --criteria "type:todo mention:@agent" src/ --write
   $ wm rm --from removals.json --write
   $ wm rm src/auth.ts:42 --write --reason "cleanup"

--- a/packages/core/src/edit.test.ts
+++ b/packages/core/src/edit.test.ts
@@ -56,7 +56,7 @@ describe("editWaymark", () => {
     await ensureDir(dirname(filePath));
     await writeFile(
       filePath,
-      "// todo ::: add rate limiting wm:test123\n",
+      "// todo ::: add rate limiting [[test123]]\n",
       "utf8"
     );
 
@@ -70,9 +70,9 @@ describe("editWaymark", () => {
       DEFAULT_CONFIG
     );
 
-    expect(result.after.raw).toContain("wm:test123");
+    expect(result.after.raw).toContain("[[test123]]");
     const contents = await readFile(filePath, "utf8");
-    expect(contents).toContain("add retry budget wm:test123");
+    expect(contents).toContain("add retry budget [[test123]]");
   });
 
   it("preserves IDs found outside the header line", async () => {
@@ -82,7 +82,7 @@ describe("editWaymark", () => {
       filePath,
       [
         "// todo ::: add rate limiting",
-        "//      ::: wm:test999 #auth",
+        "//      ::: [[test999]] #auth",
         "",
       ].join("\n"),
       "utf8"
@@ -98,9 +98,9 @@ describe("editWaymark", () => {
       DEFAULT_CONFIG
     );
 
-    expect(result.after.raw).toContain("wm:test999");
+    expect(result.after.raw).toContain("[[test999]]");
     const contents = await readFile(filePath, "utf8");
-    expect(contents).toContain("add retry budget wm:test999");
+    expect(contents).toContain("add retry budget [[test999]]");
   });
 
   it("sets and clears signals", async () => {
@@ -130,25 +130,25 @@ describe("editWaymark", () => {
     await ensureDir(dirname(filePath));
     await writeFile(
       filePath,
-      "// todo ::: implement OAuth wm:abc123\n",
+      "// todo ::: implement OAuth [[abc123]]\n",
       "utf8"
     );
 
     const { index, manager } = createManager();
     await index.set({
-      id: "wm:abc123",
+      id: "[[abc123]]",
       file: filePath,
       line: 1,
       type: "todo",
-      content: "implement OAuth wm:abc123",
-      contentHash: fingerprintContent("implement OAuth wm:abc123"),
+      content: "implement OAuth [[abc123]]",
+      contentHash: fingerprintContent("implement OAuth [[abc123]]"),
       contextHash: fingerprintContext(`${filePath}:1`),
       updatedAt: Date.now(),
     });
 
     await editWaymark(
       {
-        id: "wm:abc123",
+        id: "[[abc123]]",
         content: "implement OAuth + PKCE",
         write: true,
         idManager: manager,
@@ -156,11 +156,11 @@ describe("editWaymark", () => {
       DEFAULT_CONFIG
     );
 
-    const refreshed = await index.get("wm:abc123");
-    expect(refreshed?.content).toBe("implement OAuth + PKCE wm:abc123");
+    const refreshed = await index.get("[[abc123]]");
+    expect(refreshed?.content).toBe("implement OAuth + PKCE [[abc123]]");
 
     const contents = await readFile(filePath, "utf8");
-    expect(contents).toContain("implement OAuth + PKCE wm:abc123");
+    expect(contents).toContain("implement OAuth + PKCE [[abc123]]");
   });
 
   it("previews edits without writing", async () => {

--- a/packages/core/src/edit.ts
+++ b/packages/core/src/edit.ts
@@ -556,8 +556,9 @@ function stripHtmlClosure(
   return content;
 }
 
-const ID_REGEX = /\bwm:[a-z0-9-]+\b/gi;
-const ID_TRAIL_REGEX = /(wm:[a-z0-9-]+)$/i;
+// Match [[hash]], [[hash|alias]], or [[alias]]
+const ID_REGEX = /\[\[([a-z0-9-]+)(?:\|([^\]]+))?\]\]/gi;
+const ID_TRAIL_REGEX = /(\[\[[^\]]+\]\])$/i;
 
 function extractExistingId(content: string): string | undefined {
   const matches = content.match(ID_REGEX);
@@ -600,7 +601,13 @@ function ensureHtmlClosure(lines: string[]): void {
 }
 
 function normalizeId(id: string): string {
-  return id.startsWith("wm:") ? id : `wm:${id}`;
+  // Already in [[hash]] or [[hash|alias]] format
+  if (id.startsWith("[[") && id.endsWith("]]")) {
+    return id;
+  }
+  // Strip wm: prefix if present (legacy format)
+  const hash = id.startsWith("wm:") ? id.slice(3) : id;
+  return `[[${hash}]]`;
 }
 
 function buildFileText(

--- a/packages/core/src/edit.ts
+++ b/packages/core/src/edit.ts
@@ -556,8 +556,8 @@ function stripHtmlClosure(
   return content;
 }
 
-// Match [[hash]], [[hash|alias]], or [[alias]]
-const ID_REGEX = /\[\[([a-z0-9-]+)(?:\|([^\]]+))?\]\]/gi;
+// Match [[hash]], [[hash|alias]], or [[Draft Title]] (draft IDs with spaces/uppercase)
+const ID_REGEX = /\[\[([^\]]+)\]\]/gi;
 const ID_TRAIL_REGEX = /(\[\[[^\]]+\]\])$/i;
 
 function extractExistingId(content: string): string | undefined {

--- a/packages/core/src/ids.ts
+++ b/packages/core/src/ids.ts
@@ -133,6 +133,11 @@ export class WaymarkIdManager {
   private normalizeId(id: string): string {
     // Already in [[hash]] or [[hash|alias]] format
     if (id.startsWith("[[") && id.endsWith("]]")) {
+      const content = id.slice(2, -2);
+      // Reject empty brackets or whitespace-only content
+      if (!content || content.trim().length === 0) {
+        throw new Error(`Invalid waymark ID format: ${id}`);
+      }
       return id;
     }
     // Strip wm: prefix if present (legacy format)

--- a/packages/core/src/ids.ts
+++ b/packages/core/src/ids.ts
@@ -131,7 +131,13 @@ export class WaymarkIdManager {
   }
 
   private normalizeId(id: string): string {
-    return id.startsWith("wm:") ? id : `wm:${id}`;
+    // Already in [[hash]] or [[hash|alias]] format
+    if (id.startsWith("[[") && id.endsWith("]]")) {
+      return id;
+    }
+    // Strip wm: prefix if present (legacy format)
+    const hash = id.startsWith("wm:") ? id.slice(3) : id;
+    return `[[${hash}]]`;
   }
 
   private async validateAvailability(
@@ -183,7 +189,7 @@ export class WaymarkIdManager {
       .toString(BASE36_RADIX)
       .padStart(sliceLength, "0")
       .slice(0, sliceLength);
-    return `wm:${base36}`;
+    return `[[${base36}]]`;
   }
 }
 

--- a/packages/core/src/remove.test.ts
+++ b/packages/core/src/remove.test.ts
@@ -62,7 +62,7 @@ describe("removeWaymarks", () => {
   it("removes a waymark by id and updates the index", async () => {
     const filePath = join(workspace, "src/service.ts");
     await ensureDir(dirname(filePath));
-    const waymarkLine = "// todo ::: document handler wm:test123";
+    const waymarkLine = "// todo ::: document handler [[test123]]";
     await writeFile(
       filePath,
       ["export const handler = () => {};", waymarkLine, ""].join("\n"),
@@ -79,7 +79,7 @@ describe("removeWaymarks", () => {
     );
 
     await index.set({
-      id: "wm:test123",
+      id: "[[test123]]",
       file: filePath,
       line: 2,
       type: "todo",
@@ -89,7 +89,7 @@ describe("removeWaymarks", () => {
       updatedAt: Date.now(),
     });
 
-    const specs: RemovalSpec[] = [{ id: "wm:test123" }];
+    const specs: RemovalSpec[] = [{ id: "[[test123]]" }];
     const results = await removeWaymarks(specs, {
       write: true,
       idManager: manager,
@@ -102,13 +102,13 @@ describe("removeWaymarks", () => {
     expect(indexData).toHaveLength(0);
 
     const contents = await readFile(filePath, "utf8");
-    expect(contents).not.toContain("wm:test123");
+    expect(contents).not.toContain("[[test123]]");
   });
 
   it("records removal reason in history when provided", async () => {
     const filePath = join(workspace, "src/history.ts");
     await ensureDir(dirname(filePath));
-    const waymarkLine = "// todo ::: cleanup wm:test456";
+    const waymarkLine = "// todo ::: cleanup [[test456]]";
     await writeFile(
       filePath,
       ["export const handler = () => {};", waymarkLine, ""].join("\n"),
@@ -125,7 +125,7 @@ describe("removeWaymarks", () => {
     );
 
     await index.set({
-      id: "wm:test456",
+      id: "[[test456]]",
       file: filePath,
       line: 2,
       type: "todo",
@@ -135,7 +135,7 @@ describe("removeWaymarks", () => {
       updatedAt: Date.now(),
     });
 
-    const specs: RemovalSpec[] = [{ id: "wm:test456" }];
+    const specs: RemovalSpec[] = [{ id: "[[test456]]" }];
     await removeWaymarks(specs, {
       write: true,
       idManager: manager,

--- a/packages/core/src/remove.ts
+++ b/packages/core/src/remove.ts
@@ -109,7 +109,8 @@ type RemovalMatch = {
   reason: string;
 };
 
-const ID_REGEX = /\bwm:[a-z0-9-]+\b/gi;
+// Match [[hash]], [[hash|alias]], or [[alias]]
+const ID_REGEX = /\[\[([a-z0-9-]+)(?:\|([^\]]+))?\]\]/gi;
 const LINE_SPLIT_REGEX = /\r?\n/;
 const MAX_CONTENT_PATTERN_LENGTH = 512;
 
@@ -480,7 +481,15 @@ function findRecordById(
   records: WaymarkRecord[],
   id: string
 ): WaymarkRecord | undefined {
-  const normalized = id.startsWith("wm:") ? id : `wm:${id}`;
+  // Normalize to [[hash]] format
+  let normalized: string;
+  if (id.startsWith("[[") && id.endsWith("]]")) {
+    normalized = id;
+  } else if (id.startsWith("wm:")) {
+    normalized = `[[${id.slice(3)}]]`;
+  } else {
+    normalized = `[[${id}]]`;
+  }
   return records.find((record) => record.raw.includes(normalized));
 }
 


### PR DESCRIPTION
## Summary

Changes the waymark ID format from `wm:xxx` prefix notation to `[[hash]]` wikilink-style syntax. This aligns with familiar wiki conventions and enables richer ID variants including aliases and draft IDs.

## ID Format Changes

| Variant | Format | Purpose |
|---------|--------|---------|
| Canonical | `[[abc123]]` | Standard assigned ID |
| With alias | `[[abc123\|OAuth Flow]]` | ID with human-readable label |
| Draft | `[[OAuth Flow]]` | Pre-assignment placeholder |

## Changes

### Core (`packages/core`)
- Update `ID_REGEX` and `ID_TRAIL_REGEX` patterns in `edit.ts`
- Update `normalizeId()` to handle new format
- Update `makeId()` to generate `[[hash]]` format
- Update ID extraction in `remove.ts`
- Update `id-index.ts` storage format

### CLI (`packages/cli`)
- Update `modify.ts` ID handling
- Update all help text and examples

## Breaking Change

ID format has changed from `wm:xxx` to `[[xxx]]`.

**Before:**
```typescript
// todo ::: implement OAuth wm:abc123
// fix ::: security patch wm:def456
```

**After:**
```typescript
// todo ::: implement OAuth [[abc123]]
// fix ::: security patch [[def456]]
// note ::: draft feature [[My Feature]]
// todo ::: with alias [[ghi789|Payment Flow]]
```

## Migration

Legacy `wm:` format is still accepted by `normalizeId()` for migration purposes:

```bash
# Find old ID format
rg 'wm:[a-z0-9-]+' --type ts --type md

# Replace wm:xxx with [[xxx]]
```

The CLI's `wm edit` and `wm rm` commands accept both formats during transition.

---
Closes #131 (wikilink IDs)

Part of [v1 Syntax Changes](#129)