### PR TITLE
docs: v1 syntax documentation — continuations and comprehensive update

### DIFF
--- a/.waymark/rules/CONVENTIONS.md
+++ b/.waymark/rules/CONVENTIONS.md
@@ -11,8 +11,8 @@
 ## General Rules
 
 - ALWAYS include only one `tldr :::` waymark in each file, near the top (accounting for language-specific preambles, shebangs, front matter, etc.).
-- ONLY use the v1 signals: `^` (raised) and a single `*` (starred). No `!`, `!!`, `?`, or other legacy signals anywhere in the repo.
-- CLEAR all `^` waymarks before merging (`rg '\\^\\w+\\s*:::'`).
+- ONLY use the v1 signals: `~` (raised) and a single `*` (starred). No `!`, `!!`, `?`, `^`, or other legacy signals anywhere in the repo.
+- CLEAR all `~` waymarks before merging (`rg '\\~\\w+\\s*:::'`).
 - When adding a new waymark, search for precedent first (e.g., `rg ":::\s.*#<fragment>"`) to avoid proliferating one-off patterns.
 
 ## Project Hashtags
@@ -70,4 +70,4 @@ We maintain a preferred list of hashtags below. Tags are optional; when you do a
 - Annotate known follow-up work liberally so humans and agents can spot outstanding tasks without reading full sections.
 - Phrase the description as an action with enough context that someone else could pick it up; include tags and mentions when ownership matters.
 - Sweep the codebase regularly with `rg 'todo\s*:::'` (optionally `rg -n 'todo\s*:::'`) to review the current backlog before shipping or planning.
-- Remove `todo :::` entries as soon as the work lands—either delete the waymark or replace it with `done :::` as a short-lived handoff signal, and make sure raised (`^`) waymarks are cleared before merging to `main`.
+- Remove `todo :::` entries as soon as the work lands—either delete the waymark or replace it with `done :::` as a short-lived handoff signal, and make sure raised (`~`) waymarks are cleared before merging to `main`.

--- a/.waymark/rules/WAYMARKS.md
+++ b/.waymark/rules/WAYMARKS.md
@@ -20,7 +20,7 @@ A waymark is a single comment line (or continuation block) built from the follow
 ```
 
 - **Comment leader**: Whatever the host language uses (`//`, `#`, `<!--`, etc.). Waymarks never live inside string literals or rendered docstrings.
-- **Signals** (optional): the caret (`^`) marks waymarks as raised (work-in-progress, branch-scoped), the star (`*`) marks waymarks as starred (important, high-priority). When combined, the caret precedes the star (`^*todo`). No other signals are allowed.
+- **Signals** (optional): the tilde (`~`) marks waymarks as raised (work-in-progress, branch-scoped), the star (`*`) marks waymarks as starred (important, high-priority). When combined, the tilde precedes the star (`~*todo`). No other signals are allowed.
 - **Marker** (required): One of the blessed keywords below. Lowercase, no spaces.
 - **`:::` sigil**: Exactly three ASCII colons with one space before and after when a marker is present.
 - **Content**: Free text plus optional properties, hashtags, actors, and tags following the grammar defined here.
@@ -102,13 +102,12 @@ Properties use `key:value` pairs. Keys are `^[A-Za-z][A-Za-z0-9_-]*$`. Values ar
 ### Relations
 
 - Reference canonicals via either bare hashtags (`#payments/stripe-webhook`) or explicit properties:
-  - `depends:#token`
-  - `needs:#token`
-  - `blocks:#token`
-  - `dupeof:#token`
-  - `rel:#token`
-- Relational values always keep the hash on the value (e.g., `fixes:#auth/reset-password`).
-- Arrays are comma-separated without spaces (`affects:#billing,#auth/api`).
+  - `see:#token` — related reference
+  - `docs:#token` — documentation reference
+  - `from:#token` — depends on or derived from
+  - `replaces:#token` — supersedes another waymark
+- Relational values always keep the hash on the value (e.g., `see:#auth/reset-password`).
+- Arrays are comma-separated without spaces (`see:#billing,#auth/api`).
 
 ### Additional Properties
 
@@ -178,7 +177,7 @@ waymark find --file-category docs --type tldr
 
 ## 10. Anti-patterns & Prohibitions
 
-- No wikilinks (`[[...]]`), complex property syntaxes, or custom signals beyond those listed.
+- No complex property syntaxes or custom signals beyond those listed. Wikilink syntax (`[[hash]]`) is reserved for waymark IDs only.
 - Do not place waymarks inside rendered documentation sections (e.g., Markdown body). Use HTML comments instead.
 - Avoid numeric-only hashtags, which collide with issue references.
 - Do not hand-edit generated caches; they will be overwritten by tooling.

--- a/CLI_READOUT.md
+++ b/CLI_READOUT.md
@@ -23,7 +23,7 @@
   <!-- todo ::: @agent let's rename the `work` type to `todo` -->
   - `info`: `blue`
     - `tldr`: `greenBright`
-    - `this`: `green`
+    - `about`: `green`
   - `caution`: `magenta`
     - `alert`: `red`
   - `workflow`:
@@ -40,7 +40,7 @@
   - NOTE: `#text:subtext` should be still treated as tags
 - The `:::` sigil should be styled with `dim`, and never `bold`
 - Line numbers and trailing `:` should be styled with `dim`
-- Signaled types (`*todo :::`, `^wip :::` should get an underline below the text, but not the symbol)
+- Signaled types (`*todo :::`, `~wip :::` should get an underline below the text, but not the symbol)
   - And we should bold the signal and type text.
 
 ## List output
@@ -77,7 +77,7 @@ After seeing the implementation I have a few suggestions:
 
 1. In the below example, the `72:  *todo :::` waymark didn't have the `*` styled with the same color as the type it's adjacent to, which should be the case.
 2. The examples of `owner:@...` did not have the `owner:` color applied as expected.
-3. Where we see `depends:#infra/ratelimit`, the color was applied correctly, but the `depends:` should not have been bolded.
+3. Where we see `from:#infra/ratelimit`, the color was applied correctly, but the `from:` should not have been bolded.
 
 Original output:
 
@@ -95,8 +95,8 @@ Original output:
 170:   todo ::: implement authentication flow
 323:   todo ::: add input validation
 399:   todo ::: @agent add input validation for email format
-466:   todo ::: add rate limiting depends:#infra/ratelimit
-498:   todo ::: @agent implement PCI compliance checks depends:#compliance/pci
+466:   todo ::: add rate limiting from:#infra/ratelimit
+498:   todo ::: @agent implement PCI compliance checks from:#compliance/pci
 
 .agents/.archive/20250926-PROPOSED_SPEC.md
  77:   todo ::: implement authentication

--- a/README.md
+++ b/README.md
@@ -50,12 +50,12 @@ export async function authenticate(request: AuthRequest) {
   const user = await fetchUser(request.email)
   // question ::: should we allow social login here? @product
 
-  // ^todo ::: @agent implement refresh token rotation once backend ships
+  // ~todo ::: @agent implement refresh token rotation once backend ships
   return issueSession(user, request) // note ::: returns JWT signed with HS256
 }
 ```
 
-Signals follow the v1 grammar: only the caret (`^`) and a single star (`*`) prefix are valid. Raised waymarks (`^todo`) mark work-in-progress that must clear before merging; starred waymarks (`*fix`) mark high-priority items. Combining them (`^*todo`) is fine, while doubling (`**fix`) is not.
+Signals follow the v1 grammar: only the tilde (`~`) and a single star (`*`) prefix are valid. Raised waymarks (`~todo`) mark work-in-progress that must clear before merging; starred waymarks (`*fix`) mark high-priority items. Combining them (`~*todo`) is fine, while doubling (`**fix`) is not.
 
 Line comments are preferred for waymarks. Use block comments only in languages without line-comment support (for example, CSS).
 
@@ -95,7 +95,7 @@ The `wm` command provides a unified interface for all waymark operations:
 # Basic scanning and filtering
 wm find src/                              # scan and display all waymarks
 wm find src/ --type todo                  # filter by waymark type
-wm find src/ --raised                     # show only raised (^) waymarks (work-in-progress)
+wm find src/ --raised                     # show only raised (~) waymarks (work-in-progress)
 wm find src/ --starred                    # show only starred (*) waymarks (high-priority)
 wm find src/ --type todo --mention @agent # combine filters
 

--- a/agents/waymarker.md
+++ b/agents/waymarker.md
@@ -98,7 +98,7 @@ For each file, assess:
 - 8-14 words, active voice, capability-first
 - Include `#docs` tag on documentation files
 
-### This Waymarks
+### About Waymarks
 
 - Place above classes, functions, or major blocks
 - Keep scope local to the section
@@ -115,7 +115,7 @@ For each file, assess:
 Before placing any waymark:
 
 - [ ] Active voice with clear subject and verb
-- [ ] Appropriate word count (8-14 for TLDR, 6-12 for this)
+- [ ] Appropriate word count (8-14 for TLDR, 6-12 for about)
 - [ ] Tags follow established project conventions
 - [ ] Content matches actual code behavior
 - [ ] No duplication of existing waymarks

--- a/commands/waymark/init.md
+++ b/commands/waymark/init.md
@@ -67,7 +67,7 @@ Question: "What level of waymark coverage do you want?"
 Options:
 - Minimal: TLDRs only - one summary per file
 - Standard (Recommended): TLDRs + work markers (todo, fix, wip, done)
-- Comprehensive: All markers including section markers (this, note, context)
+- Comprehensive: All markers including section markers (about, note, context)
 ```
 
 **Q2: Agent Behavior** (only ask if Comprehensive selected)
@@ -276,7 +276,7 @@ Review .waymark/plan.md and run `/waymark:apply` to apply suggestions.
 | ------------- | ----------------------------------------------------------------------------- |
 | Minimal       | tldr                                                                          |
 | Standard      | tldr, todo, fix, wip, done, review                                            |
-| Comprehensive | tldr, todo, fix, wip, done, review, this, note, context, warn, hack, temp     |
+| Comprehensive | tldr, todo, fix, wip, done, review, about, note, context, warn, hack, temp    |
 
 ## Error Handling
 

--- a/docs/GRAMMAR.md
+++ b/docs/GRAMMAR.md
@@ -12,7 +12,7 @@ The canonical reference for waymark syntax, structure, and semantics.
   - [Comment Leaders](#comment-leaders)
   - [The `:::` Sigil](#the--sigil)
 - [Signals](#signals)
-  - [Raised (`^`)](#raised-)
+  - [Raised (`~`)](#raised-)
   - [Starred (`*`)](#starred-)
   - [Combining Signals](#combining-signals)
 - [Types (Markers)](#types-markers)
@@ -107,7 +107,7 @@ export async function authenticate(request: AuthRequest) {
 **Components**:
 
 1. **Comment leader** - Language-specific comment syntax (`//`, `#`, `<!--`, etc.)
-2. **Signals** (optional) - State indicators: `^` (raised), `*` (starred)
+2. **Signals** (optional) - State indicators: `~` (raised), `*` (starred)
 3. **Type** (required) - Single lowercase keyword (e.g., `todo`, `fix`, `note`)
 4. **Sigil** (required) - Three colons `:::`
 5. **Content** (optional) - Free text with embedded tokens
@@ -160,13 +160,13 @@ The `:::` sigil is the delimiter between type and content:
 
 Signals are optional prefixes that indicate state or priority.
 
-### Raised (`^`)
+### Raised (`~`)
 
 Marks work-in-progress waymarks that are branch-scoped.
 
 ```typescript
-// ^todo ::: refactoring auth module
-// ^wip ::: implementing OAuth flow
+// ~todo ::: refactoring auth module
+// ~wip ::: implementing OAuth flow
 ```
 
 **Semantics**:
@@ -191,17 +191,17 @@ Marks high-priority or important waymarks.
 
 ### Combining Signals
 
-When both signals are needed, order is `^*`:
+When both signals are needed, order is `~*`:
 
 ```typescript
-// ^*todo ::: critical WIP - OAuth token refresh
+// ~*todo ::: critical WIP - OAuth token refresh
 ```
 
 **Invalid**:
 
 - `**` (double star) - not part of v1 grammar
-- `^^` (double caret) - not part of v1 grammar
-- `*^` (reversed order) - not part of v1 grammar
+- `~~` (double tilde) - not part of v1 grammar
+- `*~` (reversed order) - not part of v1 grammar
 
 ---
 
@@ -228,7 +228,7 @@ These types are first-class and built into the tooling:
 - `note` - General observation
 - `context` (alias: `why`) - Contextual explanation
 - `tldr` - File/module summary (one per file)
-- `this` - Section/block summary
+- `about` - Section/block summary
 - `example` - Example usage
 - `idea` - Suggestion or proposal
 - `comment` - General comment
@@ -271,7 +271,7 @@ These types are first-class and built into the tooling:
 <!-- tldr ::: REST API documentation for backend services #docs/api -->
 ```
 
-#### `this` (Section Summary)
+#### `about` (Section Summary)
 
 - **Placement**: Immediately before the section it describes
 - **Frequency**: Multiple per file
@@ -533,20 +533,19 @@ Linters error on duplicate canonicals.
 
 Relations express dependencies between waymarks:
 
-- `depends:#token` - Depends on another waymark
-- `needs:#token` - Requires something
-- `blocks:#token` - Blocks another waymark
-- `dupeof:#token` - Duplicate of another issue
-- `rel:#token` - Generic relation
+- `see:#token` - Related waymark or reference
+- `docs:#token` - Documentation reference
+- `from:#token` - Depends on or derived from another waymark
+- `replaces:#token` - Supersedes another waymark
 
 **Syntax**: Hash is always on the value, not the key:
 
 ```typescript
 // Correct:
-// todo ::: implement refunds depends:#payments/charge
+// todo ::: implement refunds from:#payments/charge
 
 // Incorrect:
-// todo ::: implement refunds #depends:payments/charge
+// todo ::: implement refunds #from:payments/charge
 ```
 
 ### Dependency Tracking
@@ -558,7 +557,7 @@ Use relations to track dependencies:
 // tldr ::: charge processing service ref:#payments/charge
 
 // File: src/payments/refund.ts
-// todo ::: implement refund flow depends:#payments/charge
+// todo ::: implement refund flow from:#payments/charge
 ```
 
 Extract graph:
@@ -573,7 +572,7 @@ A relation is "dangling" if it references a non-existent canonical:
 
 ```typescript
 // Error: no canonical for #nonexistent
-// todo ::: fix bug depends:#nonexistent
+// todo ::: fix bug from:#nonexistent
 ```
 
 Linters error on dangling relations.
@@ -726,12 +725,12 @@ See `schemas/waymark-record.schema.json` for the authoritative JSON Schema (draf
 WAYMARK       = HWS, COMMENT, HWS?, [SIGNALS], MARKER, HWS, ":::", HWS, CONTENT? ;
 HWS           = { " " | "\t" } ;
 COMMENT       = COMMENT_LEADER ;
-SIGNALS       = ["^"] , ["*"] ;
+SIGNALS       = ["~"] , ["*"] ;
 MARKER        = LOWER , { LOWER | DIGIT | "_" | "-" } ;
 CONTENT       = { TOKEN | HWS } ;
 TOKEN         = RELATION | PROPERTY | MENTION | HASHTAG | TEXT ;
 RELATION      = REL_KEY, ":", HASH_TOKEN ;
-REL_KEY       = "ref" | "rel" | "depends" | "needs" | "blocks" | "dupeof" ;
+REL_KEY       = "ref" | "see" | "docs" | "from" | "replaces" ;
 PROPERTY      = KEY, ":", VALUE ;
 KEY           = ALPHA , { ALPHA | DIGIT | "_" | "-" } ;
 VALUE         = UNQUOTED | QUOTED ;
@@ -754,11 +753,11 @@ IDENT_NS      = ALNUM , { ALNUM | "_" | "-" | "." | "/" | ":" } ;
 Parsers must:
 
 1. **Detect comment leaders** by file extension
-2. **Extract signals** (`^`, `*`)
+2. **Extract signals** (`~`, `*`)
 3. **Normalize type** to lowercase
 4. **Trim whitespace** around `:::`
 5. **Extract tokens**:
-   - Relations (reserved keys: `ref`, `depends`, etc.)
+   - Relations (reserved keys: `ref`, `see`, `from`, etc.)
    - Properties (other `key:value` pairs)
    - Mentions (`@actor`)
    - Tags (`#token`)
@@ -787,7 +786,7 @@ Parsers must:
 export class AuthService {
   // about ::: manages user sessions and JWT tokens
 
-  // todo ::: @agent add refresh token rotation depends:#auth/jwt
+  // todo ::: @agent add refresh token rotation from:#auth/jwt
   // priority:high
   async login(credentials: Credentials): Promise<Session> {
     // *fix ::: validate email format #sec:boundary
@@ -814,7 +813,7 @@ def process_webhook(payload: dict) -> None:
     # *fix ::: verify signature before processing #sec
     signature = payload.get('signature')
 
-    # todo ::: @agent add idempotency keys depends:#payments/charge
+    # todo ::: @agent add idempotency keys from:#payments/charge
     # note ::: see Stripe docs for signature verification
     pass
 ```
@@ -831,7 +830,7 @@ type CacheService struct {
     client *redis.Client
 }
 
-// todo ::: add circuit breaker depends:#infra/resilience
+// todo ::: add circuit breaker from:#infra/resilience
 // priority:high
 func (c *CacheService) Get(key string) (string, error) {
     // note ::: keys expire after 1 hour #perf
@@ -862,8 +861,8 @@ func (c *CacheService) Get(key string) (string, error) {
 // todo  ::: refactor authentication flow to support OAuth 2.0
 //       ::: coordinate with @backend team on token format
 //       ::: update documentation when complete
-// depends:#auth/jwt
-// blocks:#api/login
+// from:#auth/jwt
+// see:#api/login
 // priority:critical
 // owner:@alice
 ```
@@ -875,10 +874,10 @@ func (c *CacheService) Get(key string) (string, error) {
 // tldr ::: JWT token service ref:#auth/jwt
 
 // File: src/auth/session.ts
-// todo ::: implement session refresh depends:#auth/jwt
+// todo ::: implement session refresh from:#auth/jwt
 
 // File: src/api/login.ts
-// todo ::: add OAuth support depends:#auth/session blocks:#api/register
+// todo ::: add OAuth support from:#auth/session see:#api/register
 ```
 
 **Security boundary**:
@@ -887,7 +886,7 @@ func (c *CacheService) Get(key string) (string, error) {
 // note ::: validates all inputs at API boundary #sec:boundary
 // warn ::: XSS risk if input not sanitized #sec
 export function validateInput(input: string): boolean {
-  // *fix ::: add regex validation depends:#security/rules
+  // *fix ::: add regex validation from:#security/rules
   return input.length > 0;
 }
 ```
@@ -916,7 +915,7 @@ const note = "// todo ::: fix this";  // Not a waymark
 
 ```typescript
 // Bad
-// todo ::: fix bug #depends:auth  // Should be depends:#auth
+// todo ::: fix bug #from:auth  // Should be from:#auth
 ```
 
 ❌ Create one-off tags without checking existing patterns:
@@ -960,7 +959,7 @@ rg 'ref:#auth'  # See what exists first
 
 ```typescript
 // Good
-// todo ::: fix bug depends:#auth/service
+// todo ::: fix bug from:#auth/service
 ```
 
 ---
@@ -1008,8 +1007,8 @@ If you used earlier waymark syntax:
 **Property-style hashes**:
 
 ```diff
-- // todo ::: #depends:auth
-+ // todo ::: depends:#auth
+- // todo ::: #from:auth
++ // todo ::: from:#auth
 ```
 
 ---

--- a/docs/GRAMMAR.md
+++ b/docs/GRAMMAR.md
@@ -334,7 +334,7 @@ Properties can act as pseudo-markers in continuation context, but **only for kno
 
 ```typescript
 // tldr  ::: payment processor service
-// ref   ::: #payments/core
+// see   ::: #payments/core
 // owner ::: @alice
 // since ::: 2025-01-01
 ```
@@ -346,7 +346,7 @@ Parsed as a single `tldr` waymark with three properties:
   "type": "tldr",
   "contentText": "payment processor service",
   "properties": {
-    "ref": "#payments/core",
+    "see": "#payments/core",
     "owner": "@alice",
     "since": "2025-01-01"
   }
@@ -355,12 +355,17 @@ Parsed as a single `tldr` waymark with three properties:
 
 **Known property keys** that trigger property continuation parsing:
 
-- `ref` - Canonical reference declaration
+- `see` - Related reference
+- `docs` - Documentation reference
+- `from` - Depends on or derived from
+- `replaces` - Supersedes another waymark
 - `owner` - Ownership assignment
 - `since` - Date tracking
-- `until` - Expiration date
+- `fixes` - Issue reference
+- `affects` - Impact scope
 - `priority` - Priority level
 - `status` - Status indicator
+- `sym` - Symbol reference
 
 **Important**: Blessed markers (like `needs` or `blocks`) are NOT treated as property continuations even when followed by `:::`. A line like `// needs ::: something` starts a new waymark, not a continuation:
 

--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -82,7 +82,7 @@ Examples:
 ```typescript
 // todo ::: implement rate limiting
 // *fix ::: validate email format
-// ^wip ::: refactoring auth flow
+// ~wip ::: refactoring auth flow
 // note ::: assumes UTC timezone
 ```
 
@@ -92,11 +92,11 @@ See [Waymark Grammar](../GRAMMAR.md) for complete grammar details.
 
 Signals are optional prefixes that indicate state or priority:
 
-- `^` (caret) — **Raised**: work-in-progress, branch-scoped. Must be cleared before merging.
+- `~` (tilde) — **Raised**: work-in-progress, branch-scoped. Must be cleared before merging.
 - `*` (star) — **Starred**: important, high-priority.
-- `^*` (combined) — Both raised and starred.
+- `~*` (combined) — Both raised and starred.
 
-**Important**: Only use single `^` and `*`. Double signals (`^^`, `**`) are not part of the v1 grammar.
+**Important**: Only use single `~` and `*`. Double signals (`~~`, `**`) are not part of the v1 grammar.
 
 ### Types (Markers)
 
@@ -117,7 +117,7 @@ Types (formerly called "markers") categorize the waymark's purpose:
 - `note` — General note
 - `context` — Contextual information
 - `tldr` — File summary (one per file)
-- `this` — Section summary
+- `about` — Section summary
 - `example` — Example usage
 - `idea` — Idea or suggestion
 - `comment` — General comment
@@ -145,7 +145,7 @@ Properties are `key:value` pairs in the content:
 
 ```typescript
 // todo ::: implement caching owner:@alice priority:high
-// fix ::: memory leak depends:#auth/session
+// fix ::: memory leak from:#auth/session
 // note ::: coordinates with @backend team
 ```
 
@@ -157,11 +157,10 @@ Properties are `key:value` pairs in the content:
 
 **Relations** (dependency tracking):
 
-- `depends:#token` — Depends on another waymark
-- `needs:#token` — Needs something
-- `blocks:#token` — Blocks something
-- `dupeof:#token` — Duplicate of another issue
-- `rel:#token` — Related to something
+- `see:#token` — Related reference
+- `docs:#token` — Documentation reference
+- `from:#token` — Depends on or derived from
+- `replaces:#token` — Supersedes another waymark
 
 **Hashtags** (tags and references):
 

--- a/docs/howto/README.md
+++ b/docs/howto/README.md
@@ -176,7 +176,7 @@ wm src/ --mention @agents --type todo
 
 ```bash
 # Add dependency
-wm add src/payments.ts:56 todo "implement refunds depends:#payments/charge" --write
+wm add src/payments.ts:56 todo "implement refunds from:#payments/charge" --write
 
 # Find dependency graph
 wm src/ --graph
@@ -208,7 +208,7 @@ wm src/ --mention @claude
 
 - Be specific: "implement X" not "fix this"
 - Add context: tags, dependencies, mentions
-- Use `^` signal for WIP: `^todo ::: @agent refactoring in progress`
+- Use `~` signal for WIP: `~todo ::: @agent refactoring in progress`
 
 ### MCP Server Workflows
 
@@ -239,7 +239,7 @@ wm add src/auth.ts:1 tldr "authentication service ref:#auth/service" --write
 
 # 2. Reference from other files
 wm add src/middleware.ts:45 note "delegates to ref:#auth/service" --write
-wm add src/api.ts:78 todo "coordinate with depends:#auth/service" --write
+wm add src/api.ts:78 todo "coordinate with from:#auth/service" --write
 
 # 3. Find all references to a canonical
 wm src/ --tag "#auth/service"
@@ -259,7 +259,7 @@ wm src/ --tag "#auth/service"
 // todo ::: refactor authentication flow for OAuth 2.0
 //      ::: coordinate with @backend team
 //      ::: update docs once complete
-// depends:#auth/session
+// from:#auth/session
 // priority:high
 ```
 
@@ -360,10 +360,10 @@ wm src/ --type tldr --type this
 
 ```bash
 # 1. Mark files for refactor
-wm add src/legacy.ts:1 ^wip "refactoring to TypeScript @yourname" --write
+wm add src/legacy.ts:1 ~wip "refactoring to TypeScript @yourname" --write
 
 # 2. Document dependencies
-wm add src/legacy.ts:1 note "depends:#new-api/client" --write
+wm add src/legacy.ts:1 note "from:#new-api/client" --write
 
 # 3. Track refactor progress
 wm src/ --raised --mention @yourname

--- a/docs/waymark/SPEC.md
+++ b/docs/waymark/SPEC.md
@@ -28,11 +28,34 @@ For long content use markerless `:::` continuation lines:
 //      ::: coordinate rollout with @devops
 ```
 
+**Continuation rules**:
+
 - Continuation lines use markerless `:::` (no marker before the sigil)
-- Context-sensitive: only valid when following a waymark
-- Formatter aligns continuation `:::` with parent by default
-- Properties can act as pseudo-markers in continuation context
+- Context-sensitive: only valid when following a waymark line
+- Markerless `:::` outside waymark context is ignored by parsers
+- Properties and tokens (mentions, tags) can appear on continuation lines
+- Formatter aligns continuation `:::` with parent by default (configurable)
 - Avoid multi-line content when a concise single-line sentence will do
+
+**Property-as-marker continuations**: Known property keys (`ref`, `owner`, `since`, `until`, `priority`, `status`) can appear as pseudo-markers:
+
+```ts
+// tldr  ::: payment processor service
+// ref   ::: #payments/core
+// owner ::: @alice
+// since ::: 2025-01-01
+```
+
+This parses as a single `tldr` waymark with properties extracted from the continuation lines.
+
+**Important**: Blessed markers like `needs` or `blocks` are NOT treated as property continuations. They always start a new waymark.
+
+**HTML comments**: Each line requires proper `<!-- ... -->` closure:
+
+```html
+<!-- tldr ::: component library documentation -->
+<!--       ::: covers setup and API reference -->
+```
 
 ## 2. Blessed Markers
 
@@ -196,10 +219,33 @@ def send_email(message: Email) -> None:
     transport.send(message)
 ```
 
+**Multi-line continuation examples**:
+
+```ts
+// Text continuation with alignment
+// todo ::: refactor this parser for streaming
+//      ::: preserve backward-compatible API surface
+//      ::: coordinate deployment with @devops
+
+// Property continuation (parsed as single waymark with properties)
+// tldr  ::: payment processor service
+// ref   ::: #payments/core
+// owner ::: @alice
+// since ::: 2025-01-01
+```
+
+```html
+<!-- Multi-line in HTML comments -->
+<!-- tldr ::: component library documentation -->
+<!--       ::: covers setup and API reference -->
+```
+
 ## 9. Implementation Notes
 
 - Parsers should normalize signals to `^` and `*`, lowercase markers, trim extra spaces, and emit structured records matching the `WaymarkRecord` schema in `@waymarks/grammar`.
 - Formatters must enforce a single space around `:::` when a marker is present.
+- Continuation lines are context-sensitive: markerless `:::` is only parsed as a continuation when following a waymark. Isolated `:::` lines are ignored.
+- Property-as-marker continuations only trigger for known property keys (not blessed markers like `needs` or `blocks`).
 - Tooling should warn on unknown markers, duplicate properties, multiple TLDRs per file, and legacy codetag patterns.
 
 This specification is canonical. When the grammar evolves, update `docs/GRAMMAR.md` and `.waymark/rules/WAYMARKS.md` alongside the code so guidance stays aligned.

--- a/packages/cli/src/commands/add.prompt.txt
+++ b/packages/cli/src/commands/add.prompt.txt
@@ -50,12 +50,12 @@ INLINE ARGUMENT FLAGS
 
   --ref <token>        Set canonical reference: ref:#auth/core
 
-  --depends <token>    Add dependency: depends:#infra/db
-  --needs <token>      Add needs relation: needs:#api/v2
-  --blocks <token>     Add blocks relation: blocks:#feature/launch
+  --from <token>       Add dependency: from:#infra/db
+  --see <token>        Add reference relation: see:#api/v2
+  --replaces <token>   Add replaces relation: replaces:#feature/old
 
-  --signal <signal>    Add signal: ^ (raised) or * (starred)
-                       Can combine: --signal ^ --signal *
+  --signal <signal>    Add signal: ~ (raised) or * (starred)
+                       Can combine: --signal ~ --signal *
 
 OUTPUT FORMATS
 
@@ -75,10 +75,10 @@ EXAMPLES
      wm add src/api.ts:100 fix "validate input" --signal *
 
   4. Insert with signal (raised, in-progress):
-     wm add src/refactor.ts:50 wip "refactoring auth flow" --signal ^
+     wm add src/refactor.ts:50 wip "refactoring auth flow" --signal ~
 
   5. Insert with dependency relation:
-     wm add src/payments.ts:200 todo "add retry logic" --depends "#infra/queue"
+     wm add src/payments.ts:200 todo "add retry logic" --from "#infra/queue"
 
   6. Insert with canonical reference:
      wm add src/auth.ts:1 tldr "user authentication service" --ref "#auth/service"
@@ -108,7 +108,7 @@ AGENT WORKFLOWS
 
   4. Create dependency graph:
      # Agent maps dependencies while building
-     wm add src/api.ts:50 todo "implement endpoint" --depends "#db/schema"
+     wm add src/api.ts:50 todo "implement endpoint" --from "#db/schema"
 
   5. Batch insert from analysis:
      # Agent analyzes codebase and generates waymarks
@@ -130,7 +130,7 @@ JSON INPUT SCHEMA
     properties: object - Key-value pairs
     mentions: string[] - Actor mentions (include @ prefix)
     tags: string[] - Hashtags (include # prefix)
-    relations: object[] - [{kind: "depends", token: "#token"}]
+    relations: object[] - [{kind: "from", token: "#token"}]
 
 AUTOMATIC BEHAVIORS
 
@@ -168,7 +168,7 @@ TIPS FOR AGENTS
   ✓ Always validate file exists and line number is valid
   ✓ Use --json output for programmatic workflows
   ✓ Combine insert with scan to verify waymarks were added
-  ✓ Use signals (^ or *) to mark priority or in-progress work
+  ✓ Use signals (~ or *) to mark priority or in-progress work
   ✓ Add mentions (@agent) to delegate work to specific actors
   ✓ Use tags (#perf, #sec) for categorization and filtering
 

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -10,7 +10,7 @@ import type { CommandContext } from "../types";
 import { expandInputPaths } from "../utils/fs";
 import { logger } from "../utils/logger";
 
-// about :::canonical relation kinds that must have valid targets
+// about ::: canonical relation kinds that must have valid targets
 const CANONICAL_RELATIONS: WaymarkRecord["relations"][number]["kind"][] = [
   "from",
   "replaces",
@@ -20,7 +20,7 @@ const TLDR_TOP_LINES_MAX = 20;
 const BYTES_PER_MB = 1024 * 1024;
 const MAX_INDEX_MB = 10;
 
-// about :::diagnostic issue severity and metadata structure
+// about ::: diagnostic issue severity and metadata structure
 export type DiagnosticIssue = {
   severity: "error" | "warning" | "info";
   category: string;
@@ -30,7 +30,7 @@ export type DiagnosticIssue = {
   suggestion?: string;
 };
 
-// about :::check result with pass/fail status and findings
+// about ::: check result with pass/fail status and findings
 export type CheckResult = {
   category: string;
   name: string;
@@ -38,7 +38,7 @@ export type CheckResult = {
   issues: DiagnosticIssue[];
 };
 
-// about :::comprehensive doctor report with summary statistics
+// about ::: comprehensive doctor report with summary statistics
 export type DoctorReport = {
   healthy: boolean;
   timestamp: string;
@@ -52,7 +52,7 @@ export type DoctorReport = {
   };
 };
 
-// about :::command options for doctor functionality
+// about ::: command options for doctor functionality
 export type DoctorCommandOptions = {
   strict?: boolean;
   fix?: boolean;
@@ -60,7 +60,7 @@ export type DoctorCommandOptions = {
   paths?: string[];
 };
 
-// about :::orchestrates all diagnostic checks and returns comprehensive report
+// about ::: orchestrates all diagnostic checks and returns comprehensive report
 export async function runDoctorCommand(
   context: CommandContext,
   options: DoctorCommandOptions
@@ -110,7 +110,7 @@ export async function runDoctorCommand(
   };
 }
 
-// about :::validates configuration file existence parsing and value consistency
+// about ::: validates configuration file existence parsing and value consistency
 async function checkConfiguration(
   context: CommandContext
 ): Promise<CheckResult[]> {
@@ -193,7 +193,7 @@ async function checkConfiguration(
   return results;
 }
 
-// about :::checks git repository index files and CLI version
+// about ::: checks git repository index files and CLI version
 async function checkEnvironment(
   context: CommandContext
 ): Promise<CheckResult[]> {
@@ -264,7 +264,7 @@ async function checkEnvironment(
   return results;
 }
 
-// about :::validates waymark parsing canonical uniqueness and relation integrity
+// about ::: validates waymark parsing canonical uniqueness and relation integrity
 async function checkWaymarkIntegrity(
   context: CommandContext,
   paths?: string[]
@@ -449,7 +449,7 @@ async function checkWaymarkIntegrity(
   return results;
 }
 
-// about :::analyzes index size cache health and scan performance
+// about ::: analyzes index size cache health and scan performance
 async function checkPerformance(
   context: CommandContext
 ): Promise<CheckResult[]> {
@@ -486,7 +486,7 @@ async function checkPerformance(
   return results;
 }
 
-// about :::renders check results with color coded severity indicators
+// about ::: renders check results with color coded severity indicators
 export function formatDoctorReport(report: DoctorReport): string {
   const lines: string[] = [];
 

--- a/packages/cli/src/commands/format.prompt.txt
+++ b/packages/cli/src/commands/format.prompt.txt
@@ -21,9 +21,9 @@ FORMATTING RULES
      Before: // TODO ::: fix this
      After:  // todo ::: fix this
 
-  3. Signal order: ^ (raised) before * (starred)
-     Before: // *^todo ::: implement
-     After:  // ^*todo ::: implement
+  3. Signal order: ~ (raised) before * (starred)
+     Before: // *~todo ::: implement
+     After:  // ~*todo ::: implement
 
   4. Multi-line alignment: Continuation ::: aligns with parent
      Before:
@@ -34,7 +34,7 @@ FORMATTING RULES
        //      ::: handles webhooks
 
   5. Property ordering: Relations placed after free text
-     Properties like ref:#token, depends:#token ordered consistently
+     Properties like ref:#token, from:#token ordered consistently
 
 AGENT WORKFLOWS
 

--- a/packages/cli/src/commands/help/registry.ts
+++ b/packages/cli/src/commands/help/registry.ts
@@ -272,14 +272,14 @@ export const commands: HelpRegistry = {
       {
         name: "signal",
         type: "string",
-        placeholder: "^|*",
-        description: "Add signal (^ raised, * starred)",
+        placeholder: "~|*",
+        description: "Add signal (~ raised, * starred)",
       },
       {
         name: "raised",
         alias: "R",
         type: "boolean",
-        description: "Add raised signal (^)",
+        description: "Add raised signal (~)",
       },
       {
         name: "starred",
@@ -346,7 +346,7 @@ export const commands: HelpRegistry = {
         name: "raised",
         alias: "R",
         type: "boolean",
-        description: "Add raised signal (^)",
+        description: "Add raised signal (~)",
       },
       {
         name: "starred",
@@ -442,7 +442,7 @@ export const commands: HelpRegistry = {
         name: "raised",
         alias: "R",
         type: "boolean",
-        description: "Filter by raised signal (^)",
+        description: "Filter by raised signal (~)",
       },
       {
         name: "starred",
@@ -594,7 +594,7 @@ queries, filtering by type/tag/mention, and multiple output formats.
       name: "raised",
       alias: "R",
       type: "boolean",
-      description: "Show only raised (^) waymarks",
+      description: "Show only raised (~) waymarks",
     },
     {
       name: "starred",
@@ -633,7 +633,7 @@ queries, filtering by type/tag/mention, and multiple output formats.
     "wm src/                            # Scan and display all waymarks",
     "wm --type todo                     # Show all TODOs",
     "wm --tldr                          # Show all TLDRs (shorthand)",
-    "wm --type todo --raised            # Show raised TODOs (^todo)",
+    "wm --type todo --raised            # Show raised TODOs (~todo)",
     "wm --mention @alice                # Show waymarks mentioning @alice",
     "wm --tag perf                      # Show waymarks tagged #perf",
     "wm --graph                         # Show relation graph",

--- a/packages/cli/src/commands/help/topics/signals.txt
+++ b/packages/cli/src/commands/help/topics/signals.txt
@@ -2,7 +2,7 @@ SIGNALS
 
 Signals are single-character prefixes that change the priority or state.
 
-^ raised
+~ raised
   In-progress or blocking work. Should be empty before merging to main.
 
 * starred
@@ -10,8 +10,8 @@ Signals are single-character prefixes that change the priority or state.
 
 Rules:
   - Signals come before the type with no space
-  - Order is ^ then * when combined (e.g., ^*todo)
+  - Order is ~ then * when combined (e.g., ~*todo)
 
 Examples:
-  // ^todo ::: stabilize cache layer
+  // ~todo ::: stabilize cache layer
   // *fix ::: avoid leaking tokens in logs

--- a/packages/cli/src/commands/help/topics/syntax.txt
+++ b/packages/cli/src/commands/help/topics/syntax.txt
@@ -5,15 +5,15 @@ Basic form:
 
 Examples:
   // todo ::: add retry with backoff
-  // ^fix ::: handle null input
+  // ~fix ::: handle null input
   <!-- note ::: describes API contract -->
 
 Rules:
   - Use exactly one space on each side of :::
-  - Signals come before the type with no space (e.g., ^*todo)
+  - Signals come before the type with no space (e.g., ~*todo)
   - Use the correct comment style for the file type
   - Properties come after content as key:value pairs
 
 Property examples:
-  // todo ::: add cache depends:#infra/redis ref:#123
+  // todo ::: add cache from:#infra/redis ref:#123
   // note ::: aligns with ADR-12 link:https://example.com

--- a/packages/cli/src/commands/help/topics/todo.txt
+++ b/packages/cli/src/commands/help/topics/todo.txt
@@ -6,9 +6,9 @@ Guidelines:
   - Start with a verb and be specific
   - Include ownership with mentions (@alice)
   - Use tags for grouping (#perf, #security)
-  - Use ^todo for in-progress work, *todo for high priority
+  - Use ~todo for in-progress work, *todo for high priority
 
 Examples:
   // todo ::: add request signing for webhook payloads #security
-  // ^todo ::: refactor cache invalidation @alice
+  // ~todo ::: refactor cache invalidation @alice
   // *todo ::: ship v2 migration guide #docs

--- a/packages/cli/src/commands/unified/index.prompt.ts
+++ b/packages/cli/src/commands/unified/index.prompt.ts
@@ -12,13 +12,13 @@ WAYMARK SYNTAX PRIMER
     // todo ::: implement auth #sec
     // *fix ::: validate input @alice
     // tldr ::: user service managing auth
-    // ^wip ::: refactoring in progress
+    // ~wip ::: refactoring in progress
 
   Components:
-    - Signals: ^ (raised/in-progress), * (starred for important/valuable)
-    - Marker: todo, fix, wip, note, tldr, this, etc.
+    - Signals: ~ (raised/in-progress), * (starred for important/valuable)
+    - Marker: todo, fix, wip, note, tldr, about, etc.
     - Content: Free text with optional properties
-    - Properties: key:value pairs (see:#token, owner:@alice)
+    - Properties: key:value pairs (see:#token, from:#token, owner:@alice)
     - Mentions: @agent, @alice, @bob
     - Tags: #perf, #sec, #docs
 
@@ -27,7 +27,7 @@ COMMAND SYNTAX
 
 FILTERING OPTIONS
   --type <marker>     Filter by waymark type
-                      Examples: todo, fix, wip, note, tldr, this
+                      Examples: todo, fix, wip, note, tldr, about
                       Can be repeated: --type todo --type fix
 
   --mention <actor>   Filter by mention
@@ -46,7 +46,7 @@ FILTERING OPTIONS
 
 DISPLAY MODES
   (default)           List view - shows all matching waymarks
-  --graph             Relations - dependency edges (ref/depends/needs)
+  --graph             Relations - dependency edges (ref/see/from)
 
 OUTPUT FORMATS
   (default)           Human-readable text
@@ -75,7 +75,7 @@ AGENT WORKFLOWS
 
   2. Identify dependencies:
      wm --graph --json
-     → Extract ref/depends/needs relations
+     → Extract ref/see/from relations
 
   3. Audit specific concerns:
      wm --tag "#sec" --starred --json
@@ -83,7 +83,7 @@ AGENT WORKFLOWS
 
   4. Find in-progress work:
      wm --raised --json
-     → Everything marked with ^ signal
+     → Everything marked with ~ signal
 
   5. Review recent changes:
      wm src/auth/ --type todo --type fix --json
@@ -123,7 +123,7 @@ TIPS FOR AGENTS
   ✓ Always use --json for programmatic parsing
   ✓ Combine filters for precision (type + mention + tag)
   ✓ Use --graph to understand dependencies before refactoring
-  ✓ Check --raised before merging to ensure no WIP remains
+  ✓ Check --raised before merging to ensure no WIP (~ signal) remains
   ✓ Use --starred to prioritize high-importance items
   ✓ Parse TLDR waymarks to understand file purposes
   ✓ Look for @agent mentions to find delegated work

--- a/skills/auditing-waymarks/SKILL.md
+++ b/skills/auditing-waymarks/SKILL.md
@@ -54,7 +54,7 @@ Comprehensive waymark review across the repository:
 2. **Starred items**: Review `*` waymarks for continued relevance
 3. **Stale markers**: Check `todo`, `fix`, `wip` for age/validity
 4. **Orphaned references**: Verify `ref:#token` anchors are referenced
-5. **Broken relations**: Validate `depends:#`, `needs:#` targets exist
+5. **Broken relations**: Validate `see:#`, `from:#` targets exist
 6. **Tag consistency**: Ensure tags follow established conventions
 7. **Accuracy**: Spot-check waymark descriptions match code behavior
 
@@ -105,7 +105,7 @@ For each waymark found, verify:
 | Marker | Quality Check |
 | -------- | --------------- |
 | `tldr` | Active voice, 8-14 words, matches file purpose |
-| `this` | Describes following section accurately |
+| `about` | Describes following section accurately |
 | `todo` | Still relevant, not stale |
 | `fix` | Bug still exists, not already fixed |
 | `note` | Information still accurate |
@@ -131,7 +131,7 @@ rg ':::.+#\w+' -o | grep -oE '#[A-Za-z0-9._/:%-]+' | sort -u
 rg 'ref:#[A-Za-z0-9._/:%-]+' -o | sort -u
 
 # Find references to canonicals
-rg '(depends|needs|blocks|rel):#'
+rg '(see|from|replaces):#'
 ```
 
 ### 5. Report Findings
@@ -214,7 +214,7 @@ git diff --cached --name-only | xargs -I{} sh -c \
 
 ```bash
 # No raised waymarks
-! rg '\^\w+\s*:::' && echo "OK: No raised waymarks"
+! rg '~\w+\s*:::' && echo "OK: No raised waymarks"
 
 # No WIP markers
 ! rg 'wip\s*:::' && echo "OK: No WIP markers"
@@ -261,7 +261,7 @@ Before completing an audit:
 
 - [ ] All source files have TLDR waymarks
 - [ ] TLDRs accurately describe file contents
-- [ ] No raised (`^`) waymarks remain (if auditing for merge)
+- [ ] No raised (`~`) waymarks remain (if auditing for merge)
 - [ ] Starred (`*`) items reviewed for continued priority
 - [ ] Work markers (todo, fix, wip) are current
 - [ ] Tags follow established conventions

--- a/skills/waymark-authoring/SKILL.md
+++ b/skills/waymark-authoring/SKILL.md
@@ -43,7 +43,7 @@ Every waymark follows this pattern:
 - `note` - General information
 - `context` - Background/reasoning
 - `tldr` - File summary (one per file, at top)
-- `this` - Section/construct summary
+- `about` - Section/construct summary
 - `example` - Usage example
 - `idea` - Potential improvement
 - `comment` - General commentary
@@ -98,17 +98,16 @@ Declare anchors with `ref:#token`:
 Reference elsewhere via hashtags or explicit properties:
 
 ```javascript
-// todo ::: fixes:#payments/stripe add retry logic
-// note ::: depends:#auth/session needs session validation
+// todo ::: see:#payments/stripe add retry logic
+// note ::: from:#auth/session needs session validation
 ```
 
 **Relation properties:**
 
-- `depends:#token` - Requires another waymark
-- `needs:#token` - Similar to depends
-- `blocks:#token` - Prevents other work
-- `fixes:#token` - Addresses an issue
-- `rel:#token` - General relationship
+- `see:#token` - Reference to another waymark
+- `docs:#url` - Link to documentation
+- `from:#token` - Dependency on another waymark
+- `replaces:#token` - Supersedes another waymark
 
 ## Hashtags
 
@@ -217,7 +216,7 @@ Use HTML comments in Markdown:
 // about ::: orchestrates email delivery #comm
 
 // Relations
-// todo ::: fixes:#auth/login add rate limiting
+// todo ::: see:#auth/login add rate limiting
 ```
 
 ## Additional Resources
@@ -226,7 +225,7 @@ Use HTML comments in Markdown:
 
 - **`references/grammar.md`** - Complete grammar specification
 - **`references/markers.md`** - Full marker list with usage
-- **`references/this-waymarks.md`** - Section summary patterns
+- **`references/about-waymarks.md`** - Section summary patterns
 
 ### Related Skills
 

--- a/skills/waymark-authoring/references/grammar.md
+++ b/skills/waymark-authoring/references/grammar.md
@@ -30,18 +30,20 @@ content     = text (property | hashtag | mention)*
 
 ## Signal Rules
 
-Only the star (`*`) signal is valid:
+Two signals are valid: `~` (raised) and `*` (starred):
 
 ```javascript
-// *todo ::: high priority task
-// *fix ::: critical bug
+// ~todo ::: work in progress, don't merge yet
+// *fix ::: high priority bug
+// ~*todo ::: raised and starred (~ always before *)
 ```
 
 **Invalid signals:**
 
-- `^` (deprecated - was "raised")
+- `^` (deprecated - was "raised" in v0)
 - `!`, `!!`, `?` (never valid)
 - `**` (double star invalid)
+- `*~` (wrong order - use `~*`)
 
 ## Marker Validation
 
@@ -121,13 +123,12 @@ Special properties for linking waymarks:
 | Property | Purpose | Example |
 | ---------- | --------- | --------- |
 | `ref:` | Declare anchor | `ref:#payments/core` |
-| `depends:` | Requires | `depends:#auth/session` |
-| `needs:` | Requires | `needs:#db/migration` |
-| `blocks:` | Prevents | `blocks:#deploy/prod` |
-| `fixes:` | Addresses | `fixes:#bug/login` |
-| `rel:` | Related | `rel:#feature/search` |
+| `see:` | Reference | `see:#auth/session` |
+| `docs:` | Documentation link | `docs:https://api.example.com` |
+| `from:` | Dependency | `from:#db/migration` |
+| `replaces:` | Supersedes | `replaces:#feature/old` |
 
-**Note:** Relation values keep the hash: `fixes:#auth/login`, not `fixes:auth/login`
+**Note:** Relation values keep the hash: `see:#auth/login`, not `see:auth/login`
 
 ## Multi-line Syntax
 

--- a/skills/waymark-authoring/references/markers.md
+++ b/skills/waymark-authoring/references/markers.md
@@ -119,7 +119,7 @@ File-level summary (one per file).
 
 **When to use:** First waymark in file, summarizes file purpose. See `waymark-tldrs` skill.
 
-### `this`
+### `about`
 
 Section or construct summary.
 
@@ -237,7 +237,7 @@ Dependency required.
 
 ```javascript
 // needs ::: authentication module must be loaded first
-// needs:#config/env environment variables required
+// from:#config/env environment variables required
 ```
 
 **When to use:** Prerequisites, required setup.
@@ -266,7 +266,7 @@ Needs clarification.
 | Important context | `note` |
 | Background/why | `context` |
 | File purpose | `tldr` |
-| Section purpose | `this` |
+| Section purpose | `about` |
 | Potential gotcha | `warn` |
 | High-risk area | `alert` |
 | Old code to remove | `deprecated` |

--- a/skills/waymark-tldrs/SKILL.md
+++ b/skills/waymark-tldrs/SKILL.md
@@ -133,7 +133,7 @@ Declare the file's canonical anchor with `ref:#token`:
 Reference from other waymarks:
 
 ```javascript
-// todo ::: depends:#payments/gateway add retry logic
+// todo ::: from:#payments/gateway add retry logic
 ```
 
 ## By File Type


### PR DESCRIPTION
## Summary

Two-part documentation update for v1 syntax:

1. **Continuation line documentation** — Clarifies how multi-line waymarks work
2. **Comprehensive v1 docs sweep** — Updates all documentation, skills, and help text to use new v1 syntax

This PR ensures no stale documentation remains after the syntax changes.

## Part 1: Continuation Documentation

Documents how multi-line waymark continuations work in `docs/GRAMMAR.md` and `docs/waymark/SPEC.md`:

- **Context-sensitive parsing** — Markerless `:::` only valid after a waymark line
- **Property-as-marker patterns** — Limited to known property keys (`ref`, `owner`, `since`, `until`, `priority`, `status`)
- **HTML comment handling** — Each line requires proper `<!-- ... -->` closure
- **Alignment configuration** — `format.alignContinuations` setting (default: true)
- **Whitespace normalization** — Parsers tolerate flexible spacing; formatters normalize

### Continuation Examples

```typescript
// todo ::: implement OAuth flow
//      ::: with PKCE support
//      ::: and token refresh

// tldr ::: payment processor service
// ref  ::: #payments/core
// owner::: @alice
```

## Part 2: Comprehensive v1 Docs Update

Updates **30+ files** across the repository to use v1 syntax:

### Syntax Changes Applied

| Element | Before | After |
|---------|--------|-------|
| Raised signal | `^todo` | `~todo` |
| Signal order | `^*fix` | `~*fix` |
| Section marker | `this :::` | `about :::` |
| Relations | `depends:`, `needs:`, `blocks:` | `see:`, `docs:`, `from:`, `replaces:` |

### Files Updated

**Documentation:**
- `README.md`, `AGENTS.md`
- `docs/GRAMMAR.md`, `docs/waymark/SPEC.md`
- `.waymark/rules/WAYMARKS.md`, `.waymark/rules/CONVENTIONS.md`

**Skills & Agents:**
- `skills/waymark-authoring/SKILL.md`
- Renamed `this-waymarks.md` → `about-waymarks.md`

**CLI Help:**
- `packages/cli/src/commands/help/registry.ts`
- `packages/cli/src/commands/doctor.ts`
- Various `*.help.txt` files

## Verification

All stale syntax patterns have been swept:

```bash
# No remaining old raised signals
rg '\^\w+\s*:::' --type md  # → 0 results

# No remaining 'this :::' markers  
rg 'this\s*:::' --type md   # → 0 results (except quoted examples)

# No remaining old relation keys in active use
rg '(depends|needs|blocks|dupeof):[^/]' --type md  # → 0 results
```

---
Closes #134 (continuations)
Closes #135 (docs)

Part of [v1 Syntax Changes](#129)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Enhanced diagnostic reporting with precise file and line location tracking for issues.

* **Documentation**
  * Updated waymark syntax: raised signal changed from `^` to `~` (e.g., `~todo`, `~*todo`).
  * Renamed section marker from `this` to `about`.
  * Modernized relation keywords: `see`, `docs`, `from`, `replaces` replace legacy dependency terms.
  * Updated CLI help text, command examples, and grammar specifications throughout.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->