### PR TITLE
chore: remove backwards compatibility code for pre-release cleanup

### DIFF
--- a/.agents/plans/v1-syntax/PLAN.md
+++ b/.agents/plans/v1-syntax/PLAN.md
@@ -74,7 +74,7 @@ properties-sym (4)    tags-mentions (5)  [parallel ok]
 - `packages/grammar/src/parser.test.ts` - Update test expectations
 - `packages/grammar/src/constants.test.ts` - Update marker list assertions
 - `.waymark/rules/WAYMARKS.md` - Update marker documentation
-- `.waymark/rules/THIS.md` - Rename to `ABOUT.md`, update content
+- `.waymark/rules/ABOUT.md` - Update content if needed
 
 **Verification**:
 

--- a/.agents/plans/v1/PLAN.md
+++ b/.agents/plans/v1/PLAN.md
@@ -719,7 +719,7 @@ The docstring serves TypeScript tooling and API consumers. The waymarks serve yo
 - `.waymark/rules/WAYMARKS.md`
 - `.waymark/rules/DOCSTRING-COMPATIBILITY.md`
 - `.waymark/rules/TLDRs.md`
-- `.waymark/rules/THIS.md`
+- `.waymark/rules/ABOUT.md`
 
 ---
 

--- a/commands/waymark/add.md
+++ b/commands/waymark/add.md
@@ -13,7 +13,7 @@ Guide the user through adding a waymark to a file.
 ## Arguments
 
 - `$1` - File path (required)
-- `$2` - Marker type (optional: tldr, todo, fix, note, this, etc.)
+- `$2` - Marker type (optional: tldr, todo, fix, note, about, etc.)
 
 ## Context Injection
 
@@ -47,7 +47,7 @@ Otherwise, use AskUserQuestion to determine intent:
 - "Mark a task" → `todo`
 - "Flag a bug" → `fix`
 - "Add context/note" → `note`
-- "Describe a section" → `this`
+- "Describe a section" → `about`
 - "Add a warning" → `warn`
 
 ### Step 3: Content Drafting
@@ -61,7 +61,7 @@ Based on marker type:
 - Lead with capability, end with key detail
 - Add relevant tags (`#docs` for documentation)
 
-**For `this`:**
+**For `about`:**
 
 - Place above the target section/function/class
 - Describe what the following code does
@@ -83,7 +83,7 @@ Based on marker type:
 Determine correct insertion point:
 
 - `tldr` → After shebang/frontmatter, before code
-- `this` → Line above target construct
+- `about` → Line above target construct
 - Others → Near relevant code
 
 ### Step 5: Insert

--- a/packages/cli/src/commands/modify.ts
+++ b/packages/cli/src/commands/modify.ts
@@ -81,8 +81,6 @@ const LINE_SPLIT_REGEX = /\r?\n/;
 // Match [[hash]], [[hash|alias]], or [[alias]] at end of content
 const ID_TRAIL_REGEX = /(\[\[[^\]]+\]\])$/i;
 const DEFAULT_MARKERS = ["todo", "fix", "note", "warn", "tldr", "done"];
-const LEGACY_WM_PREFIX = "wm:";
-const LEGACY_WM_PREFIX_LENGTH = LEGACY_WM_PREFIX.length;
 
 const DEFAULT_IO: ModifyIo = {
   stdin: process.stdin,
@@ -491,11 +489,7 @@ function normalizeId(id: string): string {
   if (id.startsWith("[[") && id.endsWith("]]")) {
     return id;
   }
-  // Strip wm: prefix if present (legacy format)
-  const hash = id.startsWith(LEGACY_WM_PREFIX)
-    ? id.slice(LEGACY_WM_PREFIX_LENGTH)
-    : id;
-  return `[[${hash}]]`;
+  return `[[${id}]]`;
 }
 
 async function runInteractiveSession(

--- a/packages/cli/src/commands/unified/query-parser.test.ts
+++ b/packages/cli/src/commands/unified/query-parser.test.ts
@@ -74,7 +74,6 @@ describe("Query Parser", () => {
   test("fuzzy matches common type variations", () => {
     expect(parseQuery("todos").types).toEqual(["todo"]);
     expect(parseQuery("to-do").types).toEqual(["todo"]);
-    expect(parseQuery("fixme").types).toEqual(["fix"]);
     expect(parseQuery("tldrs").types).toEqual(["tldr"]);
   });
 

--- a/packages/core/src/edit.ts
+++ b/packages/core/src/edit.ts
@@ -20,8 +20,6 @@ const HTML_COMMENT_LEADER = "<!--";
 const HTML_COMMENT_CLOSE_REGEX = /\s*--!?>\s*$/;
 const CONTEXT_BEFORE_LINES = 2;
 const CONTEXT_AFTER_LINES = 3;
-const LEGACY_WM_PREFIX = "wm:";
-const LEGACY_WM_PREFIX_LENGTH = LEGACY_WM_PREFIX.length;
 
 export const EditSpecSchema = z
   .object({
@@ -607,11 +605,7 @@ function normalizeId(id: string): string {
   if (id.startsWith("[[") && id.endsWith("]]")) {
     return id;
   }
-  // Strip wm: prefix if present (legacy format)
-  const hash = id.startsWith(LEGACY_WM_PREFIX)
-    ? id.slice(LEGACY_WM_PREFIX_LENGTH)
-    : id;
-  return `[[${hash}]]`;
+  return `[[${id}]]`;
 }
 
 function buildFileText(

--- a/packages/core/src/ids.ts
+++ b/packages/core/src/ids.ts
@@ -140,9 +140,7 @@ export class WaymarkIdManager {
       }
       return id;
     }
-    // Strip wm: prefix if present (legacy format)
-    const hash = id.startsWith("wm:") ? id.slice(3) : id;
-    return `[[${hash}]]`;
+    return `[[${id}]]`;
   }
 
   private async validateAvailability(

--- a/packages/core/src/remove.ts
+++ b/packages/core/src/remove.ts
@@ -113,8 +113,6 @@ type RemovalMatch = {
 const ID_REGEX = /\[\[([a-z0-9-]+)(?:\|([^\]]+))?\]\]/gi;
 const LINE_SPLIT_REGEX = /\r?\n/;
 const MAX_CONTENT_PATTERN_LENGTH = 512;
-const LEGACY_WM_PREFIX = "wm:";
-const LEGACY_WM_PREFIX_LENGTH = LEGACY_WM_PREFIX.length;
 
 type RemovalState = {
   results: RemovalResult[];
@@ -484,14 +482,8 @@ function findRecordById(
   id: string
 ): WaymarkRecord | undefined {
   // Normalize to [[hash]] format
-  let normalized: string;
-  if (id.startsWith("[[") && id.endsWith("]]")) {
-    normalized = id;
-  } else if (id.startsWith(LEGACY_WM_PREFIX)) {
-    normalized = `[[${id.slice(LEGACY_WM_PREFIX_LENGTH)}]]`;
-  } else {
-    normalized = `[[${id}]]`;
-  }
+  const normalized =
+    id.startsWith("[[") && id.endsWith("]]") ? id : `[[${id}]]`;
   return records.find((record) => record.raw.includes(normalized));
 }
 

--- a/packages/grammar/src/constants.ts
+++ b/packages/grammar/src/constants.ts
@@ -3,7 +3,7 @@
 export const SIGIL = ":::" as const;
 
 // Signal constants
-// ~ = flagged (work-in-progress, branch-scoped)
+// ~ = flagged (actively in-progress, branch-scoped)
 // * = starred (important, high-priority)
 export const SIGNALS = {
   flagged: "~",
@@ -27,12 +27,7 @@ export type MarkerDefinition = {
 export const MARKER_DEFINITIONS: MarkerDefinition[] = [
   // Work/Action
   { name: "todo", category: "work", description: "Task to be completed" },
-  {
-    name: "fix",
-    category: "work",
-    aliases: ["fixme"],
-    description: "Bug or issue to resolve",
-  },
+  { name: "fix", category: "work", description: "Bug or issue to resolve" },
   { name: "wip", category: "work", description: "Work currently in progress" },
   { name: "done", category: "work", description: "Completed task" },
   {
@@ -60,7 +55,6 @@ export const MARKER_DEFINITIONS: MarkerDefinition[] = [
   {
     name: "context",
     category: "info",
-    aliases: ["why"],
     description: "Explains reasoning or background",
   },
   {
@@ -104,14 +98,7 @@ export const MARKER_DEFINITIONS: MarkerDefinition[] = [
   {
     name: "temp",
     category: "caution",
-    aliases: ["tmp"],
     description: "Temporary code not for production",
-  },
-  {
-    name: "hack",
-    category: "caution",
-    aliases: ["stub"],
-    description: "Workaround or incomplete implementation",
   },
 
   // Workflow
@@ -127,15 +114,10 @@ export const MARKER_DEFINITIONS: MarkerDefinition[] = [
   },
 
   // Inquiry
-  {
-    name: "question",
-    category: "inquiry",
-    aliases: ["ask"],
-    description: "Question needing answer",
-  },
+  { name: "ask", category: "inquiry", description: "Question needing answer" },
 ];
 
-// Build a flat list of all markers including aliases for backward compatibility
+// Build a flat list of all blessed markers
 // In continuation context, the parser explicitly excludes blessed markers from being
 // treated as property continuations (see parseContinuation in content.ts).
 export const BLESSED_MARKERS = MARKER_DEFINITIONS.flatMap((def) => [
@@ -168,7 +150,6 @@ export function getTypeCategory(type: string): MarkerCategory | undefined {
 export const MARKERS = {
   todo: "todo",
   fix: "fix",
-  fixme: "fixme",
   wip: "wip",
   done: "done",
   review: "review",
@@ -176,7 +157,6 @@ export const MARKERS = {
   check: "check",
   note: "note",
   context: "context",
-  why: "why",
   tldr: "tldr",
   about: "about",
   example: "example",
@@ -186,12 +166,8 @@ export const MARKERS = {
   alert: "alert",
   deprecated: "deprecated",
   temp: "temp",
-  tmp: "tmp",
-  hack: "hack",
-  stub: "stub",
   blocked: "blocked",
   needs: "needs",
-  question: "question",
   ask: "ask",
 } as const;
 

--- a/skills/find-waymarks/SKILL.md
+++ b/skills/find-waymarks/SKILL.md
@@ -65,7 +65,7 @@ wm --type todo --mention @agent --tag security --json
 
 ## Available Filters
 
-- `--type <marker>`: Filter by waymark type (todo, fix, note, tldr, this, etc.)
+- `--type <marker>`: Filter by waymark type (todo, fix, note, tldr, about, etc.)
 - `--mention <actor>`: Filter by mentions (@alice, @agent, etc.)
 - `--tag <tag>`: Filter by hashtags (#perf, #security, etc.)
 - `--flagged`: Show only flagged (~) waymarks (work-in-progress)
@@ -138,7 +138,7 @@ Waymarks use a special syntax starting with `:::`:
 - `fix` - Bug to fix
 - `note` - Important note
 - `tldr` - File/section summary
-- `this` - Reference to current context
+- `about` - Section/block summary
 
 **Signals:**
 


### PR DESCRIPTION
## Summary

Removes backwards compatibility code since waymark is still pre-release and no one is using the legacy formats.

### Changes

**Marker aliases removed:**
- `fixme` → just use `fix`
- `why` → just use `context`  
- `tmp` → just use `temp`
- `hack`/`stub` → removed entirely (use `temp` instead)

**Canonical marker change:**
- `question` → `ask` (terser, more natural)

**Legacy ID format removed:**
- Removed `wm:xxx` prefix handling from ID normalization in 4 files
- IDs now use `[[hash]]` wikilink format exclusively

**Documentation updates:**
- Updated `this` marker references to `about`
- Fixed THIS.md → ABOUT.md file references

### Files Changed

- `packages/grammar/src/constants.ts` - Marker definitions
- `packages/core/src/ids.ts` - ID normalization
- `packages/core/src/edit.ts` - ID normalization
- `packages/core/src/remove.ts` - ID normalization
- `packages/cli/src/commands/modify.ts` - ID normalization
- `packages/cli/src/commands/unified/query-parser.test.ts` - Test updates
- Documentation files (4 files)

Closes #146

---

🤖 Generated with [Claude Code](https://claude.ai/code)