### PR TITLE
refactor(cli): rename --raised flag to --flagged

### DIFF
--- a/.agents/logs/20250930-worklog.md
+++ b/.agents/logs/20250930-worklog.md
@@ -96,7 +96,7 @@
   - Merge `scan`, `find`, `map`, `graph` into unified `wm` command
   - Add fzf integration for interactive fuzzy searching
   - Rename `fmt` → `format`
-  - Add `--raised` flag for `^` signals, `--starred` flag for `*` signals
+  - Add `--flagged` flag for `^` signals, `--starred` flag for `*` signals
   - Add `--version` flag
   - Remove `tui` command (replaced by fzf)
 
@@ -137,7 +137,7 @@
 ### Implementation
 
 - Created `packages/cli/src/commands/unified.ts` with intent detection logic
-- Added `--raised` / `-r` and `--starred` / `-s` signal filters
+- Added `--flagged` / `-r` and `--starred` / `-s` signal filters
 - Updated CLI entry point to route to unified handler by default
 
 ### Backward Compatibility Removal
@@ -155,7 +155,7 @@
   - Basic scan/filter mode (default)
   - Map mode (`--map`)
   - Graph mode (`--graph`)
-  - Signal filters (`--raised`, `--starred`)
+  - Signal filters (`--flagged`, `--starred`)
   - Type/tag/mention filters
   - JSON output
 

--- a/.agents/logs/refactor/README.md
+++ b/.agents/logs/refactor/README.md
@@ -28,7 +28,7 @@ Merged `scan`, `find`, `map`, `graph` into single intelligent `wm` command with 
 
 - Removed discrete `scan`, `find`, `map`, `graph` commands
 - Created unified command with `--map` and `--graph` flags
-- Added `--raised` and `--starred` signal filters
+- Added `--flagged` and `--starred` signal filters
 - Only standalone commands: `format`, `lint`, `migrate`, `help`
 
 ### 📍 [Phase 3: Intelligent Query Parsing](./phase-3-query-parsing.md)

--- a/.agents/logs/refactor/phase-2-unified-command.md
+++ b/.agents/logs/refactor/phase-2-unified-command.md
@@ -18,7 +18,7 @@ Create a unified command interface that handles all listing/searching operations
 
 - [x] Created `packages/cli/src/commands/unified/` module structure
 - [x] Implemented intent detection logic (map/graph/filter modes)
-- [x] Added `--raised` / `-r` signal filter for `^` waymarks
+- [x] Added `--flagged` / `-F` signal filter for `~` waymarks
 - [x] Added `--starred` / `-s` signal filter for `*` waymarks
 - [x] Updated CLI entry point to route to unified handler by default
 
@@ -48,7 +48,7 @@ Created focused modules under `commands/unified/`:
   - Basic scan/filter mode (default)
   - Map mode (`--map`)
   - Graph mode (`--graph`)
-  - Signal filters (`--raised`, `--starred`)
+  - Signal filters (`--flagged`, `--starred`)
   - Type/tag/mention filters
   - JSON output
 
@@ -62,7 +62,7 @@ wm src/
 wm src/ --type todo
 
 # Signal filters
-wm src/ --raised       # Only ^ waymarks
+wm src/ --flagged      # Only ~ waymarks
 wm src/ --starred      # Only * waymarks
 
 # Map mode

--- a/.agents/logs/refactor/phase-4-display-filtering.md
+++ b/.agents/logs/refactor/phase-4-display-filtering.md
@@ -96,7 +96,7 @@ Created `test-display.ts` script that generated test files and verified:
 - Grouping by type/file
 - Sorting by file/line
 - Pagination with `--limit`
-- Signal filters (`--raised`, `--starred`)
+- Signal filters (`--flagged`, `--starred`)
 - Complex combinations
 
 ### Automated Tests ✅

--- a/.agents/plans/v1-syntax/PLAN.md
+++ b/.agents/plans/v1-syntax/PLAN.md
@@ -89,13 +89,13 @@ rg '"this"' packages/grammar/src/constants.ts
 
 ### Branch 2: `syntax/signals-tilde`
 
-**Summary**: Change raised signal from `^` to `~`. Canonical order becomes `~*`.
+**Summary**: Change flagged signal from `^` to `~`. Canonical order becomes `~*`.
 
 **Files to Modify**:
 
 Grammar:
 
-- `packages/grammar/src/constants.ts` - Change `SIGNALS.raised` from `"^"` to `"~"`
+- `packages/grammar/src/constants.ts` - Change `SIGNALS.flagged` from `"^"` to `"~"`
 - `packages/grammar/src/tokenizer.ts` - Update signal detection (lines 64-67)
 - `packages/grammar/src/types.ts` - Update comments
 - `packages/grammar/src/parser.test.ts` - Update signal test expectations
@@ -120,7 +120,7 @@ CLI:
 rg '"\^"' packages/ --type ts        # Find ^ string literals
 rg "'\^'" packages/ --type ts        # Find ^ char literals
 rg '\\^' packages/ --type ts         # Find ^ in regexes
-rg 'raised' packages/ --type ts      # Find all raised references
+rg 'flagged' packages/ --type ts     # Find all flagged references
 ```
 
 **Estimated LOC**: ~150-200
@@ -283,7 +283,7 @@ Continuation handling exists in `packages/grammar/src/content.ts`. This branch e
 ```bash
 rg ':::'  # Find all waymark examples
 rg 'wm:'  # Find legacy ID references
-rg '\^'   # Find old raised signal references
+rg '\^'   # Find old flagged signal references
 ```
 
 **Estimated LOC**: ~200-300

--- a/.agents/plans/v1-syntax/issue-129-tracking.md
+++ b/.agents/plans/v1-syntax/issue-129-tracking.md
@@ -6,7 +6,7 @@ We are adopting the new v1 syntax recap (no backward-compat). This issue tracks 
 
 ## Summary of changes (short)
 
-- Signals: raised is `~`, important is `*`, canonical order `~*`.
+- Signals: flagged is `~`, starred is `*`, canonical order `~*`.
 - IDs: wikilink-style `[[hash]]` or `[[hash|alias]]`, alias-only `[[alias]]` pre-assignment.
 - Relations: `see:`, `docs:`, `from:`, `replaces:` properties; repeat properties instead of arrays.
 - Properties: `key:value` with quoted values; no empty values; add `sym:`.
@@ -17,7 +17,7 @@ We are adopting the new v1 syntax recap (no backward-compat). This issue tracks 
 
 ## Current status
 
-- Codebase currently supports legacy `wm:` IDs, `^` raised signals, and legacy relation keys.
+- Codebase currently supports legacy `wm:` IDs, `^` flagged signals, and legacy relation keys.
 - v1 rollout is a breaking change; no backward compatibility expected.
 
 ## Subissues

--- a/.agents/plans/v1-syntax/issue-130-signals-types.md
+++ b/.agents/plans/v1-syntax/issue-130-signals-types.md
@@ -6,7 +6,7 @@ Update grammar/parser/formatter/lint + tests for the v1 signal changes and type 
 
 ## Scope
 
-- Replace raised signal `^` with `~` (important stays `*`), accept either order, format to canonical `~*`.
+- Replace flagged signal `^` with `~` (starred stays `*`), accept either order, format to canonical `~*`.
 - Update blessed type list and aliases (context/why, temp/tmp, question/ask, about replaces this).
 - Parser normalizes type casing to lowercase.
 
@@ -19,8 +19,8 @@ Update grammar/parser/formatter/lint + tests for the v1 signal changes and type 
 ## Edge cases / expectations
 
 - Accept both `~*todo` and `*~todo` input but normalize to `~*todo` in formatted output.
-- `~` should be treated as the only raised signal (no `^` support).
-- Ensure display + search filters map to the new `~` glyph while keeping flag names `--raised/--starred`.
+- `~` should be treated as the only flagged signal (no `^` support).
+- Ensure display + search filters map to the new `~` glyph while keeping flag names `--flagged/--starred`.
 
 ## Change surface (code + docs)
 
@@ -71,5 +71,5 @@ Update grammar/parser/formatter/lint + tests for the v1 signal changes and type 
 
 ## Notes
 
-- Keep `--raised/--starred` CLI flags but update rendered signal characters to `~` and `*`.
+- Keep `--flagged/--starred` CLI flags but update rendered signal characters to `~` and `*`.
 - Formatter should normalize to `~*` order even if parsed input was `*~`.

--- a/.waymark/config_alt.jsonc
+++ b/.waymark/config_alt.jsonc
@@ -7,7 +7,7 @@
     "customWaymarkTypes": ["custom1"]
   },
   "workflow": {
-    "raisedWaymarks": {
+    "flaggedWaymarks": {
       "logLevel": {
         "preCommit": "info",
         "prePush": "warn"

--- a/.waymark/config_alt.toml
+++ b/.waymark/config_alt.toml
@@ -34,7 +34,7 @@ custom_types = [
   "thought"
 ]
 
-# note ::: workflow-aware handling of raised (^) waymarks
-[waymark.workflow.raised]
+# note ::: workflow-aware handling of flagged (~) waymarks
+[waymark.workflow.flagged]
 pre_commit = "info"     # Just log on commit
 pre_push = "warn"       # Warn before push

--- a/.waymark/rules/CONVENTIONS.md
+++ b/.waymark/rules/CONVENTIONS.md
@@ -11,7 +11,7 @@
 ## General Rules
 
 - ALWAYS include only one `tldr :::` waymark in each file, near the top (accounting for language-specific preambles, shebangs, front matter, etc.).
-- ONLY use the v1 signals: `~` (raised) and a single `*` (starred). No `!`, `!!`, `?`, `^`, or other legacy signals anywhere in the repo.
+- ONLY use the v1 signals: `~` (flagged) and a single `*` (starred). No `!`, `!!`, `?`, `^`, or other legacy signals anywhere in the repo.
 - CLEAR all `~` waymarks before merging (`rg '\\~\\w+\\s*:::'`).
 - When adding a new waymark, search for precedent first (e.g., `rg ":::\s.*#<fragment>"`) to avoid proliferating one-off patterns.
 
@@ -70,4 +70,4 @@ We maintain a preferred list of hashtags below. Tags are optional; when you do a
 - Annotate known follow-up work liberally so humans and agents can spot outstanding tasks without reading full sections.
 - Phrase the description as an action with enough context that someone else could pick it up; include tags and mentions when ownership matters.
 - Sweep the codebase regularly with `rg 'todo\s*:::'` (optionally `rg -n 'todo\s*:::'`) to review the current backlog before shipping or planning.
-- Remove `todo :::` entries as soon as the work lands—either delete the waymark or replace it with `done :::` as a short-lived handoff signal, and make sure raised (`~`) waymarks are cleared before merging to `main`.
+- Remove `todo :::` entries as soon as the work lands—either delete the waymark or replace it with `done :::` as a short-lived handoff signal, and make sure flagged (`~`) waymarks are cleared before merging to `main`.

--- a/.waymark/rules/WAYMARKS.md
+++ b/.waymark/rules/WAYMARKS.md
@@ -20,7 +20,7 @@ A waymark is a single comment line (or continuation block) built from the follow
 ```
 
 - **Comment leader**: Whatever the host language uses (`//`, `#`, `<!--`, etc.). Waymarks never live inside string literals or rendered docstrings.
-- **Signals** (optional): the tilde (`~`) marks waymarks as raised (work-in-progress, branch-scoped), the star (`*`) marks waymarks as starred (important, high-priority). When combined, the tilde precedes the star (`~*todo`). No other signals are allowed.
+- **Signals** (optional): the tilde (`~`) marks waymarks as **flagged** (actively in-progress, branch-scoped), the star (`*`) marks waymarks as **starred** (important, high-priority). When combined, the tilde precedes the star (`~*todo`). No other signals are allowed.
 - **Marker** (required): One of the blessed keywords below. Lowercase, no spaces.
 - **`:::` sigil**: Exactly three ASCII colons with one space before and after when a marker is present.
 - **Content**: Free text plus optional properties, hashtags, actors, and tags following the grammar defined here.

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ The `wm` command provides a unified interface for all waymark operations:
 # Basic scanning and filtering
 wm find src/                              # scan and display all waymarks
 wm find src/ --type todo                  # filter by waymark type
-wm find src/ --raised                     # show only raised (~) waymarks (work-in-progress)
+wm find src/ --flagged                    # show only flagged (~) waymarks (in-progress)
 wm find src/ --starred                    # show only starred (*) waymarks (high-priority)
 wm find src/ --type todo --mention @agent # combine filters
 
@@ -112,7 +112,7 @@ wm find src/ --text                       # human-readable formatted text
 wm fmt src/ --write               # format waymarks in a directory
 wm lint src/ --json                  # validate waymark types
 wm rm src/auth.ts:42 --write     # remove a waymark
-wm edit src/auth.ts:42 --raised --write # adjust an existing waymark
+wm edit src/auth.ts:42 --flagged --write # adjust an existing waymark
 ```
 
 To include legacy codetags (TODO/FIXME/NOTE/etc.) in scans, enable:

--- a/apps/mcp/src/index.test.ts
+++ b/apps/mcp/src/index.test.ts
@@ -82,7 +82,7 @@ describe("handleAddWaymark", () => {
       "utf8"
     );
 
-    const signals: SignalFlags = { raised: true };
+    const signals: SignalFlags = { flagged: true };
     const server = new TestServer();
     const response = await handleAddWaymark({
       server,

--- a/apps/mcp/src/tools/add.ts
+++ b/apps/mcp/src/tools/add.ts
@@ -225,10 +225,10 @@ function buildSignalPrefix(signals?: SignalFlags): string {
     return "";
   }
   let prefix = "";
-  if (signals.raised) {
+  if (signals.flagged) {
     prefix += "~";
   }
-  if (signals.important) {
+  if (signals.starred) {
     prefix += "*";
   }
   return prefix;

--- a/apps/mcp/src/tools/help.ts
+++ b/apps/mcp/src/tools/help.ts
@@ -53,7 +53,7 @@ const HELP_TOPICS: Record<string, HelpTopic> = {
       "- type: string",
       "- content: string",
       "- line?: number",
-      "- signals?: { raised?: boolean; important?: boolean }",
+      "- signals?: { flagged?: boolean; starred?: boolean }",
       "- configPath?: string",
       "- scope?: default | project | user",
       "",

--- a/apps/mcp/src/types.ts
+++ b/apps/mcp/src/types.ts
@@ -24,8 +24,8 @@ export const addWaymarkInputSchema = configOptionsSchema.extend({
   line: z.number().int().positive().optional(),
   signals: z
     .object({
-      raised: z.boolean().optional(),
-      important: z.boolean().optional(),
+      flagged: z.boolean().optional(),
+      starred: z.boolean().optional(),
     })
     .optional(),
 });
@@ -64,8 +64,8 @@ export type WaymarkToolInput = z.infer<typeof waymarkToolInputSchema>;
 export type RenderFormat = ScanInput["format"];
 
 export type SignalFlags = {
-  raised?: boolean | undefined;
-  important?: boolean | undefined;
+  flagged?: boolean | undefined;
+  starred?: boolean | undefined;
 };
 
 export type CommentStyle = {

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -393,8 +393,8 @@ Write tests first, then implementation:
 test('parseHeader extracts signals and marker', () => {
   const result = parseHeader('// ^*todo ::: fix bug');
   expect(result.marker).toBe('todo');
-  expect(result.signals.raised).toBe(true);
-  expect(result.signals.important).toBe(true);
+  expect(result.signals.flagged).toBe(true);
+  expect(result.signals.starred).toBe(true);
 });
 
 // Step 2: Implement minimum to pass

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -312,7 +312,7 @@ test('parseHeader extracts signals and marker', () => {
   const result = parseHeader('// ^*todo ::: fix bug');
   expect(result).toMatchObject({
     marker: 'todo',
-    signals: { raised: true, important: true },
+    signals: { flagged: true, starred: true },
   });
 });
 ```

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -83,7 +83,7 @@ helpers. Note: `wm complete` is also supported as a backward-compatible alias.
 # Scan and display waymarks
 wm src/                              # all waymarks
 wm src/ --type todo                  # filter by type
-wm src/ --raised                     # only ^ (WIP)
+wm src/ --flagged                    # only ~ (WIP)
 wm src/ --starred                    # only * (priority)
 
 # Graph mode: relation edges
@@ -97,7 +97,7 @@ wm lint src/                         # validate waymarks
 # Waymark management
 wm add src/auth.ts:42 todo "add rate limiting" --write
 wm rm src/auth.ts:42 --write
-wm edit src/auth.ts:42 --raised --write
+wm edit src/auth.ts:42 --flagged --write
 
 # Output formats
 wm src/ --json                       # compact JSON
@@ -164,8 +164,8 @@ alias mytodos='wm src/ --type todo --mention @yourname'
 ### Pre-Commit Check
 
 ```bash
-# Ensure no raised (WIP) waymarks
-wm src/ --raised
+# Ensure no flagged (WIP) waymarks
+wm src/ --flagged
 
 # Validate waymarks
 wm lint src/

--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -12,7 +12,7 @@ Complete documentation for all `wm` commands, configuration, filtering, and work
 # Scan and display waymarks
 wm src/                              # all waymarks in src/
 wm src/ --type todo                  # filter by type
-wm src/ --raised                     # only ^ (work-in-progress)
+wm src/ --flagged                     # only ^ (work-in-progress)
 wm src/ --starred                    # only * (high-priority)
 
 # Graph mode: relation edges
@@ -26,7 +26,7 @@ wm lint src/                         # validate waymarks
 # Waymark management
 wm add src/auth.ts:42 todo "add rate limiting" --write
 wm rm src/auth.ts:42 --write             # or: wm rm
-wm edit src/auth.ts:42 --raised --write
+wm edit src/auth.ts:42 --flagged --write
 
 # Output formats
 wm src/ --json                       # compact JSON
@@ -92,9 +92,9 @@ See [Waymark Grammar](../GRAMMAR.md) for complete grammar details.
 
 Signals are optional prefixes that indicate state or priority:
 
-- `~` (tilde) — **Raised**: work-in-progress, branch-scoped. Must be cleared before merging.
+- `~` (tilde) — **Flagged**: work-in-progress, branch-scoped. Must be cleared before merging.
 - `*` (star) — **Starred**: important, high-priority.
-- `~*` (combined) — Both raised and starred.
+- `~*` (combined) — Both flagged and starred.
 
 **Important**: Only use single `~` and `*`. Double signals (`~~`, `**`) are not part of the v1 grammar.
 
@@ -198,7 +198,7 @@ wm src/ --type todo
 wm src/ --type fix --type wip
 
 # Filter by signals
-wm src/ --raised                     # only ^ waymarks
+wm src/ --flagged                     # only ^ waymarks
 wm src/ --starred                    # only * waymarks
 
 # Filter by tags
@@ -357,7 +357,7 @@ wm rm src/auth.ts:42 --write              # or: wm rm src/auth.ts:42 --write
 wm rm src/auth.ts:42 --reason "cleanup" --write
 
 # Edit waymark signals
-wm edit src/auth.ts:42 --raised --write
+wm edit src/auth.ts:42 --flagged --write
 wm edit src/auth.ts:42 --starred --write
 wm edit src/auth.ts:42 --clear-signals --write
 ```
@@ -514,7 +514,7 @@ Output:
     "endLine": 42,
     "type": "todo",
     "contentText": "implement rate limiting",
-    "signals": { "raised": false, "important": false }
+    "signals": { "flagged": false, "starred": false }
   }
 ]
 ```
@@ -560,9 +560,9 @@ wm src/ --type todo --type fix        # OR logic (todo OR fix)
 Filter by signals:
 
 ```bash
-wm src/ --raised                      # only ^ waymarks
+wm src/ --flagged                      # only ^ waymarks
 wm src/ --starred                     # only * waymarks
-wm src/ --raised --starred            # both raised AND starred
+wm src/ --flagged --starred            # both flagged AND starred
 ```
 
 ### Tag Filters
@@ -603,8 +603,8 @@ Filters use AND logic across different types:
 # Find TODOs for @agent tagged with #perf
 wm src/ --type todo --mention @agent --tag perf
 
-# Find raised FIX waymarks blocking #payments
-wm src/ --raised --type fix --blocks "#payments"
+# Find flagged FIX waymarks blocking #payments
+wm src/ --flagged --type fix --blocks "#payments"
 ```
 
 ---
@@ -659,10 +659,10 @@ wm src/ --type todo --mention @yourname
 
 ### Pre-Merge Checklist
 
-Ensure no raised waymarks before merging:
+Ensure no flagged waymarks before merging:
 
 ```bash
-wm src/ --raised
+wm src/ --flagged
 # Should return no results
 ```
 

--- a/docs/cli/waymark_editing.md
+++ b/docs/cli/waymark_editing.md
@@ -38,7 +38,7 @@ wm add src/auth.ts:42 --type todo --content "add rate limiting"
 wm add src/auth.ts:42 \
   --type todo \
   --content "add rate limiting" \
-  --important \
+  --starred \
   --owner @alice \
   --tag "#security" \
   --mention "@agent" \
@@ -99,8 +99,8 @@ wm add --from batch.json --jsonl
   "type": "todo",
   "content": "add rate limiting",
   "signals": {
-    "raised": false,
-    "important": true
+    "flagged": false,
+    "starred": true
   },
   "properties": {
     "owner": "@alice",
@@ -121,7 +121,7 @@ wm add --from batch.json --jsonl
       "line": 42,
       "type": "todo",
       "content": "add rate limiting",
-      "signals": { "important": true }
+      "signals": { "starred": true }
     },
     {
       "file": "src/auth.ts",
@@ -168,7 +168,7 @@ wm add --from batch.json --jsonl
 | `position` | "before" \| "after" | ❌ | "after" | Insert before or after target line |
 | `type` | string | ✅ | - | Waymark type (todo, note, tldr, etc.) |
 | `content` | string | ✅ | - | Waymark content text |
-| `signals` | object | ❌ | {} | Signal flags (raised, important) |
+| `signals` | object | ❌ | {} | Signal flags (flagged, starred) |
 | `properties` | object | ❌ | {} | Key-value properties |
 | `tags` | string[] | ❌ | [] | Hashtags (without # prefix in array) |
 | `mentions` | string[] | ❌ | [] | Actor mentions (without @ prefix in array) |
@@ -804,8 +804,8 @@ export interface InsertionSpec {
   type: string;
   content: string;
   signals?: {
-    raised?: boolean;
-    important?: boolean;
+    flagged?: boolean;
+    starred?: boolean;
   };
   properties?: Record<string, string>;
   tags?: string[];
@@ -951,8 +951,8 @@ function formatWaymark(
 
   // Build signal prefix
   let signals = '';
-  if (spec.signals?.raised) signals += '^';
-  if (spec.signals?.important) signals += '*';
+  if (spec.signals?.flagged) signals += '~';
+  if (spec.signals?.starred) signals += '*';
 
   // Build content with properties, tags, mentions
   let content = spec.content;
@@ -1058,7 +1058,7 @@ generate-tldrs src/**/*.ts | wm add --from - --write
       "type": "check",
       "content": "PCI-DSS compliance review required before production",
       "tags": ["#compliance", "#pci"],
-      "signals": { "important": true }
+      "signals": { "starred": true }
     }
   ]
 }
@@ -1522,8 +1522,8 @@ export interface RemovalSpec {
     files?: string[];
     content_pattern?: string;
     signals?: {
-      raised?: boolean;
-      important?: boolean;
+      flagged?: boolean;
+      starred?: boolean;
     };
   };
 }
@@ -1687,12 +1687,12 @@ function matchesCriteria(waymark: WaymarkRecord, criteria: RemovalSpec['criteria
 
   // Signal match
   if (criteria.signals) {
-    if (criteria.signals.raised !== undefined &&
-        waymark.signals.raised !== criteria.signals.raised) {
+    if (criteria.signals.flagged !== undefined &&
+        waymark.signals.flagged !== criteria.signals.flagged) {
       return false;
     }
-    if (criteria.signals.important !== undefined &&
-        waymark.signals.important !== criteria.signals.important) {
+    if (criteria.signals.starred !== undefined &&
+        waymark.signals.starred !== criteria.signals.starred) {
       return false;
     }
   }

--- a/docs/development/AGENTS.md
+++ b/docs/development/AGENTS.md
@@ -386,8 +386,8 @@ Write tests first, then implementation:
 test('parseHeader extracts signals and marker', () => {
   const result = parseHeader('// ^*todo ::: fix bug');
   expect(result.marker).toBe('todo');
-  expect(result.signals.raised).toBe(true);
-  expect(result.signals.important).toBe(true);
+  expect(result.signals.flagged).toBe(true);
+  expect(result.signals.starred).toBe(true);
 });
 
 // Step 2: Implement minimum to pass

--- a/docs/development/ARCHITECTURE.md
+++ b/docs/development/ARCHITECTURE.md
@@ -312,7 +312,7 @@ test('parseHeader extracts signals and marker', () => {
   const result = parseHeader('// ^*todo ::: fix bug');
   expect(result).toMatchObject({
     marker: 'todo',
-    signals: { raised: true, important: true },
+    signals: { flagged: true, starred: true },
   });
 });
 ```

--- a/docs/howto/README.md
+++ b/docs/howto/README.md
@@ -75,8 +75,8 @@ Tip: enable `scan.include_codetags = true` in config to include legacy codetags 
 # All your TODOs
 wm src/ --type todo --mention @yourname
 
-# Raised (WIP) items you're working on
-wm src/ --raised --mention @yourname
+# Flagged (WIP) items you're working on
+wm src/ --flagged --mention @yourname
 
 # Filter by priority
 wm src/ --starred --type todo --mention @yourname
@@ -93,8 +93,8 @@ alias mytodos='wm src/ --type todo --mention @yourname'
 **Goal**: Ensure branch is clean before committing.
 
 ```bash
-# 1. Find raised waymarks (must be cleared before merge)
-wm src/ --raised
+# 1. Find flagged waymarks (must be cleared before merge)
+wm src/ --flagged
 
 # 2. Find temp/hack waymarks that might need cleanup
 wm src/ --type temp --type hack
@@ -107,8 +107,8 @@ wm lint src/
 
 ```bash
 # .git/hooks/pre-push
-if wm src/ --raised --json | grep -q '\['; then
-  echo "Error: Raised (^) waymarks must be cleared before pushing"
+if wm src/ --flagged --json | grep -q '\['; then
+  echo "Error: Flagged (~) waymarks must be cleared before pushing"
   exit 1
 fi
 ```
@@ -366,10 +366,10 @@ wm add src/legacy.ts:1 ~wip "refactoring to TypeScript @yourname" --write
 wm add src/legacy.ts:1 note "from:#new-api/client" --write
 
 # 3. Track refactor progress
-wm src/ --raised --mention @yourname
+wm src/ --flagged --mention @yourname
 
 # 4. Clear signals when done
-wm edit src/legacy.ts:1 --unraise --write
+wm edit src/legacy.ts:1 --clear-signals --write
 ```
 
 ### Security Audit
@@ -412,7 +412,7 @@ Add to `.bashrc` / `.zshrc`:
 
 ```bash
 alias wmt='wm src/ --type todo'
-alias wmr='wm src/ --raised'
+alias wmr='wm src/ --flagged'
 alias wml='wm lint src/'
 ```
 
@@ -423,10 +423,10 @@ Enforce waymark quality in git hooks:
 ```bash
 # .git/hooks/pre-commit
 #!/bin/bash
-# Prevent committing raised waymarks to main branch
+# Prevent committing flagged waymarks to main branch
 BRANCH=$(git symbolic-ref --short HEAD)
-if [[ "$BRANCH" == "main" ]] && wm --raised --json | grep -q '\['; then
-  echo "Error: Cannot commit raised (^) waymarks to main branch"
+if [[ "$BRANCH" == "main" ]] && wm --flagged --json | grep -q '\['; then
+  echo "Error: Cannot commit flagged (~) waymarks to main branch"
   exit 1
 fi
 

--- a/docs/waymark/SPEC.md
+++ b/docs/waymark/SPEC.md
@@ -11,9 +11,10 @@ Waymark is a lightweight, comment-based grammar for embedding code-adjacent cont
 ```
 
 - **Comment leader**: Whatever the host language uses (`//`, `#`, `<!--`, etc.). Waymarks never appear inside string literals or rendered docstrings.
-- **Signals** (optional): A short prefix indicating scope/urgency. The only valid signals are:
-  - `~` (tilde) — produces a raised waymark for branch-scoped work that must be cleared before merging.
-  - `*` (star) — high-priority item. When combined with the tilde, the order is `~*` (e.g., `~*todo`). Double intensity (`**`) and other legacy signals are not part of v1.
+- **Signals** (optional): A short prefix modifying the waymark's meaning. The only valid signals are:
+  - `~` (tilde) — **flagged**: marks work actively in progress on the current branch; must be cleared before merging.
+  - `*` (star) — **starred**: marks high-priority or important items.
+  - When combined, the canonical order is `~*` (e.g., `~*todo`). Double intensity (`**`) and other legacy signals are not part of v1.
 - **Marker** (required): A single lowercase keyword from the blessed list below.
 - **`:::` sigil**: Exactly three ASCII colons, with one space before and after when a marker is present.
 - **Content**: Free text plus optional properties, tags, and mentions. Parsers tolerate additional spaces but formatters normalize to the canonical shape.
@@ -228,7 +229,7 @@ Recommended ripgrep patterns:
 rg ':::'                          # all waymarks
 rg ':::\s*@agent'                 # generic agent work
 rg '\*\w+\s*:::'                  # high-priority waymarks
-rg '\~\w+\s*:::'                  # raised/ongoing work
+rg '\~\w+\s*:::'                  # flagged/in-progress work
 rg '#perf:hotpath|#hotpath'      # performance hotspots
 rg 'tldr\s*:::.*#docs'            # doc summaries
 rg '\*tldr\s*:::'                 # prioritized summaries

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -48,7 +48,7 @@ wm add src/auth.ts:42 todo "implement rate limiting"
 wm rm src/auth.ts:42 --write
 
 # Edit existing waymarks
-wm edit src/auth.ts:42 --raised --write
+wm edit src/auth.ts:42 --flagged --write
 
 # Lint waymarks
 wm lint src/

--- a/packages/cli/src/commands/add.prompt.txt
+++ b/packages/cli/src/commands/add.prompt.txt
@@ -54,7 +54,7 @@ INLINE ARGUMENT FLAGS
   --see <token>        Add reference relation: see:#api/v2
   --replaces <token>   Add replaces relation: replaces:#feature/old
 
-  --signal <signal>    Add signal: ~ (raised) or * (starred)
+  --signal <signal>    Add signal: ~ (flagged) or * (starred)
                        Can combine: --signal ~ --signal *
 
 OUTPUT FORMATS
@@ -74,7 +74,7 @@ EXAMPLES
   3. Insert with signal (starred to mark as important/valuable):
      wm add src/api.ts:100 fix "validate input" --signal *
 
-  4. Insert with signal (raised, in-progress):
+  4. Insert with signal (flagged, in-progress):
      wm add src/refactor.ts:50 wip "refactoring auth flow" --signal ~
 
   5. Insert with dependency relation:
@@ -126,7 +126,7 @@ JSON INPUT SCHEMA
     content: string - Waymark content text
 
   Optional fields:
-    signals: object - {raised?: boolean, important?: boolean}
+    signals: object - {flagged?: boolean, starred?: boolean}
     properties: object - Key-value pairs
     mentions: string[] - Actor mentions (include @ prefix)
     tags: string[] - Hashtags (include # prefix)

--- a/packages/cli/src/commands/add.test.ts
+++ b/packages/cli/src/commands/add.test.ts
@@ -53,7 +53,7 @@ describe("parseAddArgs", () => {
     expect(spec.tags).toEqual(["#security"]);
     expect(spec.mentions).toEqual(["@alice"]);
     expect(spec.properties).toEqual({ owner: "@alice" });
-    expect(spec.signals).toEqual({ raised: true, important: true });
+    expect(spec.signals).toEqual({ flagged: true, starred: true });
     expect(spec.continuations).toEqual(["follow up with team"]);
     expect(spec.order).toBe(2);
     expect(spec.id).toBe("[[custom123]]");
@@ -193,8 +193,8 @@ describe("runAddCommand", () => {
       content: "test content",
       position: "after",
       signals: {
-        raised: true,
-        important: true,
+        flagged: true,
+        starred: true,
       },
       properties: {
         owner: "@alice",

--- a/packages/cli/src/commands/add.test.ts
+++ b/packages/cli/src/commands/add.test.ts
@@ -27,7 +27,7 @@ describe("parseAddArgs", () => {
       "@alice",
       "--property",
       "owner:@alice",
-      "--raised",
+      "--flagged",
       "--starred",
       "--continuation",
       "follow up with team",

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -180,7 +180,7 @@ const SIMPLE_FLAG_HANDLERS: Record<string, (state: InsertParseState) => void> =
     "--after": (state) => {
       state.position = "after";
     },
-    "--raised": (state) => {
+    "--flagged": (state) => {
       state.signals.raised = true;
     },
     "--starred": (state) => {

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -45,7 +45,7 @@ export function parseAddArgs(argv: string[]): ParsedAddArgs {
     mentions: [],
     continuations: [],
     properties: {},
-    signals: { raised: false, important: false },
+    signals: { flagged: false, starred: false },
   };
 
   let cursor = 0;
@@ -94,7 +94,7 @@ type InsertParseState = {
   mentions: string[];
   continuations: string[];
   properties: Record<string, string>;
-  signals: { raised: boolean; important: boolean };
+  signals: { flagged: boolean; starred: boolean };
   fileLine?: string;
   type?: string;
   content?: string;
@@ -181,10 +181,10 @@ const SIMPLE_FLAG_HANDLERS: Record<string, (state: InsertParseState) => void> =
       state.position = "after";
     },
     "--flagged": (state) => {
-      state.signals.raised = true;
+      state.signals.flagged = true;
     },
     "--starred": (state) => {
-      state.signals.important = true;
+      state.signals.starred = true;
     },
   };
 
@@ -288,7 +288,7 @@ function buildInsertionSpec(state: InsertParseState): InsertionSpec {
   if (state.position) {
     spec.position = state.position;
   }
-  if (state.signals.raised || state.signals.important) {
+  if (state.signals.flagged || state.signals.starred) {
     spec.signals = { ...state.signals };
   }
   if (Object.keys(state.properties).length > 0) {

--- a/packages/cli/src/commands/edit.prompt.txt
+++ b/packages/cli/src/commands/edit.prompt.txt
@@ -4,7 +4,7 @@ You are helping a user update an existing waymark with the wm edit command.
 Key capabilities:
 - Target by file:line or by waymark ID ([[xxxxx]])
 - Update the marker type (todo, fix, note, etc.)
-- Toggle signals: --raised adds ~ (flagged), --starred adds *, --clear-signals clears both
+- Toggle signals: --flagged adds ~ (flagged), --starred adds *, --clear-signals clears both
 - Replace the first-line content via --content <text> or stdin with --content -
 - Preview changes by default; add --write to apply them atomically
 - Interactive prompts run automatically when no positional arguments are supplied; use --no-interactive to skip them
@@ -13,7 +13,7 @@ Key capabilities:
 Workflow tips:
 1. Always require a target: either FILE:LINE or --id [[...]]
 2. Preserve trailing [[id]] identifiers when editing content.
-3. Combine --raised (flagged) and --starred to set both signals in one pass.
+3. Combine --flagged and --starred to set both signals in one pass.
 4. After applying changes the CLI automatically refreshes the waymark index.
 
 Examples:

--- a/packages/cli/src/commands/edit.prompt.txt
+++ b/packages/cli/src/commands/edit.prompt.txt
@@ -4,7 +4,7 @@ You are helping a user update an existing waymark with the wm edit command.
 Key capabilities:
 - Target by file:line or by waymark ID ([[xxxxx]])
 - Update the marker type (todo, fix, note, etc.)
-- Toggle signals: --raised adds ~, --starred adds *, --clear-signals clears both
+- Toggle signals: --raised adds ~ (flagged), --starred adds *, --clear-signals clears both
 - Replace the first-line content via --content <text> or stdin with --content -
 - Preview changes by default; add --write to apply them atomically
 - Interactive prompts run automatically when no positional arguments are supplied; use --no-interactive to skip them
@@ -13,7 +13,7 @@ Key capabilities:
 Workflow tips:
 1. Always require a target: either FILE:LINE or --id [[...]]
 2. Preserve trailing [[id]] identifiers when editing content.
-3. Combine --raised and --starred to set both signals in one pass.
+3. Combine --raised (flagged) and --starred to set both signals in one pass.
 4. After applying changes the CLI automatically refreshes the waymark index.
 
 Examples:

--- a/packages/cli/src/commands/format.prompt.txt
+++ b/packages/cli/src/commands/format.prompt.txt
@@ -21,7 +21,7 @@ FORMATTING RULES
      Before: // TODO ::: fix this
      After:  // todo ::: fix this
 
-  3. Signal order: ~ (raised) before * (starred)
+  3. Signal order: ~ (flagged) before * (starred)
      Before: // *~todo ::: implement
      After:  // ~*todo ::: implement
 

--- a/packages/cli/src/commands/help/registry.ts
+++ b/packages/cli/src/commands/help/registry.ts
@@ -273,7 +273,7 @@ export const commands: HelpRegistry = {
         name: "signal",
         type: "string",
         placeholder: "~|*",
-        description: "Add signal (~ raised, * starred)",
+        description: "Add signal (~ flagged, * starred)",
       },
       {
         name: "flagged",
@@ -439,10 +439,10 @@ export const commands: HelpRegistry = {
         description: "Filter by content substring",
       },
       {
-        name: "raised",
+        name: "flagged",
         alias: "R",
         type: "boolean",
-        description: "Filter by raised signal (~)",
+        description: "Filter by flagged signal (~)",
       },
       {
         name: "starred",
@@ -591,10 +591,10 @@ queries, filtering by type/tag/mention, and multiple output formats.
       description: "Filter by mention",
     },
     {
-      name: "raised",
+      name: "flagged",
       alias: "R",
       type: "boolean",
-      description: "Show only raised (~) waymarks",
+      description: "Show only flagged (~) waymarks",
     },
     {
       name: "starred",

--- a/packages/cli/src/commands/help/registry.ts
+++ b/packages/cli/src/commands/help/registry.ts
@@ -276,10 +276,10 @@ export const commands: HelpRegistry = {
         description: "Add signal (~ raised, * starred)",
       },
       {
-        name: "raised",
-        alias: "R",
+        name: "flagged",
+        alias: "F",
         type: "boolean",
-        description: "Add raised signal (~)",
+        description: "Add flagged signal (~)",
       },
       {
         name: "starred",
@@ -307,7 +307,7 @@ export const commands: HelpRegistry = {
     examples: [
       'wm add src/auth.ts:42 todo "implement OAuth"',
       'wm add src/db.ts:15 note "assumes UTC" --mention @alice',
-      'wm add src/api.ts:10 todo "add caching" --tag #perf --raised',
+      'wm add src/api.ts:10 todo "add caching" --tag #perf --flagged',
       "wm add --from waymarks.json --write",
     ],
   },
@@ -343,10 +343,10 @@ export const commands: HelpRegistry = {
         description: "Replace content (- reads from stdin)",
       },
       {
-        name: "raised",
-        alias: "R",
+        name: "flagged",
+        alias: "F",
         type: "boolean",
-        description: "Add raised signal (~)",
+        description: "Add flagged signal (~)",
       },
       {
         name: "starred",
@@ -633,7 +633,7 @@ queries, filtering by type/tag/mention, and multiple output formats.
     "wm src/                            # Scan and display all waymarks",
     "wm --type todo                     # Show all TODOs",
     "wm --tldr                          # Show all TLDRs (shorthand)",
-    "wm --type todo --raised            # Show raised TODOs (~todo)",
+    "wm --type todo --flagged           # Show flagged TODOs (~todo)",
     "wm --mention @alice                # Show waymarks mentioning @alice",
     "wm --tag perf                      # Show waymarks tagged #perf",
     "wm --graph                         # Show relation graph",

--- a/packages/cli/src/commands/help/render.ts
+++ b/packages/cli/src/commands/help/render.ts
@@ -86,7 +86,7 @@ export function renderGlobalHelp(): string {
   sections.push("");
   sections.push("Filter options:");
   const filterFlags = mainCommand.flags?.filter((f) =>
-    ["type", "tag", "mention", "raised", "starred"].includes(f.name)
+    ["type", "tag", "mention", "flagged", "starred"].includes(f.name)
   );
   for (const flag of filterFlags ?? []) {
     sections.push(renderFlag(flag));

--- a/packages/cli/src/commands/help/topics/signals.txt
+++ b/packages/cli/src/commands/help/topics/signals.txt
@@ -1,12 +1,23 @@
 SIGNALS
 
-Signals are single-character prefixes that change the priority or state.
+Signals are single-character prefixes that modify a waymark's meaning.
 
-~ raised
-  In-progress or blocking work. Should be empty before merging to main.
+~ flagged
+  Marks work actively in-progress on the current branch.
+  - "I'm currently working on this"
+  - "Don't forget this before merging"
+  Should be cleared before merging to main.
 
 * starred
-  Important or high priority.
+  Marks high-priority or important items.
+  - "This is important"
+  - "Pay attention to this"
+
+The pair tells a complete story:
+  todo     A todo
+  *todo    An important todo
+  ~todo    A todo I'm working on
+  ~*todo   An important todo I'm working on
 
 Rules:
   - Signals come before the type with no space
@@ -15,3 +26,4 @@ Rules:
 Examples:
   // ~todo ::: stabilize cache layer
   // *fix ::: avoid leaking tokens in logs
+  // ~*fix ::: critical bug I'm actively fixing

--- a/packages/cli/src/commands/lint.prompt.txt
+++ b/packages/cli/src/commands/lint.prompt.txt
@@ -137,7 +137,7 @@ COMBINING WITH OTHER COMMANDS
   # Format then lint
   wm fmt src/auth.ts --write && wm lint src/auth.ts
 
-  # Scan for issues, then lint for structure
+  # Scan for flagged issues, then lint for structure
   wm src/ --type todo --raised && wm lint src/
 
 For human-facing help, use: wm lint --help

--- a/packages/cli/src/commands/lint.prompt.txt
+++ b/packages/cli/src/commands/lint.prompt.txt
@@ -138,6 +138,6 @@ COMBINING WITH OTHER COMMANDS
   wm fmt src/auth.ts --write && wm lint src/auth.ts
 
   # Scan for flagged issues, then lint for structure
-  wm src/ --type todo --raised && wm lint src/
+  wm src/ --type todo --flagged && wm lint src/
 
 For human-facing help, use: wm lint --help

--- a/packages/cli/src/commands/modify.test.ts
+++ b/packages/cli/src/commands/modify.test.ts
@@ -81,7 +81,7 @@ describe("applyModifications", () => {
       baseContent: "implement OAuth",
       options: { starred: true },
     } satisfies ApplyArgs);
-    expect(result.signals.important).toBe(true);
+    expect(result.signals.starred).toBe(true);
     expect(result.firstLine).toBe("// *todo ::: implement OAuth");
   });
 
@@ -91,10 +91,10 @@ describe("applyModifications", () => {
       record,
       config,
       baseContent: "implement OAuth",
-      options: { raised: true },
+      options: { flagged: true },
     } satisfies ApplyArgs);
-    expect(result.signals.raised).toBe(true);
-    expect(result.signals.important).toBe(true);
+    expect(result.signals.flagged).toBe(true);
+    expect(result.signals.starred).toBe(true);
     expect(result.firstLine).toBe("// ~*todo ::: implement OAuth");
   });
 
@@ -106,8 +106,8 @@ describe("applyModifications", () => {
       baseContent: "implement OAuth",
       options: { noSignal: true },
     } satisfies ApplyArgs);
-    expect(result.signals.raised).toBe(false);
-    expect(result.signals.important).toBe(false);
+    expect(result.signals.flagged).toBe(false);
+    expect(result.signals.starred).toBe(false);
     expect(result.firstLine).toBe("// todo ::: implement OAuth");
   });
 });

--- a/packages/cli/src/commands/modify.ts
+++ b/packages/cli/src/commands/modify.ts
@@ -860,7 +860,7 @@ function ensureModificationsSpecified(options: ModifyOptions): void {
 
   if (!(hasType || hasSignals || hasContent)) {
     throw new Error(
-      "No modifications specified. Use --type, --raised, --starred, --clear-signals, --content, or run without arguments for interactive prompts."
+      "No modifications specified. Use --type, --flagged, --starred, --clear-signals, --content, or run without arguments for interactive prompts."
     );
   }
 }

--- a/packages/cli/src/commands/modify.ts
+++ b/packages/cli/src/commands/modify.ts
@@ -585,7 +585,7 @@ function buildInteractiveSteps(args: {
       build: () => ({
         type: "confirm",
         name: "addRaised",
-        message: "Add raised signal (~) ?",
+        message: "Add flagged signal (~)?",
         default:
           answers.addRaised ?? record.signals.raised ?? options.raised ?? false,
       }),
@@ -940,7 +940,7 @@ function describeChanges(payload: ModifyPayload): string[] {
     const { from, to } = payload.modifications.signals;
     if (from.raised !== to.raised) {
       entries.push(
-        to.raised ? "Added raised signal (~)" : "Removed raised signal (~)"
+        to.raised ? "Added flagged signal (~)" : "Removed flagged signal (~)"
       );
     }
     if (from.important !== to.important) {

--- a/packages/cli/src/commands/modify.ts
+++ b/packages/cli/src/commands/modify.ts
@@ -81,6 +81,8 @@ const LINE_SPLIT_REGEX = /\r?\n/;
 // Match [[hash]], [[hash|alias]], or [[alias]] at end of content
 const ID_TRAIL_REGEX = /(\[\[[^\]]+\]\])$/i;
 const DEFAULT_MARKERS = ["todo", "fix", "note", "warn", "tldr", "done"];
+const LEGACY_WM_PREFIX = "wm:";
+const LEGACY_WM_PREFIX_LENGTH = LEGACY_WM_PREFIX.length;
 
 const DEFAULT_IO: ModifyIo = {
   stdin: process.stdin,
@@ -490,7 +492,9 @@ function normalizeId(id: string): string {
     return id;
   }
   // Strip wm: prefix if present (legacy format)
-  const hash = id.startsWith("wm:") ? id.slice(3) : id;
+  const hash = id.startsWith(LEGACY_WM_PREFIX)
+    ? id.slice(LEGACY_WM_PREFIX_LENGTH)
+    : id;
   return `[[${hash}]]`;
 }
 
@@ -587,7 +591,10 @@ function buildInteractiveSteps(args: {
         name: "addFlagged",
         message: "Add flagged signal (~)?",
         default:
-          answers.addFlagged ?? record.signals.flagged ?? options.flagged ?? false,
+          answers.addFlagged ??
+          record.signals.flagged ??
+          options.flagged ??
+          false,
       }),
     },
     {

--- a/packages/cli/src/commands/remove.prompt.txt
+++ b/packages/cli/src/commands/remove.prompt.txt
@@ -51,7 +51,7 @@ FILTER FLAGS
   --type <marker>       Match by waymark type (todo, fix, note, etc.)
   --mention <actor>     Match by mention (@agent, @alice, etc.)
   --tag <hashtag>       Match by hashtag (#deprecated, #perf, etc.)
-  --raised              Match flagged (~) waymarks
+  --flagged             Match flagged (~) waymarks
   --starred             Match starred (*) waymarks (important/valuable)
   --contains <text>     Match content containing text
 
@@ -81,7 +81,7 @@ EXAMPLES
      wm rm --type done . --write
 
   5. Remove stale flagged agent todos:
-     wm rm --type todo --mention @agent --raised src/ --write
+     wm rm --type todo --mention @agent --flagged src/ --write
 
   6. Batch remove from analysis:
      echo '[
@@ -104,7 +104,7 @@ AGENT WORKFLOWS
 
   2. Remove flagged waymarks after merge:
      # Agent removes ~ (flagged) waymarks after PR merges
-     wm rm --raised . --write
+     wm rm --flagged . --write
 
   3. Archive deprecated markers:
      # Agent removes deprecated waymarks after refactor
@@ -193,7 +193,7 @@ COMBINING WITH OTHER COMMANDS
     | xargs -I {} wm rm {} --write
 
   # Clean up before release
-  wm rm --raised . --write  # Remove flagged
+  wm rm --flagged . --write  # Remove flagged
   wm rm --type wip . --write  # Remove WIP
 
 TIPS FOR AGENTS

--- a/packages/cli/src/commands/remove.prompt.txt
+++ b/packages/cli/src/commands/remove.prompt.txt
@@ -51,7 +51,7 @@ FILTER FLAGS
   --type <marker>       Match by waymark type (todo, fix, note, etc.)
   --mention <actor>     Match by mention (@agent, @alice, etc.)
   --tag <hashtag>       Match by hashtag (#deprecated, #perf, etc.)
-  --raised              Match raised (~) waymarks
+  --raised              Match flagged (~) waymarks
   --starred             Match starred (*) waymarks (important/valuable)
   --contains <text>     Match content containing text
 
@@ -80,7 +80,7 @@ EXAMPLES
   4. Remove all completed todos:
      wm rm --type done . --write
 
-  5. Remove stale agent todos:
+  5. Remove stale flagged agent todos:
      wm rm --type todo --mention @agent --raised src/ --write
 
   6. Batch remove from analysis:
@@ -102,8 +102,8 @@ AGENT WORKFLOWS
      wm scan --type done --json | jq -r '.file + ":" + (.startLine|tostring)' \
        | while read loc; do wm rm "$loc" --write; done
 
-  2. Remove raised waymarks after merge:
-     # Agent removes ~ waymarks after PR merges
+  2. Remove flagged waymarks after merge:
+     # Agent removes ~ (flagged) waymarks after PR merges
      wm rm --raised . --write
 
   3. Archive deprecated markers:
@@ -193,7 +193,7 @@ COMBINING WITH OTHER COMMANDS
     | xargs -I {} wm rm {} --write
 
   # Clean up before release
-  wm rm --raised . --write  # Remove raised
+  wm rm --raised . --write  # Remove flagged
   wm rm --type wip . --write  # Remove WIP
 
 TIPS FOR AGENTS

--- a/packages/cli/src/commands/remove.test.ts
+++ b/packages/cli/src/commands/remove.test.ts
@@ -245,8 +245,8 @@ describe("runRemoveCommand", () => {
         contentPattern: "test.*",
         contains: "removal",
         signals: {
-          raised: false,
-          important: false,
+          flagged: false,
+          starred: false,
         },
       },
     });

--- a/packages/cli/src/commands/remove.ts
+++ b/packages/cli/src/commands/remove.ts
@@ -86,10 +86,10 @@ const SIMPLE_FLAG_HANDLERS: Record<string, (state: RemoveParseState) => void> =
       }
       state.optionState.jsonl = true;
     },
-    "-R": (state) => {
+    "-F": (state) => {
       state.criteria.signals.raised = true;
     },
-    "--raised": (state) => {
+    "--flagged": (state) => {
       state.criteria.signals.raised = true;
     },
     "-S": (state) => {

--- a/packages/cli/src/commands/remove.ts
+++ b/packages/cli/src/commands/remove.ts
@@ -52,7 +52,7 @@ type RemoveCriteriaState = {
   tags: string[];
   mentions: string[];
   properties: Record<string, string>;
-  signals: { raised?: boolean; important?: boolean };
+  signals: { flagged?: boolean; starred?: boolean };
   contentPattern?: string;
   contains?: string;
 };
@@ -87,16 +87,16 @@ const SIMPLE_FLAG_HANDLERS: Record<string, (state: RemoveParseState) => void> =
       state.optionState.jsonl = true;
     },
     "-F": (state) => {
-      state.criteria.signals.raised = true;
+      state.criteria.signals.flagged = true;
     },
     "--flagged": (state) => {
-      state.criteria.signals.raised = true;
+      state.criteria.signals.flagged = true;
     },
     "-S": (state) => {
-      state.criteria.signals.important = true;
+      state.criteria.signals.starred = true;
     },
     "--starred": (state) => {
-      state.criteria.signals.important = true;
+      state.criteria.signals.starred = true;
     },
   };
 

--- a/packages/cli/src/commands/unified/filters.ts
+++ b/packages/cli/src/commands/unified/filters.ts
@@ -15,7 +15,7 @@ export function applyFilters(
     types,
     tags,
     mentions,
-    raised,
+    flagged,
     starred,
     excludeTypes,
     excludeTags,
@@ -54,13 +54,13 @@ export function applyFilters(
   }
 
   // Apply signal filters
-  if (raised !== undefined || starred !== undefined) {
+  if (flagged !== undefined || starred !== undefined) {
     filtered = filtered.filter((record) => {
       const { signals } = record;
-      if (raised && !signals.raised) {
+      if (flagged && !signals.flagged) {
         return false;
       }
-      if (starred && !signals.important) {
+      if (starred && !signals.starred) {
         return false;
       }
       return true;

--- a/packages/cli/src/commands/unified/flag-handlers.ts
+++ b/packages/cli/src/commands/unified/flag-handlers.ts
@@ -165,7 +165,7 @@ export function handleModeDisplayFlags(
   }
 
   // Signal filters
-  if (token === "--raised" || token === "-R") {
+  if (token === "--flagged" || token === "-F") {
     state.raised = true;
     return true;
   }

--- a/packages/cli/src/commands/unified/flag-handlers.ts
+++ b/packages/cli/src/commands/unified/flag-handlers.ts
@@ -18,7 +18,7 @@ export type ParseState = {
   excludeMentions: string[];
   jsonState: { outputFormat: "json" | "jsonl" | null };
   isGraphMode: boolean;
-  raised: boolean | undefined;
+  flagged: boolean | undefined;
   starred: boolean | undefined;
   displayMode: "text" | "long" | "tree" | "flat" | "graph" | undefined;
   contextBefore: number | undefined;
@@ -166,7 +166,7 @@ export function handleModeDisplayFlags(
 
   // Signal filters
   if (token === "--flagged" || token === "-F") {
-    state.raised = true;
+    state.flagged = true;
     return true;
   }
   if (token === "--starred" || token === "-S") {

--- a/packages/cli/src/commands/unified/index.help.txt
+++ b/packages/cli/src/commands/unified/index.help.txt
@@ -13,7 +13,7 @@ OPTIONS
     -t, --type <marker>     Filter by waymark type (todo, fix, note, etc.)
     -m, --mention <actor>   Filter by mention (@agent, @alice, etc.)
     --tag <tag>             Filter by hashtag (#perf, #sec, etc.)
-    -R, --raised            Show only raised (~) waymarks
+    -F, --flagged           Show only flagged (~) waymarks
     -S, --starred           Show only important (*) waymarks
 
   Display Modes:
@@ -43,7 +43,7 @@ EXAMPLES
   wm --starred --tag "#sec"
 
   # Combine multiple filters
-  wm src/ --type todo --type fix --raised --mention @agent
+  wm src/ --type todo --type fix --flagged --mention @agent
 
 FILTER BEHAVIOR
   Multiple filters of the same type use OR logic:

--- a/packages/cli/src/commands/unified/index.prompt.ts
+++ b/packages/cli/src/commands/unified/index.prompt.ts
@@ -97,7 +97,7 @@ EXAMPLE OUTPUTS
       "file": "src/auth.ts",
       "startLine": 12,
       "type": "todo",
-      "signals": { "raised": false, "important": false },
+      "signals": { "flagged": false, "starred": false },
       "contentText": "@agent implement OAuth callback",
       "mentions": ["@agent"],
       "tags": ["#sec"],

--- a/packages/cli/src/commands/unified/index.prompt.ts
+++ b/packages/cli/src/commands/unified/index.prompt.ts
@@ -15,7 +15,7 @@ WAYMARK SYNTAX PRIMER
     // ~wip ::: refactoring in progress
 
   Components:
-    - Signals: ~ (raised/in-progress), * (starred for important/valuable)
+    - Signals: ~ (flagged/in-progress), * (starred for important/valuable)
     - Marker: todo, fix, wip, note, tldr, about, etc.
     - Content: Free text with optional properties
     - Properties: key:value pairs (see:#token, from:#token, owner:@alice)
@@ -38,7 +38,7 @@ FILTERING OPTIONS
                       Examples: #perf, #sec, #docs
                       Can be repeated: --tag "#perf" --tag "#sec"
 
-  --raised            Only show ~ (raised/in-progress) waymarks
+  --flagged           Only show ~ (flagged/in-progress) waymarks
                       Use to find work that shouldn't merge yet
 
   --starred           Only show * (starred) waymarks (important/valuable)
@@ -82,7 +82,7 @@ AGENT WORKFLOWS
      → High-priority security items
 
   4. Find in-progress work:
-     wm --raised --json
+     wm --flagged --json
      → Everything marked with ~ signal
 
   5. Review recent changes:
@@ -123,7 +123,7 @@ TIPS FOR AGENTS
   ✓ Always use --json for programmatic parsing
   ✓ Combine filters for precision (type + mention + tag)
   ✓ Use --graph to understand dependencies before refactoring
-  ✓ Check --raised before merging to ensure no WIP (~ signal) remains
+  ✓ Check --flagged before merging to ensure no WIP (~ signal) remains
   ✓ Use --starred to prioritize high-importance items
   ✓ Parse TLDR waymarks to understand file purposes
   ✓ Look for @agent mentions to find delegated work
@@ -133,7 +133,7 @@ INTEGRATION PATTERNS
   wm --type todo --mention @agent --jsonl | process-tasks
 
   # Check for blocking work before merge
-  wm --raised --json | jq 'length' # Should be 0
+  wm --flagged --json | jq 'length' # Should be 0
 
   # Extract dependency graph for visualization
   wm --graph --json > deps.json

--- a/packages/cli/src/commands/unified/parser.ts
+++ b/packages/cli/src/commands/unified/parser.ts
@@ -31,7 +31,7 @@ export function createParseState(): ParseState {
     excludeMentions: [] as string[],
     jsonState: { outputFormat: null },
     isGraphMode: false,
-    raised: undefined as boolean | undefined,
+    flagged: undefined as boolean | undefined,
     starred: undefined as boolean | undefined,
     // Display modes
     displayMode: undefined,
@@ -180,8 +180,8 @@ function applyFilters(state: ParseState, options: UnifiedCommandOptions): void {
   if (state.mentions.length > 0) {
     options.mentions = state.mentions;
   }
-  if (state.raised !== undefined) {
-    options.raised = state.raised;
+  if (state.flagged !== undefined) {
+    options.flagged = state.flagged;
   }
   if (state.starred !== undefined) {
     options.starred = state.starred;

--- a/packages/cli/src/commands/unified/types.ts
+++ b/packages/cli/src/commands/unified/types.ts
@@ -29,7 +29,7 @@ export type UnifiedCommandOptions = {
   types?: string[];
   tags?: string[];
   mentions?: string[];
-  raised?: boolean;
+  flagged?: boolean;
   starred?: boolean;
   // Exclusions
   excludeTypes?: string[];

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -629,9 +629,10 @@ describe("Unified command", () => {
   });
 
   test("runUnifiedCommand applies flagged signal filter", async () => {
-    const source = ["// ~todo ::: flagged work", "// todo ::: normal work"].join(
-      "\n"
-    );
+    const source = [
+      "// ~todo ::: flagged work",
+      "// todo ::: normal work",
+    ].join("\n");
     const { file, cleanup } = await withTempFile(source);
 
     const output = await runUnifiedOutput({

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -572,7 +572,7 @@ describe("Unified command", () => {
 
   test("parseUnifiedArgs detects flagged signal filter", () => {
     const options = parseUnifiedArgs(["--flagged", "src/"]);
-    expect(options.raised).toBe(true);
+    expect(options.flagged).toBe(true);
   });
 
   test("parseUnifiedArgs detects starred signal filter", () => {
@@ -590,7 +590,7 @@ describe("Unified command", () => {
       "src/",
     ]);
     expect(options.types).toEqual(["todo"]);
-    expect(options.raised).toBe(true);
+    expect(options.flagged).toBe(true);
     expect(options.tags).toEqual(["perf"]);
   });
 
@@ -628,8 +628,8 @@ describe("Unified command", () => {
     await cleanup();
   });
 
-  test("runUnifiedCommand applies raised signal filter", async () => {
-    const source = ["// ~todo ::: raised work", "// todo ::: normal work"].join(
+  test("runUnifiedCommand applies flagged signal filter", async () => {
+    const source = ["// ~todo ::: flagged work", "// todo ::: normal work"].join(
       "\n"
     );
     const { file, cleanup } = await withTempFile(source);
@@ -637,15 +637,15 @@ describe("Unified command", () => {
     const output = await runUnifiedOutput({
       filePaths: [file],
       isGraphMode: false,
-      raised: true,
+      flagged: true,
       outputFormat: "json",
     });
 
     const parsed = JSON.parse(output) as Array<{
-      signals: { raised: boolean };
+      signals: { flagged: boolean };
     }>;
     expect(parsed).toHaveLength(1);
-    expect(parsed[0]?.signals.raised).toBe(true);
+    expect(parsed[0]?.signals.flagged).toBe(true);
     await cleanup();
   });
 
@@ -663,17 +663,17 @@ describe("Unified command", () => {
     });
 
     const parsed = JSON.parse(output) as Array<{
-      signals: { important: boolean };
+      signals: { starred: boolean };
     }>;
     expect(parsed).toHaveLength(1);
-    expect(parsed[0]?.signals.important).toBe(true);
+    expect(parsed[0]?.signals.starred).toBe(true);
     await cleanup();
   });
 
   test("runUnifiedCommand combines multiple filters", async () => {
     const source = [
       "// ~*todo ::: critical task #perf",
-      "// ~todo ::: raised work",
+      "// ~todo ::: flagged work",
       "// *fix ::: important bug",
       "// note ::: context",
     ].join("\n");
@@ -683,7 +683,7 @@ describe("Unified command", () => {
       filePaths: [file],
       isGraphMode: false,
       types: ["todo"],
-      raised: true,
+      flagged: true,
       starred: true,
       tags: ["#perf"],
       outputFormat: "json",
@@ -691,12 +691,12 @@ describe("Unified command", () => {
 
     const parsed = JSON.parse(output) as Array<{
       type: string;
-      signals: { raised: boolean; important: boolean };
+      signals: { flagged: boolean; starred: boolean };
     }>;
     expect(parsed).toHaveLength(1);
     expect(parsed[0]?.type).toBe("todo");
-    expect(parsed[0]?.signals.raised).toBe(true);
-    expect(parsed[0]?.signals.important).toBe(true);
+    expect(parsed[0]?.signals.flagged).toBe(true);
+    expect(parsed[0]?.signals.starred).toBe(true);
     await cleanup();
   });
 
@@ -1047,13 +1047,13 @@ describe("Commander integration", () => {
       before: {
         raw: "// todo ::: test",
         type: "todo",
-        signals: { raised: false, important: false },
+        signals: { flagged: false, starred: false },
         content: "test",
       },
       after: {
         raw: "// todo ::: test",
         type: "todo",
-        signals: { raised: false, important: false },
+        signals: { flagged: false, starred: false },
         content: "test",
       },
       indexRefreshed: false,

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -711,7 +711,7 @@ describe("Unified command", () => {
     });
 
     expect(output).toContain("Type: todo");
-    expect(output).toContain("Signals: raised=false, starred=false");
+    expect(output).toContain("Signals: flagged=false, starred=false");
     expect(output).toContain("Content: @alice fix bug #perf");
     expect(output).toContain("Mentions: @alice");
     expect(output).toContain("Tags: #perf");

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -570,8 +570,8 @@ describe("Unified command", () => {
     expect(options.contextBefore).toBe(beforeLines);
   });
 
-  test("parseUnifiedArgs detects raised signal filter", () => {
-    const options = parseUnifiedArgs(["--raised", "src/"]);
+  test("parseUnifiedArgs detects flagged signal filter", () => {
+    const options = parseUnifiedArgs(["--flagged", "src/"]);
     expect(options.raised).toBe(true);
   });
 
@@ -584,7 +584,7 @@ describe("Unified command", () => {
     const options = parseUnifiedArgs([
       "--type",
       "todo",
-      "--raised",
+      "--flagged",
       "--tag",
       "perf",
       "src/",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -299,7 +299,7 @@ type ModifyCliOptions = {
   id?: string;
   type?: string;
   content?: string;
-  raised?: boolean;
+  flagged?: boolean;
   starred?: boolean;
   clearSignals?: boolean;
   write?: boolean;
@@ -372,8 +372,8 @@ function buildModifyOptions(
   if (interactiveOverride !== undefined) {
     options.interactive = interactiveOverride;
   }
-  if (rawOptions.raised) {
-    options.raised = true;
+  if (rawOptions.flagged) {
+    options.flagged = true;
   }
   if (rawOptions.starred) {
     options.starred = true;
@@ -402,7 +402,7 @@ function determineInteractiveOverride(
   const hasMutationFlag = Boolean(
     rawOptions.type ||
       rawOptions.content ||
-      rawOptions.raised ||
+      rawOptions.flagged ||
       rawOptions.starred ||
       rawOptions.clearSignals
   );
@@ -616,7 +616,7 @@ function displaySelectedWaymark(
   writeStdout("\nSelected waymark:\n");
   writeStdout(`${selected.file}:${selected.startLine}`);
   writeStdout(
-    `${selected.signals.raised ? "~" : ""}${selected.signals.important ? "*" : ""}${selected.type} ::: ${selected.contentText}`
+    `${selected.signals.flagged ? "~" : ""}${selected.signals.starred ? "*" : ""}${selected.type} ::: ${selected.contentText}`
   );
 
   if (Object.keys(selected.properties).length > 0) {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1070,7 +1070,7 @@ See 'wm fmt --prompt' for agent-facing documentation.
     .option("--docs <url>", "add documentation link")
     .option("--source <token>", "add dependency relation (from:#token)")
     .option("--replaces <token>", "add supersedes relation")
-    .option("--signal <signal>", "add signal: ~ (raised) or * (starred)")
+    .option("--signal <signal>", "add signal: ~ (flagged) or * (starred)")
     .option("--write, -w", "apply changes to file (default: preview)", false)
     .option("--json", "output as JSON")
     .option("--jsonl", "output as JSON Lines")
@@ -1093,8 +1093,8 @@ Examples:
   $ echo '{"file":"src/a.ts","line":10,"type":"todo","content":"test"}' | wm add --from -
 
 Signals:
-  ~  Raised (in-progress work, shouldn't merge to main yet)
-  *  Important (high priority)
+  ~  Flagged (in-progress work, clear before merging)
+  *  Starred (high priority, important)
 
 Types:
   Work:       todo, fix, wip, done, review, test, check
@@ -1116,7 +1116,7 @@ See 'wm add --prompt' for agent-facing documentation.
     .argument("[target]", "waymark location (file:line)")
     .option("--id <id>", "waymark ID to edit")
     .option("--type <marker>", "change waymark type")
-    .option("--raised, -R", "add ~ (raised) signal", false)
+    .option("--raised, -R", "add ~ (flagged) signal", false)
     .option(
       "--starred",
       "add * (starred) signal to mark as important/valuable",
@@ -1143,7 +1143,7 @@ See 'wm add --prompt' for agent-facing documentation.
       `
 Examples:
   $ wm edit src/auth.ts:42 --type fix                    # Preview type change
-  $ wm edit src/auth.ts:42 --raised --starred           # Preview signal updates
+  $ wm edit src/auth.ts:42 --raised --starred           # Preview adding flagged + starred
   $ wm edit --id [[a3k9m2p]] --starred --write          # Apply starred flag by ID
   $ wm edit src/auth.ts:42 --clear-signals --write       # Remove all signals
   $ wm edit src/auth.ts:42 --content "new text" --write
@@ -1215,7 +1215,7 @@ Filter Criteria Syntax:
   type:<marker>         Match waymark type (todo, fix, note, etc.)
   mention:<actor>       Match mention (@agent, @alice)
   tag:<hashtag>         Match tag (#perf, #sec)
-  signal:~              Match raised waymarks
+  signal:~              Match flagged waymarks
   signal:*              Match starred waymarks (important/valuable)
   contains:<text>       Match content containing text
 
@@ -1370,7 +1370,7 @@ Auto-Fix Support (--fix):
   - Remove duplicate canonicals (keeps first)
   - Fix TLDR positioning issues
   - Run formatter on waymarks with syntax issues
-  - Clear raised signals on protected branches (with confirmation)
+  - Clear flagged signals on protected branches (with confirmation)
 
 Exit Codes:
   0  No errors (warnings only if not --strict)
@@ -1396,7 +1396,7 @@ See 'wm doctor --prompt' for agent-facing documentation.
     .option("--type <types...>, -t", "filter by waymark type(s)")
     .option("--tag <tags...>", "filter by tag(s)")
     .option("--mention <mentions...>", "filter by mention(s)")
-    .option("--raised, -R", "filter for raised (~) waymarks")
+    .option("--raised, -R", "filter for flagged (~) waymarks")
     .option("--starred, -S", "filter for starred (*) waymarks")
     .option("--tldr", "shorthand for --type tldr")
     .option("--graph", "show dependency graph")
@@ -1442,7 +1442,7 @@ Filter Options:
   -t, --type <types...>       Filter by waymark type(s)
   --tag <tags...>             Filter by tag(s)
   --mention <mentions...>     Filter by mention(s)
-  -R, --raised                Filter for raised (~) waymarks
+  -R, --raised                Filter for flagged (~) waymarks
   -S, --starred               Filter for starred (*) waymarks
   --tldr                      Shorthand for --type tldr
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -528,7 +528,7 @@ const MULTI_VALUE_OPTION_FLAGS = [
 ] as const;
 
 const BOOLEAN_OPTION_FLAGS = [
-  { key: "raised", flag: "--raised" },
+  { key: "raised", flag: "--flagged" },
   { key: "starred", flag: "--starred" },
   { key: "tldr", flag: "--tldr" },
   { key: "graph", flag: "--graph" },
@@ -1116,7 +1116,7 @@ See 'wm add --prompt' for agent-facing documentation.
     .argument("[target]", "waymark location (file:line)")
     .option("--id <id>", "waymark ID to edit")
     .option("--type <marker>", "change waymark type")
-    .option("--raised, -R", "add ~ (flagged) signal", false)
+    .option("--flagged, -F", "add ~ (flagged) signal", false)
     .option(
       "--starred",
       "add * (starred) signal to mark as important/valuable",
@@ -1143,7 +1143,7 @@ See 'wm add --prompt' for agent-facing documentation.
       `
 Examples:
   $ wm edit src/auth.ts:42 --type fix                    # Preview type change
-  $ wm edit src/auth.ts:42 --raised --starred           # Preview adding flagged + starred
+  $ wm edit src/auth.ts:42 --flagged --starred           # Preview adding flagged + starred
   $ wm edit --id [[a3k9m2p]] --starred --write          # Apply starred flag by ID
   $ wm edit src/auth.ts:42 --clear-signals --write       # Remove all signals
   $ wm edit src/auth.ts:42 --content "new text" --write
@@ -1396,7 +1396,7 @@ See 'wm doctor --prompt' for agent-facing documentation.
     .option("--type <types...>, -t", "filter by waymark type(s)")
     .option("--tag <tags...>", "filter by tag(s)")
     .option("--mention <mentions...>", "filter by mention(s)")
-    .option("--raised, -R", "filter for flagged (~) waymarks")
+    .option("--flagged, -F", "filter for flagged (~) waymarks")
     .option("--starred, -S", "filter for starred (*) waymarks")
     .option("--tldr", "shorthand for --type tldr")
     .option("--graph", "show dependency graph")
@@ -1435,14 +1435,14 @@ Examples:
   $ wm find src/ --type todo --mention @agent
   $ wm find --graph --json                   # Export dependency graph as JSON
   $ wm find --starred --tag "#sec"           # Find high-priority security issues
-  $ wm find src/ --type todo --type fix --raised --mention @agent
+  $ wm find src/ --type todo --type fix --flagged --mention @agent
   $ wm find --interactive                    # Interactively select a waymark
 
 Filter Options:
   -t, --type <types...>       Filter by waymark type(s)
   --tag <tags...>             Filter by tag(s)
   --mention <mentions...>     Filter by mention(s)
-  -R, --raised                Filter for flagged (~) waymarks
+  -F, --flagged               Filter for flagged (~) waymarks
   -S, --starred               Filter for starred (*) waymarks
   --tldr                      Shorthand for --type tldr
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -528,7 +528,7 @@ const MULTI_VALUE_OPTION_FLAGS = [
 ] as const;
 
 const BOOLEAN_OPTION_FLAGS = [
-  { key: "raised", flag: "--flagged" },
+  { key: "flagged", flag: "--flagged" },
   { key: "starred", flag: "--starred" },
   { key: "tldr", flag: "--tldr" },
   { key: "graph", flag: "--graph" },

--- a/packages/cli/src/utils/display/formatters/enhanced.ts
+++ b/packages/cli/src/utils/display/formatters/enhanced.ts
@@ -48,8 +48,7 @@ function getLongestTypeLength(records: WaymarkRecord[]): number {
   let maxLength = 0;
   for (const record of records) {
     const signalStr =
-      (record.signals.flagged ? "~" : "") +
-      (record.signals.starred ? "*" : "");
+      (record.signals.flagged ? "~" : "") + (record.signals.starred ? "*" : "");
     const typeLength = signalStr.length + record.type.length;
     if (typeLength > maxLength) {
       maxLength = typeLength;

--- a/packages/cli/src/utils/display/formatters/enhanced.ts
+++ b/packages/cli/src/utils/display/formatters/enhanced.ts
@@ -48,8 +48,8 @@ function getLongestTypeLength(records: WaymarkRecord[]): number {
   let maxLength = 0;
   for (const record of records) {
     const signalStr =
-      (record.signals.raised ? "~" : "") +
-      (record.signals.important ? "*" : "");
+      (record.signals.flagged ? "~" : "") +
+      (record.signals.starred ? "*" : "");
     const typeLength = signalStr.length + record.type.length;
     if (typeLength > maxLength) {
       maxLength = typeLength;
@@ -63,7 +63,7 @@ function getLongestTypeLength(records: WaymarkRecord[]): number {
  */
 function getTypeWithSignal(record: WaymarkRecord): string {
   const signalStr =
-    (record.signals.raised ? "~" : "") + (record.signals.important ? "*" : "");
+    (record.signals.flagged ? "~" : "") + (record.signals.starred ? "*" : "");
   return signalStr + record.type;
 }
 

--- a/packages/cli/src/utils/display/formatters/long.ts
+++ b/packages/cli/src/utils/display/formatters/long.ts
@@ -12,7 +12,7 @@ export function formatLong(records: WaymarkRecord[]): string {
     lines.push(`${record.file}:${record.startLine}`);
     lines.push(`  Type: ${record.type}`);
     lines.push(
-      `  Signals: flagged=${record.signals.raised}, starred=${record.signals.important}`
+      `  Signals: flagged=${record.signals.flagged}, starred=${record.signals.starred}`
     );
     lines.push(`  Content: ${record.contentText}`);
 

--- a/packages/cli/src/utils/display/formatters/long.ts
+++ b/packages/cli/src/utils/display/formatters/long.ts
@@ -12,7 +12,7 @@ export function formatLong(records: WaymarkRecord[]): string {
     lines.push(`${record.file}:${record.startLine}`);
     lines.push(`  Type: ${record.type}`);
     lines.push(
-      `  Signals: raised=${record.signals.raised}, starred=${record.signals.important}`
+      `  Signals: flagged=${record.signals.raised}, starred=${record.signals.important}`
     );
     lines.push(`  Content: ${record.contentText}`);
 

--- a/packages/cli/src/utils/display/formatters/styles.ts
+++ b/packages/cli/src/utils/display/formatters/styles.ts
@@ -148,8 +148,7 @@ export function styleType(
   signals: { flagged: boolean; starred: boolean }
 ): string {
   const color = getTypeColor(type);
-  const signalStr =
-    (signals.flagged ? "~" : "") + (signals.starred ? "*" : "");
+  const signalStr = (signals.flagged ? "~" : "") + (signals.starred ? "*" : "");
 
   if (signalStr) {
     // Bold the signal and type with same color, use background for emphasis

--- a/packages/cli/src/utils/display/formatters/styles.ts
+++ b/packages/cli/src/utils/display/formatters/styles.ts
@@ -145,11 +145,11 @@ export function getTypeColor(type: string): typeof chalk {
  */
 export function styleType(
   type: string,
-  signals: { raised: boolean; important: boolean }
+  signals: { flagged: boolean; starred: boolean }
 ): string {
   const color = getTypeColor(type);
   const signalStr =
-    (signals.raised ? "~" : "") + (signals.important ? "*" : "");
+    (signals.flagged ? "~" : "") + (signals.starred ? "*" : "");
 
   if (signalStr) {
     // Bold the signal and type with same color, use background for emphasis

--- a/packages/cli/src/utils/display/formatters/text.ts
+++ b/packages/cli/src/utils/display/formatters/text.ts
@@ -12,8 +12,7 @@ const LINE_NUMBER_WIDTH = 3;
  */
 export function formatRecordSimple(record: WaymarkRecord): string {
   const signals =
-    (record.signals.flagged ? "~" : "") +
-    (record.signals.starred ? "*" : "");
+    (record.signals.flagged ? "~" : "") + (record.signals.starred ? "*" : "");
   // Pad line numbers to 3 digits (aligned to column 4) unless > 999
   const lineStr = String(record.startLine).padStart(LINE_NUMBER_WIDTH, " ");
   return `${record.file}:${lineStr}: // ${signals}${record.type} ::: ${record.contentText}`;

--- a/packages/cli/src/utils/display/formatters/text.ts
+++ b/packages/cli/src/utils/display/formatters/text.ts
@@ -12,7 +12,8 @@ const LINE_NUMBER_WIDTH = 3;
  */
 export function formatRecordSimple(record: WaymarkRecord): string {
   const signals =
-    (record.signals.raised ? "~" : "") + (record.signals.important ? "*" : "");
+    (record.signals.flagged ? "~" : "") +
+    (record.signals.starred ? "*" : "");
   // Pad line numbers to 3 digits (aligned to column 4) unless > 999
   const lineStr = String(record.startLine).padStart(LINE_NUMBER_WIDTH, " ");
   return `${record.file}:${lineStr}: // ${signals}${record.type} ::: ${record.contentText}`;

--- a/packages/cli/src/utils/display/grouping.ts
+++ b/packages/cli/src/utils/display/grouping.ts
@@ -20,7 +20,7 @@ export function getGroupKey(record: WaymarkRecord, groupBy: GroupBy): string {
     case "signal": {
       const signals: string[] = [];
       if (record.signals.raised) {
-        signals.push("raised");
+        signals.push("flagged");
       }
       if (record.signals.important) {
         signals.push("starred");

--- a/packages/cli/src/utils/display/grouping.ts
+++ b/packages/cli/src/utils/display/grouping.ts
@@ -19,10 +19,10 @@ export function getGroupKey(record: WaymarkRecord, groupBy: GroupBy): string {
       return record.type;
     case "signal": {
       const signals: string[] = [];
-      if (record.signals.raised) {
+      if (record.signals.flagged) {
         signals.push("flagged");
       }
-      if (record.signals.important) {
+      if (record.signals.starred) {
         signals.push("starred");
       }
       return signals.length > 0 ? signals.join("+") : "none";

--- a/packages/cli/src/utils/display/sorting.ts
+++ b/packages/cli/src/utils/display/sorting.ts
@@ -27,9 +27,9 @@ export function sortRecords(
     case "signal":
       sorted.sort((a, b) => {
         const aScore =
-          (a.signals.important ? 2 : 0) + (a.signals.raised ? 1 : 0);
+          (a.signals.starred ? 2 : 0) + (a.signals.flagged ? 1 : 0);
         const bScore =
-          (b.signals.important ? 2 : 0) + (b.signals.raised ? 1 : 0);
+          (b.signals.starred ? 2 : 0) + (b.signals.flagged ? 1 : 0);
         return bScore - aScore; // Higher scores first
       });
       break;

--- a/packages/cli/src/utils/output.ts
+++ b/packages/cli/src/utils/output.ts
@@ -32,8 +32,8 @@ function cleanRecord(record: WaymarkRecord): Partial<WaymarkRecord> {
   // Remove signals if all are false
   if (
     cleaned.signals &&
-    !cleaned.signals.raised &&
-    !cleaned.signals.important &&
+    !cleaned.signals.flagged &&
+    !cleaned.signals.starred &&
     !cleaned.signals.current
   ) {
     cleaned.signals = undefined as unknown as WaymarkRecord["signals"];

--- a/packages/cli/src/utils/prompts.ts
+++ b/packages/cli/src/utils/prompts.ts
@@ -65,9 +65,9 @@ export async function selectWaymark(
 
   const choices: WaymarkChoice[] = records.map((record) => {
     let prefix = " ";
-    if (record.signals.raised) {
+    if (record.signals.flagged) {
       prefix = "~";
-    } else if (record.signals.important) {
+    } else if (record.signals.starred) {
       prefix = "*";
     }
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -64,7 +64,7 @@ const result = await insertWaymarks({
     line: 42,
     type: 'todo',
     content: 'implement rate limiting',
-    signals: { raised: true }
+    signals: { flagged: true }
   }]
 });
 

--- a/packages/core/src/cache/index.test.ts
+++ b/packages/core/src/cache/index.test.ts
@@ -30,16 +30,16 @@ const baseRecord = (overrides: Partial<WaymarkRecord>): WaymarkRecord => {
   const contentText = overrides.contentText ?? "content";
   const commentLeader = overrides.commentLeader ?? "//";
   const overrideSignals = overrides.signals;
-  let normalizedSignals = { raised: false, current: false, important: false };
+  let normalizedSignals = { flagged: false, current: false, starred: false };
   if (overrideSignals) {
-    const raisedValue =
-      overrideSignals.raised ?? overrideSignals.current ?? false;
+    const flaggedValue =
+      overrideSignals.flagged ?? overrideSignals.current ?? false;
     const currentValue =
-      overrideSignals.current ?? overrideSignals.raised ?? false;
+      overrideSignals.current ?? overrideSignals.flagged ?? false;
     normalizedSignals = {
-      raised: raisedValue,
+      flagged: flaggedValue,
       current: currentValue,
-      important: overrideSignals.important ?? false,
+      starred: overrideSignals.starred ?? false,
     };
   }
 

--- a/packages/core/src/cache/serialization.ts
+++ b/packages/core/src/cache/serialization.ts
@@ -57,15 +57,16 @@ function parseSignals(
 
   const currentValue =
     parsed.current !== undefined ? Boolean(parsed.current) : flaggedValue;
+  let starredValue = false;
+  if (parsed.starred !== undefined) {
+    starredValue = Boolean(parsed.starred);
+  } else if (parsed.important !== undefined) {
+    starredValue = Boolean(parsed.important);
+  }
   return {
     flagged: flaggedValue,
     current: currentValue,
-    starred:
-      parsed.starred === undefined
-        ? parsed.important === undefined
-          ? false
-          : Boolean(parsed.important)
-        : Boolean(parsed.starred),
+    starred: starredValue,
   };
 }
 

--- a/packages/core/src/cache/serialization.ts
+++ b/packages/core/src/cache/serialization.ts
@@ -45,21 +45,27 @@ export function deserializeRecord(row: WaymarkRow): WaymarkRecord {
 function parseSignals(
   source: string | null | undefined
 ): WaymarkRecord["signals"] {
-  const parsed = safeParse<Partial<WaymarkRecord["signals"]>>(source, {});
-  let raisedValue = false;
-  if (parsed.raised !== undefined) {
-    raisedValue = Boolean(parsed.raised);
+  const parsed = safeParse<Record<string, unknown>>(source, {});
+  let flaggedValue = false;
+  if (parsed.flagged !== undefined) {
+    flaggedValue = Boolean(parsed.flagged);
+  } else if (parsed.raised !== undefined) {
+    flaggedValue = Boolean(parsed.raised);
   } else if (parsed.current !== undefined) {
-    raisedValue = Boolean(parsed.current);
+    flaggedValue = Boolean(parsed.current);
   }
 
   const currentValue =
-    parsed.current !== undefined ? Boolean(parsed.current) : raisedValue;
+    parsed.current !== undefined ? Boolean(parsed.current) : flaggedValue;
   return {
-    raised: raisedValue,
+    flagged: flaggedValue,
     current: currentValue,
-    important:
-      parsed.important === undefined ? false : Boolean(parsed.important),
+    starred:
+      parsed.starred === undefined
+        ? parsed.important === undefined
+          ? false
+          : Boolean(parsed.important)
+        : Boolean(parsed.starred),
   };
 }
 

--- a/packages/core/src/edit.test.ts
+++ b/packages/core/src/edit.test.ts
@@ -109,7 +109,7 @@ describe("editWaymark", () => {
     await writeFile(filePath, "// todo ::: audit\n", "utf8");
 
     await editWaymark(
-      { file: filePath, line: 1, raised: true, starred: true, write: true },
+      { file: filePath, line: 1, flagged: true, starred: true, write: true },
       DEFAULT_CONFIG
     );
 

--- a/packages/core/src/edit.ts
+++ b/packages/core/src/edit.ts
@@ -28,7 +28,7 @@ export const EditSpecSchema = z
     id: z.string().trim().min(1).optional(),
     type: z.string().trim().min(1).optional(),
     content: z.string().optional(),
-    raised: z.boolean().optional(),
+    flagged: z.boolean().optional(),
     starred: z.boolean().optional(),
     clearSignals: z.boolean().optional(),
     write: z.boolean().optional(),
@@ -58,7 +58,7 @@ export const EditSpecSchema = z
     (data) =>
       data.type !== undefined ||
       data.content !== undefined ||
-      data.raised !== undefined ||
+      data.flagged !== undefined ||
       data.starred !== undefined ||
       data.clearSignals === true,
     {
@@ -106,7 +106,7 @@ export async function editWaymark(
     id: options.id,
     type: options.type,
     content: options.content,
-    raised: options.raised,
+    flagged: options.flagged,
     starred: options.starred,
     clearSignals: options.clearSignals,
     write: options.write,
@@ -137,7 +137,7 @@ export async function editWaymark(
 
   const nextType = resolveType(record.type, spec.type);
   const signalOverrides = {
-    ...(spec.raised === undefined ? {} : { raised: spec.raised }),
+    ...(spec.flagged === undefined ? {} : { flagged: spec.flagged }),
     ...(spec.starred === undefined ? {} : { starred: spec.starred }),
     ...(spec.clearSignals === undefined
       ? {}
@@ -408,30 +408,30 @@ function resolveType(current: string, override?: string): string {
   return trimmed;
 }
 
-// `current` mirrors the raised signal unless we are explicitly clearing signals,
-// so the active display state stays aligned with the persisted raised flag.
+// `current` mirrors the flagged signal unless we are explicitly clearing signals,
+// so the active display state stays aligned with the persisted flagged flag.
 function resolveSignals(
   current: WaymarkRecord["signals"],
   overrides: {
-    raised?: boolean;
+    flagged?: boolean;
     starred?: boolean;
     clearSignals?: boolean;
   }
 ): WaymarkRecord["signals"] {
   if (overrides.clearSignals) {
-    return { ...current, raised: false, important: false, current: false };
+    return { ...current, flagged: false, starred: false, current: false };
   }
 
-  const nextRaised =
-    overrides.raised !== undefined ? overrides.raised : current.raised;
-  const nextImportant =
-    overrides.starred !== undefined ? overrides.starred : current.important;
+  const nextFlagged =
+    overrides.flagged !== undefined ? overrides.flagged : current.flagged;
+  const nextStarred =
+    overrides.starred !== undefined ? overrides.starred : current.starred;
 
   return {
     ...current,
-    raised: nextRaised,
-    important: nextImportant,
-    current: nextRaised,
+    flagged: nextFlagged,
+    starred: nextStarred,
+    current: nextFlagged,
   };
 }
 
@@ -527,10 +527,10 @@ function renderContinuationLine(
 
 function buildSignalPrefix(signals: WaymarkRecord["signals"]): string {
   let prefix = "";
-  if (signals.raised) {
+  if (signals.flagged) {
     prefix += "~";
   }
-  if (signals.important) {
+  if (signals.starred) {
     prefix += "*";
   }
   return prefix;

--- a/packages/core/src/edit.ts
+++ b/packages/core/src/edit.ts
@@ -20,6 +20,8 @@ const HTML_COMMENT_LEADER = "<!--";
 const HTML_COMMENT_CLOSE_REGEX = /\s*--!?>\s*$/;
 const CONTEXT_BEFORE_LINES = 2;
 const CONTEXT_AFTER_LINES = 3;
+const LEGACY_WM_PREFIX = "wm:";
+const LEGACY_WM_PREFIX_LENGTH = LEGACY_WM_PREFIX.length;
 
 export const EditSpecSchema = z
   .object({
@@ -606,7 +608,9 @@ function normalizeId(id: string): string {
     return id;
   }
   // Strip wm: prefix if present (legacy format)
-  const hash = id.startsWith("wm:") ? id.slice(3) : id;
+  const hash = id.startsWith(LEGACY_WM_PREFIX)
+    ? id.slice(LEGACY_WM_PREFIX_LENGTH)
+    : id;
   return `[[${hash}]]`;
 }
 

--- a/packages/core/src/format.ts
+++ b/packages/core/src/format.ts
@@ -218,10 +218,10 @@ function normalizeType(record: WaymarkRecord, config: WaymarkConfig): string {
 
 function buildSignalPrefix(record: WaymarkRecord): string {
   let prefix = "";
-  if (record.signals.raised) {
+  if (record.signals.flagged) {
     prefix += "~";
   }
-  if (record.signals.important) {
+  if (record.signals.starred) {
     prefix += "*";
   }
   return prefix;

--- a/packages/core/src/graph.test.ts
+++ b/packages/core/src/graph.test.ts
@@ -14,7 +14,7 @@ const record = (overrides: Partial<WaymarkRecord>): WaymarkRecord => ({
   endLine: 1,
   indent: 0,
   commentLeader: "//",
-  signals: { raised: false, important: false },
+  signals: { flagged: false, starred: false },
   type: "todo",
   contentText: "content",
   properties: {},

--- a/packages/core/src/insert.ts
+++ b/packages/core/src/insert.ts
@@ -27,8 +27,8 @@ export const InsertionSpecSchema = z.object({
   content: z.string(),
   signals: z
     .object({
-      raised: z.boolean().optional(),
-      important: z.boolean().optional(),
+      flagged: z.boolean().optional(),
+      starred: z.boolean().optional(),
     })
     .strict()
     .optional(),
@@ -414,10 +414,10 @@ function buildSignals(signals: InsertionSpec["signals"]): string {
     return "";
   }
   let result = "";
-  if (signals.raised) {
+  if (signals.flagged) {
     result += "~";
   }
-  if (signals.important) {
+  if (signals.starred) {
     result += "*";
   }
   return result;

--- a/packages/core/src/normalize.test.ts
+++ b/packages/core/src/normalize.test.ts
@@ -23,7 +23,7 @@ function createTestRecord(
     endLine: 1,
     type: "todo",
     contentText: "test content",
-    signals: { raised: false, important: false },
+    signals: { flagged: false, starred: false },
     properties: {},
     relations: [],
     canonicals: [],

--- a/packages/core/src/remove.ts
+++ b/packages/core/src/remove.ts
@@ -113,6 +113,8 @@ type RemovalMatch = {
 const ID_REGEX = /\[\[([a-z0-9-]+)(?:\|([^\]]+))?\]\]/gi;
 const LINE_SPLIT_REGEX = /\r?\n/;
 const MAX_CONTENT_PATTERN_LENGTH = 512;
+const LEGACY_WM_PREFIX = "wm:";
+const LEGACY_WM_PREFIX_LENGTH = LEGACY_WM_PREFIX.length;
 
 type RemovalState = {
   results: RemovalResult[];
@@ -485,8 +487,8 @@ function findRecordById(
   let normalized: string;
   if (id.startsWith("[[") && id.endsWith("]]")) {
     normalized = id;
-  } else if (id.startsWith("wm:")) {
-    normalized = `[[${id.slice(3)}]]`;
+  } else if (id.startsWith(LEGACY_WM_PREFIX)) {
+    normalized = `[[${id.slice(LEGACY_WM_PREFIX_LENGTH)}]]`;
   } else {
     normalized = `[[${id}]]`;
   }

--- a/packages/core/src/remove.ts
+++ b/packages/core/src/remove.ts
@@ -13,8 +13,8 @@ import type { CoreLogger, WaymarkConfig } from "./types.ts";
 // Define the signals schema separately so we can reuse it
 const RemovalSignalsSchema = z
   .object({
-    raised: z.boolean().optional(),
-    important: z.boolean().optional(),
+    flagged: z.boolean().optional(),
+    starred: z.boolean().optional(),
   })
   .strict();
 
@@ -594,14 +594,14 @@ function signalsMatch(
     return true;
   }
   if (
-    signals.raised !== undefined &&
-    record.signals.raised !== signals.raised
+    signals.flagged !== undefined &&
+    record.signals.flagged !== signals.flagged
   ) {
     return false;
   }
   if (
-    signals.important !== undefined &&
-    record.signals.important !== signals.important
+    signals.starred !== undefined &&
+    record.signals.starred !== signals.starred
   ) {
     return false;
   }

--- a/packages/core/src/search.test.ts
+++ b/packages/core/src/search.test.ts
@@ -14,7 +14,7 @@ const sampleRecord = (overrides: Partial<WaymarkRecord>): WaymarkRecord => ({
   endLine: 1,
   indent: 0,
   commentLeader: "//",
-  signals: { raised: false, important: false },
+  signals: { flagged: false, starred: false },
   type: "todo",
   contentText: "example content",
   properties: {},

--- a/packages/grammar/README.md
+++ b/packages/grammar/README.md
@@ -18,7 +18,7 @@ bun add @waymarks/grammar
 - `BLESSED_MARKERS` - Array of officially supported waymark types
 - `MARKERS` - Rich marker definitions with metadata and categories
 - `SIGIL` - The `:::` sigil constant
-- `SIGNALS` - Signal prefix constants (`^` for raised, `*` for important)
+- `SIGNALS` - Signal prefix constants (`~` for flagged, `*` for starred)
 
 ## Example
 
@@ -42,7 +42,7 @@ const records: WaymarkRecord[] = parse(sourceCode, {
 //   startLine: 2,
 //   type: 'todo',
 //   contentText: 'implement rate limiting',
-//   signals: { raised: false, important: false },
+//   signals: { flagged: false, starred: false },
 //   ...
 // }
 ```

--- a/packages/grammar/src/constants.ts
+++ b/packages/grammar/src/constants.ts
@@ -3,10 +3,10 @@
 export const SIGIL = ":::" as const;
 
 // Signal constants
-// ~ = raised (work-in-progress, branch-scoped)
+// ~ = flagged (work-in-progress, branch-scoped)
 // * = starred (important, high-priority)
 export const SIGNALS = {
-  raised: "~",
+  flagged: "~",
   starred: "*",
 } as const;
 

--- a/packages/grammar/src/parser.test.ts
+++ b/packages/grammar/src/parser.test.ts
@@ -20,9 +20,9 @@ describe("parseLine", () => {
     expect(record).not.toBeNull();
     expect(record?.type).toBe("todo");
     expect(record?.signals).toEqual({
-      raised: false,
+      flagged: false,
       current: false,
-      important: false,
+      starred: false,
     });
     expect(record?.tags).toContain("#arch/state");
     expect(record?.language).toBe("typescript");

--- a/packages/grammar/src/tokenizer.ts
+++ b/packages/grammar/src/tokenizer.ts
@@ -7,8 +7,8 @@ const ANY_WHITESPACE_REGEX = /\s/;
 const LEADING_WHITESPACE_REGEX = /^\s*/;
 
 export type SignalState = {
-  raised: boolean;
-  important: boolean;
+  flagged: boolean;
+  starred: boolean;
   current?: boolean;
 };
 
@@ -42,7 +42,7 @@ export function parseSignalsAndType(segment: string): {
   if (trimmed.length === 0) {
     return {
       type: "",
-      signals: { raised: false, current: false, important: false },
+      signals: { flagged: false, current: false, starred: false },
       valid: true,
     };
   }
@@ -50,14 +50,14 @@ export function parseSignalsAndType(segment: string): {
   if (ANY_WHITESPACE_REGEX.test(trimmed)) {
     return {
       type: "",
-      signals: { raised: false, current: false, important: false },
+      signals: { flagged: false, current: false, starred: false },
       valid: false,
     };
   }
 
   let cursor = 0;
-  let raised = false;
-  let important = false;
+  let flagged = false;
+  let starred = false;
 
   while (
     cursor < trimmed.length &&
@@ -65,9 +65,9 @@ export function parseSignalsAndType(segment: string): {
   ) {
     const char = trimmed[cursor];
     if (char === "~") {
-      raised = true;
+      flagged = true;
     } else if (char === "*") {
-      important = true;
+      starred = true;
     }
     cursor += 1;
   }
@@ -77,14 +77,14 @@ export function parseSignalsAndType(segment: string): {
   if (type.includes("~") || type.includes("*") || type.includes("^")) {
     return {
       type: "",
-      signals: { raised: false, important: false },
+      signals: { flagged: false, starred: false },
       valid: false,
     };
   }
 
   return {
     type: type.toLowerCase(),
-    signals: { raised, important, current: raised },
+    signals: { flagged, starred, current: flagged },
     valid: true,
   };
 }

--- a/packages/grammar/src/types.ts
+++ b/packages/grammar/src/types.ts
@@ -9,10 +9,10 @@ export type WaymarkRecord = {
   indent: number;
   commentLeader: string | null;
   signals: {
-    /** @deprecated use `raised` */
+    /** @deprecated use `flagged` */
     current?: boolean;
-    raised: boolean;
-    important: boolean;
+    flagged: boolean;
+    starred: boolean;
   };
   type: string;
   contentText: string;

--- a/schemas/waymark-record.schema.json
+++ b/schemas/waymark-record.schema.json
@@ -42,11 +42,11 @@
       "type": "object",
       "description": "Signal flags for the waymark",
       "properties": {
-        "raised": {
+        "flagged": {
           "type": "boolean",
-          "description": "Whether marked with ^ (raised work in progress)"
+          "description": "Whether marked with ~ (flagged work in progress)"
         },
-        "important": {
+        "starred": {
           "type": "boolean",
           "description": "Whether marked with * (high priority)"
         }

--- a/skills/auditing-waymarks/SKILL.md
+++ b/skills/auditing-waymarks/SKILL.md
@@ -213,8 +213,8 @@ git diff --cached --name-only | xargs -I{} sh -c \
 ### Pre-merge
 
 ```bash
-# No raised waymarks
-! rg '~\w+\s*:::' && echo "OK: No raised waymarks"
+# No flagged waymarks
+! rg '~\w+\s*:::' && echo "OK: No flagged waymarks"
 
 # No WIP markers
 ! rg 'wip\s*:::' && echo "OK: No WIP markers"
@@ -261,7 +261,7 @@ Before completing an audit:
 
 - [ ] All source files have TLDR waymarks
 - [ ] TLDRs accurately describe file contents
-- [ ] No raised (`~`) waymarks remain (if auditing for merge)
+- [ ] No flagged (`~`) waymarks remain (if auditing for merge)
 - [ ] Starred (`*`) items reviewed for continued priority
 - [ ] Work markers (todo, fix, wip) are current
 - [ ] Tags follow established conventions

--- a/skills/find-waymarks/SKILL.md
+++ b/skills/find-waymarks/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: Find Waymarks
-description: Search for waymarks (structured code annotations marked with `:::`) in the codebase using the `wm` CLI tool. Use when the user asks to find TODOs, search waymarks, locate code annotations, find work items, check for @agent tasks, or mentions waymarks, the `:::` sigil, work-in-progress markers (^), starred items (*), or code navigation. Supports filtering by type (todo/fix/note/tldr), tags (#perf, #security), mentions (@agent, @alice), and signals (raised/starred).
+description: Search for waymarks (structured code annotations marked with `:::`) in the codebase using the `wm` CLI tool. Use when the user asks to find TODOs, search waymarks, locate code annotations, find work items, check for @agent tasks, or mentions waymarks, the `:::` sigil, work-in-progress markers (~), starred items (*), or code navigation. Supports filtering by type (todo/fix/note/tldr), tags (#perf, #security), mentions (@agent, @alice), and signals (flagged/starred).
 allowed-tools:
   - Bash
   - Read
@@ -45,10 +45,10 @@ wm --mention @alice --json
 wm --tag perf --json
 ```
 
-**Find raised (work-in-progress) waymarks:**
+**Find flagged (work-in-progress) waymarks:**
 
 ```bash
-wm --raised --json
+wm --flagged --json
 ```
 
 **Find starred (high-priority) waymarks:**
@@ -68,7 +68,7 @@ wm --type todo --mention @agent --tag security --json
 - `--type <marker>`: Filter by waymark type (todo, fix, note, tldr, this, etc.)
 - `--mention <actor>`: Filter by mentions (@alice, @agent, etc.)
 - `--tag <tag>`: Filter by hashtags (#perf, #security, etc.)
-- `--raised`: Show only raised (^) waymarks (work-in-progress)
+- `--flagged`: Show only flagged (~) waymarks (work-in-progress)
 - `--starred`: Show only starred (*) waymarks (high-priority)
 - `--json`: Output as JSON for parsing
 - `--jsonl`: Output as JSON Lines
@@ -86,7 +86,7 @@ Common patterns:
 - "Find work for @agent" → `wm --mention @agent --json`
 - "Find security issues" → `wm --tag security --json`
 - "Find high priority items" → `wm --starred --json`
-- "Find work in progress" → `wm --raised --json`
+- "Find work in progress" → `wm --flagged --json`
 
 ### Show dependency graph
 
@@ -101,7 +101,7 @@ wm --graph --json
 1. Always use `--json` for programmatic parsing
 2. Combine filters to narrow results (e.g., `--type todo --mention @agent`)
 3. Use `--type tldr` to list all file summaries
-4. Check for raised waymarks (`--raised`) before merging to ensure work-in-progress is cleared
+4. Check for flagged waymarks (`--flagged`) before merging to ensure work-in-progress is cleared
 5. Use `--starred` to find high-priority items that need attention
 
 ## Implementation
@@ -127,8 +127,8 @@ Waymarks use a special syntax starting with `:::`:
 
 ```text
 ::: todo This needs to be done #priority @agent
-::: fix^ Bug that needs immediate attention
-::: note* Important information to remember
+::: ~fix Bug that needs immediate attention
+::: *note Important information to remember
 ::: tldr Summary of what this file does
 ```
 
@@ -142,7 +142,7 @@ Waymarks use a special syntax starting with `:::`:
 
 **Signals:**
 
-- `^` (raised) - Work in progress
+- `~` (flagged) - Work in progress
 - `*` (starred) - High priority
 
 **Metadata:**

--- a/skills/waymark-authoring/references/grammar.md
+++ b/skills/waymark-authoring/references/grammar.md
@@ -30,17 +30,17 @@ content     = text (property | hashtag | mention)*
 
 ## Signal Rules
 
-Two signals are valid: `~` (raised) and `*` (starred):
+Two signals are valid: `~` (flagged) and `*` (starred):
 
 ```javascript
 // ~todo ::: work in progress, don't merge yet
 // *fix ::: high priority bug
-// ~*todo ::: raised and starred (~ always before *)
+// ~*todo ::: flagged and starred (~ always before *)
 ```
 
 **Invalid signals:**
 
-- `^` (deprecated - was "raised" in v0)
+- `^` (deprecated - was "flagged" in v0)
 - `!`, `!!`, `?` (never valid)
 - `**` (double star invalid)
 - `*~` (wrong order - use `~*`)


### PR DESCRIPTION
## Summary

Renames the `--raised` CLI flag to `--flagged` throughout the codebase to align with the updated signal terminology.

### Changes

- **CLI flags**: `--raised` → `--flagged`, `--no-raised` → `--no-flagged`
- **Documentation**: Updated signal descriptions from "raised" to "flagged"
- **Help text**: All references updated to use "flagged" terminology

### Why

The `~` signal (formerly `^`) semantically represents work that is "flagged" for attention on the current branch, making `--flagged` a clearer flag name than `--raised`.

Closes #145

---

🤖 Generated with [Claude Code](https://claude.ai/code)