### PR TITLE
fix(mcp): accept flexible ids

### DIFF
--- a/apps/mcp/README.md
+++ b/apps/mcp/README.md
@@ -65,6 +65,18 @@ const result = await client.callTool({
   }
 });
 
+// Add a waymark with an ID (bare values normalize to [[...]])
+const inserted = await client.callTool({
+  name: 'waymark',
+  arguments: {
+    action: 'add',
+    filePath: 'src/app.ts',
+    type: 'todo',
+    content: 'add retry',
+    id: 'auth-refresh'
+  }
+});
+
 // Drafting guidance lives in agent skills (no MCP prompts).
 ```
 

--- a/apps/mcp/src/index.test.ts
+++ b/apps/mcp/src/index.test.ts
@@ -18,6 +18,8 @@ class TestServer {
 
 const TLDR_EXISTS_REGEX = /already contains a tldr waymark/u;
 const LEGACY_ID_REGEX = /Legacy wm:/u;
+const EMPTY_ID_REGEX = /cannot be empty/u;
+const DIFFERENT_ID_REGEX = /different waymark id/u;
 const ABOUT_INSERT_LINE = 3;
 const SAMPLE_SOURCE = ["line 1", "line 2", "line 3", "line 4", "line 5"].join(
   "\n"
@@ -170,7 +172,7 @@ describe("handleAddWaymark", () => {
     await rm(dir, { recursive: true, force: true });
   });
 
-  test("appends normalized id when provided", async () => {
+  test("normalizes provided id to lowercase", async () => {
     const dir = await mkdtemp(join(tmpdir(), "waymark-mcp-id-"));
     const file = join(dir, "feature.ts");
     await writeFile(
@@ -186,12 +188,112 @@ describe("handleAddWaymark", () => {
       type: "todo",
       content: "add retry",
       line: 1,
-      id: "auth-refresh",
+      id: "Auth-Refresh",
     });
 
     const updated = await readFile(file, "utf8");
     const [firstLine] = updated.split("\n");
     expect(firstLine).toBe("// todo ::: add retry [[auth-refresh]]");
+
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  test("accepts bracketed ids and lowercases them", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "waymark-mcp-id-bracket-"));
+    const file = join(dir, "feature.ts");
+    await writeFile(
+      file,
+      ["export function feature() {", "  return true;", "}"].join("\n"),
+      "utf8"
+    );
+
+    const server = new TestServer();
+    await handleAddWaymark({
+      server,
+      filePath: file,
+      type: "todo",
+      content: "add retry",
+      line: 1,
+      id: "[[Auth-Refresh]]",
+    });
+
+    const updated = await readFile(file, "utf8");
+    const [firstLine] = updated.split("\n");
+    expect(firstLine).toBe("// todo ::: add retry [[auth-refresh]]");
+
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  test("throws when content already contains a different id", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "waymark-mcp-id-conflict-"));
+    const file = join(dir, "feature.ts");
+    await writeFile(
+      file,
+      ["export function feature() {", "  return true;", "}"].join("\n"),
+      "utf8"
+    );
+
+    const server = new TestServer();
+    await expect(
+      handleAddWaymark({
+        server,
+        filePath: file,
+        type: "todo",
+        content: "add retry [[existing-id]]",
+        line: 1,
+        id: "other-id",
+      })
+    ).rejects.toThrow(DIFFERENT_ID_REGEX);
+
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  test("trims whitespace around ids", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "waymark-mcp-id-trim-"));
+    const file = join(dir, "feature.ts");
+    await writeFile(
+      file,
+      ["export function feature() {", "  return true;", "}"].join("\n"),
+      "utf8"
+    );
+
+    const server = new TestServer();
+    await handleAddWaymark({
+      server,
+      filePath: file,
+      type: "todo",
+      content: "add retry",
+      line: 1,
+      id: "  AUTH  ",
+    });
+
+    const updated = await readFile(file, "utf8");
+    const [firstLine] = updated.split("\n");
+    expect(firstLine).toBe("// todo ::: add retry [[auth]]");
+
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  test("rejects empty ids", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "waymark-mcp-id-empty-"));
+    const file = join(dir, "feature.ts");
+    await writeFile(
+      file,
+      ["export function feature() {", "  return true;", "}"].join("\n"),
+      "utf8"
+    );
+
+    const server = new TestServer();
+    await expect(
+      handleAddWaymark({
+        server,
+        filePath: file,
+        type: "todo",
+        content: "add retry",
+        line: 1,
+        id: "   ",
+      })
+    ).rejects.toThrow(EMPTY_ID_REGEX);
 
     await rm(dir, { recursive: true, force: true });
   });

--- a/apps/mcp/src/tools/add.ts
+++ b/apps/mcp/src/tools/add.ts
@@ -351,14 +351,15 @@ function normalizeWaymarkId(id: string): string {
     if (inner.length === 0) {
       throw new Error(`Invalid waymark id format: ${id}`);
     }
-    if (inner.toLowerCase().startsWith(LEGACY_ID_PREFIX)) {
+    const normalizedInner = inner.toLowerCase();
+    if (normalizedInner.startsWith(LEGACY_ID_PREFIX)) {
       throw new Error(
         "Legacy wm: ids are not supported. Use [[hash]] or [[hash|alias]]."
       );
     }
-    return `[[${inner}]]`;
+    return `[[${normalizedInner}]]`;
   }
-  return `[[${trimmed}]]`;
+  return `[[${lower}]]`;
 }
 
 function applyIdToContent(content: string, id?: string): string {

--- a/apps/mcp/src/tools/add.ts
+++ b/apps/mcp/src/tools/add.ts
@@ -16,6 +16,8 @@ import { normalizePathForOutput } from "../utils/filesystem";
 const EXTENSION_REGEX = /(\.[^.]+)$/u;
 const NEWLINE_SPLIT_REGEX = /\r?\n/u;
 const LEADING_WHITESPACE_REGEX = /^[ \t]*/u;
+const ID_TRAIL_REGEX = /(\[\[[^\]]+\]\])$/i;
+const LEGACY_ID_PREFIX = "wm:";
 
 const COMMENT_STYLE_BY_EXTENSION: Record<string, CommentStyle> = {
   ".c": { leader: "//" },
@@ -83,7 +85,10 @@ export async function handleAdd(
   server: Pick<McpServer, "sendResourceListChanged">
 ): Promise<CallToolResult> {
   const params = addWaymarkInputSchema.parse(input);
-  const { filePath, type, content, line, signals, configPath, scope } = params;
+  const { filePath, type, content, line, signals, id, configPath, scope } =
+    params;
+  const normalizedId = id ? normalizeWaymarkId(id) : undefined;
+  const normalizedContent = applyIdToContent(content, normalizedId);
 
   const absolutePath = resolve(process.cwd(), filePath);
   if (!existsSync(absolutePath)) {
@@ -112,7 +117,7 @@ export async function handleAdd(
   const insertion = _addWaymark({
     source: originalSource,
     type,
-    content,
+    content: normalizedContent,
     ...(line !== undefined ? { line } : {}),
     newline,
     commentStyle,
@@ -133,7 +138,7 @@ export async function handleAdd(
   const insertedRecord = findInsertedRecord({
     records: updatedRecords,
     type: markerLower,
-    content,
+    content: normalizedContent,
     insertedLine: insertion.lineNumber,
   });
 
@@ -144,7 +149,7 @@ export async function handleAdd(
     type: insertedRecord?.type ?? type,
     startLine: insertedRecord?.startLine ?? insertion.lineNumber,
     endLine: insertedRecord?.endLine ?? insertion.lineNumber,
-    content: insertedRecord?.contentText ?? content,
+    content: insertedRecord?.contentText ?? normalizedContent,
     signals: insertedRecord?.signals,
   });
 }
@@ -330,6 +335,55 @@ function toJsonResponse(value: unknown): CallToolResult {
   };
 }
 
+function normalizeWaymarkId(id: string): string {
+  const trimmed = id.trim();
+  if (trimmed.length === 0) {
+    throw new Error("Waymark id cannot be empty.");
+  }
+  const lower = trimmed.toLowerCase();
+  if (lower.startsWith(LEGACY_ID_PREFIX)) {
+    throw new Error(
+      "Legacy wm: ids are not supported. Use [[hash]] or [[hash|alias]]."
+    );
+  }
+  if (trimmed.startsWith("[[") && trimmed.endsWith("]]")) {
+    const inner = trimmed.slice(2, -2).trim();
+    if (inner.length === 0) {
+      throw new Error(`Invalid waymark id format: ${id}`);
+    }
+    if (inner.toLowerCase().startsWith(LEGACY_ID_PREFIX)) {
+      throw new Error(
+        "Legacy wm: ids are not supported. Use [[hash]] or [[hash|alias]]."
+      );
+    }
+    return `[[${inner}]]`;
+  }
+  return `[[${trimmed}]]`;
+}
+
+function applyIdToContent(content: string, id?: string): string {
+  const trimmed = content.trim();
+  if (!id) {
+    return trimmed;
+  }
+
+  const match = trimmed.match(ID_TRAIL_REGEX);
+  const existingId = match?.[1];
+  if (existingId) {
+    const normalizedExisting = normalizeWaymarkId(existingId);
+    if (normalizedExisting !== id) {
+      throw new Error(
+        `Content already contains a different waymark id: ${existingId}`
+      );
+    }
+    const base = trimmed.replace(ID_TRAIL_REGEX, "").trimEnd();
+    return base.length > 0
+      ? `${base} ${normalizedExisting}`
+      : normalizedExisting;
+  }
+  return trimmed.length > 0 ? `${trimmed} ${id}` : id;
+}
+
 export const addToolDefinition = {
   title: "Add a waymark",
   description:
@@ -342,6 +396,7 @@ export function handleAddWaymark(params: {
   filePath: string;
   type: string;
   content: string;
+  id?: string | undefined;
   line?: number | undefined;
   signals?: SignalFlags | undefined;
   configPath?: string | undefined;

--- a/apps/mcp/src/tools/help.ts
+++ b/apps/mcp/src/tools/help.ts
@@ -52,13 +52,14 @@ const HELP_TOPICS: Record<string, HelpTopic> = {
       "- filePath: string",
       "- type: string",
       "- content: string",
+      "- id?: string (wikilink [[hash]], [[hash|alias]], [[alias]] or bare)",
       "- line?: number",
       "- signals?: { flagged?: boolean; starred?: boolean }",
       "- configPath?: string",
       "- scope?: default | project | user",
       "",
       "Example:",
-      '{"action":"add","filePath":"src/app.ts","type":"todo","content":"add retry"}',
+      '{"action":"add","filePath":"src/app.ts","type":"todo","content":"add retry","id":"auth-refresh"}',
     ].join("\n"),
   },
 };
@@ -71,7 +72,7 @@ const DEFAULT_HELP = [
   "Actions:",
   "- scan  (paths?, format?, configPath?, scope?)",
   "- graph (paths?, configPath?, scope?)",
-  "- add   (filePath, type, content, line?, signals?)",
+  "- add   (filePath, type, content, id?, line?, signals?)",
   "- help  (topic?)",
   "",
   "Defaults:",
@@ -82,7 +83,7 @@ const DEFAULT_HELP = [
   "Examples:",
   '{"action":"scan"}',
   '{"action":"graph","paths":["src/"]}',
-  '{"action":"add","filePath":"src/app.ts","type":"todo","content":"add retry"}',
+  '{"action":"add","filePath":"src/app.ts","type":"todo","content":"add retry","id":"auth-refresh"}',
   '{"action":"help","topic":"scan"}',
 ].join("\n");
 

--- a/apps/mcp/src/types.ts
+++ b/apps/mcp/src/types.ts
@@ -21,6 +21,7 @@ export const addWaymarkInputSchema = configOptionsSchema.extend({
   filePath: z.string().min(1),
   type: z.string().min(1),
   content: z.string().min(1),
+  id: z.string().min(1).optional(),
   line: z.number().int().positive().optional(),
   signals: z
     .object({
@@ -53,6 +54,7 @@ export const waymarkToolInputShape = {
   filePath: addWaymarkInputSchema.shape.filePath.optional(),
   type: addWaymarkInputSchema.shape.type.optional(),
   content: addWaymarkInputSchema.shape.content.optional(),
+  id: addWaymarkInputSchema.shape.id.optional(),
   line: addWaymarkInputSchema.shape.line.optional(),
   signals: addWaymarkInputSchema.shape.signals.optional(),
   topic: helpInputSchema.shape.topic.optional(),


### PR DESCRIPTION
## Summary\n- add optional `id` input for the MCP add action and include it in the tool schema\n- normalize provided IDs to wikilink form and append them to content\n- reject legacy `wm:` IDs with a clear error\n- update help/docs/examples and add tests for ID handling\n\n## Testing\n- `turbo run lint`\n- `bun run lint:md`\n- `turbo run typecheck`\n- `turbo run test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional ID parameter when creating waymarks; IDs are normalized (lowercased, trimmed) and validated.

* **Documentation**
  * Updated README and help text with example usage showing the new optional ID field.

* **Tests**
  * Added tests covering ID normalization, bracketed-ID handling, trimming, empty-ID rejection, and legacy-format rejection.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->