### PR TITLE
docs: comprehensive v1 syntax documentation update

### DIFF
--- a/packages/cli/src/commands/add.prompt.txt
+++ b/packages/cli/src/commands/add.prompt.txt
@@ -50,7 +50,7 @@ INLINE ARGUMENT FLAGS
 
   --ref <token>        Set canonical reference: ref:#auth/core
 
-  --source <token>     Add dependency: from:#infra/db
+  --source <token>     Add dependency: source:#infra/db
   --see <token>        Add reference relation: see:#api/v2
   --replaces <token>   Add replaces relation: replaces:#feature/old
 

--- a/packages/cli/src/commands/add.prompt.txt
+++ b/packages/cli/src/commands/add.prompt.txt
@@ -50,7 +50,7 @@ INLINE ARGUMENT FLAGS
 
   --ref <token>        Set canonical reference: ref:#auth/core
 
-  --from <token>       Add dependency: from:#infra/db
+  --source <token>     Add dependency: from:#infra/db
   --see <token>        Add reference relation: see:#api/v2
   --replaces <token>   Add replaces relation: replaces:#feature/old
 

--- a/packages/cli/src/commands/edit.prompt.txt
+++ b/packages/cli/src/commands/edit.prompt.txt
@@ -4,7 +4,7 @@ You are helping a user update an existing waymark with the wm edit command.
 Key capabilities:
 - Target by file:line or by waymark ID ([[xxxxx]])
 - Update the marker type (todo, fix, note, etc.)
-- Toggle signals: --raised adds ^, --starred adds *, --clear-signals clears both
+- Toggle signals: --raised adds ~, --starred adds *, --clear-signals clears both
 - Replace the first-line content via --content <text> or stdin with --content -
 - Preview changes by default; add --write to apply them atomically
 - Interactive prompts run automatically when no positional arguments are supplied; use --no-interactive to skip them

--- a/packages/cli/src/commands/format.help.txt
+++ b/packages/cli/src/commands/format.help.txt
@@ -18,7 +18,7 @@ FORMATTING RULES
   - Marker case normalized (default: lowercase)
   - Multi-line continuations aligned to parent :::
   - Property ordering: relations after free text
-  - Signal order: ^ before * when combined
+  - Signal order: ~ before * when combined
 
 EXAMPLES
   # Preview formatting changes (dry-run)

--- a/packages/cli/src/commands/modify.ts
+++ b/packages/cli/src/commands/modify.ts
@@ -585,7 +585,7 @@ function buildInteractiveSteps(args: {
       build: () => ({
         type: "confirm",
         name: "addRaised",
-        message: "Add raised signal (^) ?",
+        message: "Add raised signal (~) ?",
         default:
           answers.addRaised ?? record.signals.raised ?? options.raised ?? false,
       }),
@@ -940,7 +940,7 @@ function describeChanges(payload: ModifyPayload): string[] {
     const { from, to } = payload.modifications.signals;
     if (from.raised !== to.raised) {
       entries.push(
-        to.raised ? "Added raised signal (^)" : "Removed raised signal (^)"
+        to.raised ? "Added raised signal (~)" : "Removed raised signal (~)"
       );
     }
     if (from.important !== to.important) {

--- a/packages/cli/src/commands/remove.prompt.txt
+++ b/packages/cli/src/commands/remove.prompt.txt
@@ -51,7 +51,7 @@ FILTER FLAGS
   --type <marker>       Match by waymark type (todo, fix, note, etc.)
   --mention <actor>     Match by mention (@agent, @alice, etc.)
   --tag <hashtag>       Match by hashtag (#deprecated, #perf, etc.)
-  --raised              Match raised (^) waymarks
+  --raised              Match raised (~) waymarks
   --starred             Match starred (*) waymarks (important/valuable)
   --contains <text>     Match content containing text
 
@@ -103,7 +103,7 @@ AGENT WORKFLOWS
        | while read loc; do wm rm "$loc" --write; done
 
   2. Remove raised waymarks after merge:
-     # Agent removes ^ waymarks after PR merges
+     # Agent removes ~ waymarks after PR merges
      wm rm --raised . --write
 
   3. Archive deprecated markers:

--- a/packages/cli/src/commands/unified/index.help.txt
+++ b/packages/cli/src/commands/unified/index.help.txt
@@ -13,7 +13,7 @@ OPTIONS
     -t, --type <marker>     Filter by waymark type (todo, fix, note, etc.)
     -m, --mention <actor>   Filter by mention (@agent, @alice, etc.)
     --tag <tag>             Filter by hashtag (#perf, #sec, etc.)
-    -R, --raised            Show only raised (^) waymarks
+    -R, --raised            Show only raised (~) waymarks
     -S, --starred           Show only important (*) waymarks
 
   Display Modes:

--- a/packages/cli/src/commands/unified/index.prompt.ts
+++ b/packages/cli/src/commands/unified/index.prompt.ts
@@ -38,7 +38,7 @@ FILTERING OPTIONS
                       Examples: #perf, #sec, #docs
                       Can be repeated: --tag "#perf" --tag "#sec"
 
-  --raised            Only show ^ (raised/in-progress) waymarks
+  --raised            Only show ~ (raised/in-progress) waymarks
                       Use to find work that shouldn't merge yet
 
   --starred           Only show * (starred) waymarks (important/valuable)

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1025,7 +1025,7 @@ Formatting Rules:
   - Marker case normalized (default: lowercase)
   - Multi-line continuations aligned to parent :::
   - Property ordering: relations after free text
-  - Signal order: ^ before * when combined
+  - Signal order: ~ before * when combined
 
 Before Formatting:
   //todo:::implement auth
@@ -1070,7 +1070,7 @@ See 'wm fmt --prompt' for agent-facing documentation.
     .option("--docs <url>", "add documentation link")
     .option("--source <token>", "add dependency relation (from:#token)")
     .option("--replaces <token>", "add supersedes relation")
-    .option("--signal <signal>", "add signal: ^ (raised) or * (starred)")
+    .option("--signal <signal>", "add signal: ~ (raised) or * (starred)")
     .option("--write, -w", "apply changes to file (default: preview)", false)
     .option("--json", "output as JSON")
     .option("--jsonl", "output as JSON Lines")
@@ -1093,12 +1093,12 @@ Examples:
   $ echo '{"file":"src/a.ts","line":10,"type":"todo","content":"test"}' | wm add --from -
 
 Signals:
-  ^  Raised (in-progress work, shouldn't merge to main yet)
+  ~  Raised (in-progress work, shouldn't merge to main yet)
   *  Important (high priority)
 
 Types:
   Work:       todo, fix, wip, done, review, test, check
-  Info:       note, context, tldr, this, example, idea, comment
+  Info:       note, context, tldr, about, example, idea, comment
   Caution:    warn, alert, deprecated, temp, hack
   Workflow:   blocked, needs
   Inquiry:    question
@@ -1116,7 +1116,7 @@ See 'wm add --prompt' for agent-facing documentation.
     .argument("[target]", "waymark location (file:line)")
     .option("--id <id>", "waymark ID to edit")
     .option("--type <marker>", "change waymark type")
-    .option("--raised, -R", "add ^ (raised) signal", false)
+    .option("--raised, -R", "add ~ (raised) signal", false)
     .option(
       "--starred",
       "add * (starred) signal to mark as important/valuable",
@@ -1215,7 +1215,7 @@ Filter Criteria Syntax:
   type:<marker>         Match waymark type (todo, fix, note, etc.)
   mention:<actor>       Match mention (@agent, @alice)
   tag:<hashtag>         Match tag (#perf, #sec)
-  signal:^              Match raised waymarks
+  signal:~              Match raised waymarks
   signal:*              Match starred waymarks (important/valuable)
   contains:<text>       Match content containing text
 
@@ -1396,7 +1396,7 @@ See 'wm doctor --prompt' for agent-facing documentation.
     .option("--type <types...>, -t", "filter by waymark type(s)")
     .option("--tag <tags...>", "filter by tag(s)")
     .option("--mention <mentions...>", "filter by mention(s)")
-    .option("--raised, -R", "filter for raised (^) waymarks")
+    .option("--raised, -R", "filter for raised (~) waymarks")
     .option("--starred, -S", "filter for starred (*) waymarks")
     .option("--tldr", "shorthand for --type tldr")
     .option("--graph", "show dependency graph")
@@ -1442,7 +1442,7 @@ Filter Options:
   -t, --type <types...>       Filter by waymark type(s)
   --tag <tags...>             Filter by tag(s)
   --mention <mentions...>     Filter by mention(s)
-  -R, --raised                Filter for raised (^) waymarks
+  -R, --raised                Filter for raised (~) waymarks
   -S, --starred               Filter for starred (*) waymarks
   --tldr                      Shorthand for --type tldr
 

--- a/packages/grammar/src/constants.test.ts
+++ b/packages/grammar/src/constants.test.ts
@@ -37,6 +37,8 @@ describe("PROPERTY_KEYS contract", () => {
       "docs",
       "from",
       "replaces",
+      // Canonical anchor key
+      "ref",
       // Other property keys
       "owner",
       "since",

--- a/packages/grammar/src/constants.ts
+++ b/packages/grammar/src/constants.ts
@@ -203,6 +203,8 @@ export const PROPERTY_KEYS = new Set([
   "docs",
   "from",
   "replaces",
+  // Canonical anchor key
+  "ref",
   // Other property keys
   "owner",
   "since",

--- a/packages/grammar/src/properties.ts
+++ b/packages/grammar/src/properties.ts
@@ -48,6 +48,10 @@ export function normalizeRelationToken(token: string): string | null {
   if (isUrl(token)) {
     return token;
   }
+  // Preserve wikilink IDs as-is (e.g., see:[[a1b2c3d]])
+  if (token.startsWith("[[")) {
+    return token;
+  }
   return token.startsWith("#") ? token : `#${token}`;
 }
 


### PR DESCRIPTION
Fixes stale v0 syntax and adds missing documentation:

CLI help/prompt text:
- ^ → ~ for raised signal across all commands
- this → about in marker lists
- Updated signal examples and descriptions

Grammar implementation:
- Added 'ref' to PROPERTY_KEYS for canonical anchors
- Updated test to include 'ref' in expected keys

Documentation (SPEC.md, GRAMMAR.md):
- Added [[hash]] ID format documentation
- Added sym: property for symbol binding
- Added stricter mention validation rules
- Added stub alias for hack marker

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>