### PR TITLE
docs: align v1-rc plan with review updates

### DIFF
--- a/.agents/plans/v1-rc/PLAN.md
+++ b/.agents/plans/v1-rc/PLAN.md
@@ -121,6 +121,7 @@ See @blockers.md for implementation details and code samples.
 | Centralize TTY/color detection | `packages/cli/src/utils/terminal.ts` | M | |
 | Document exit codes in `--help` | `packages/cli/src/index.ts` | S | |
 | Decide Commander error/exit contract + align SPEC | `packages/cli/src/index.ts`, `.agents/plans/v1-rc/SPEC.md` | S | |
+| Clarify manual argv parsing requirement in SPEC | `.agents/plans/v1-rc/SPEC.md` | S | |
 | **Commander Quick Wins** | | | |
 | Use `.hideCommand()` for fmt/lint | `packages/cli/src/index.ts` | S | |
 | Add `.choices()` to `--scope` | `packages/cli/src/index.ts` | S | |
@@ -129,6 +130,7 @@ See @blockers.md for implementation details and code samples.
 | Use `program.error()` consistently | Multiple files | M | |
 | Sanitize ANSI/control chars in human output | `packages/cli/src/utils/output.ts` | S | |
 | Harden `wm update --command` (warn + allowlist) | `packages/cli/src/commands/update.ts` | S | |
+| Define `--quiet` precedence with JSON output | `packages/cli/src/utils/output.ts` | S | |
 | **Contract Tests** | | | |
 | Create contracts test directory | `packages/core/src/__tests__/contracts/` | S | |
 | Add ID stability contract tests | `packages/core/src/__tests__/contracts/ids.test.ts` | M | |
@@ -143,6 +145,7 @@ See @blockers.md for implementation details and code samples.
 - [ ] `wm --no-input` fails fast when input required
 - [ ] `wm find | cat` produces no ANSI codes
 - [ ] `NO_COLOR=1 wm find` produces no ANSI codes
+- [ ] `wm find --json --quiet` still emits JSON (quiet only affects human output)
 - [ ] Ctrl+C exits cleanly with code 130
 - [ ] Contract tests prevent regressions in ID generation and relations
 
@@ -279,11 +282,12 @@ Phases must be completed in order (P0 before P1, etc.) because:
 
 ### Per-Task Workflow
 
-1. Create branch: `git checkout -b fix/p0-deterministic-ids`
+1. Graphite-synced repos: start with `gt log`; non-Graphite: `git checkout -b fix/p0-deterministic-ids`
 2. Write failing test first (TDD red phase)
 3. Implement fix (TDD green phase)
 4. Run `bun check:all` before commit
-5. PR with reference to this plan
+5. Stage changes, then commit (`gt create` for Graphite; conventional commit otherwise)
+6. PR with reference to this plan
 
 ### Commit Guidelines
 
@@ -308,8 +312,8 @@ Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
 |-------|--------|------------|
 | P0 | Not Started | 0/10 tasks |
 | P1 | Not Started | 0/10 tasks |
-| P2 | Not Started | 0/18 tasks |
-| P3 | Not Started | 0/24 tasks |
+| P2 | Not Started | 0/20 tasks |
+| P3 | Not Started | 0/25 tasks |
 
 ### Blockers
 
@@ -341,6 +345,8 @@ Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
 | Cache integration | Wire into scan vs remove docs claim | Pending investigation |
 | Spec as source of truth | Formalize derivations (schema/types/help) in CI | Pending design |
 | Mention parsing edge cases | Align mention parsing to spec to avoid false triggers | Pending spec review |
+| Skill manifest shape | `index.json` top-level vs `structure` wrapper | Pending alignment |
+| `wm skill path` output | Return directory vs SKILL.md file path | Pending decision |
 
 ---
 
@@ -354,3 +360,9 @@ Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
 - @skill-command.md - `wm skill` command design (problem analysis, CLI interface)
 - @skill-structure.md - Modular skill file structure (supersedes monolithic approach)
 - `/Users/mg/Developer/outfitter/waymark/.scratch/gold-standard-synthesis.md` - Source synthesis
+- `/Users/mg/Developer/outfitter/waymark/.scratch/20260108-fresh-eyes-review.md` - Fresh-eyes review notes
+- `/Users/mg/Developer/outfitter/waymark/.scratch/gold-standard-recommendations-a.md` - Review recommendations (A)
+- `/Users/mg/Developer/outfitter/waymark/.scratch/gold-standard-recommendations-b.md` - Review recommendations (B)
+- `/Users/mg/Developer/outfitter/waymark/.scratch/gold-standard-recommendations-c.md` - Review recommendations (C)
+- `/Users/mg/Developer/outfitter/waymark/.scratch/20260108-rc-plan-review.md` - Plan review deltas
+- `/Users/mg/Developer/outfitter/waymark/.scratch/20260108-rc-plan-opportunities.md` - Additional opportunity backlog

--- a/.agents/plans/v1-rc/PLAN.md
+++ b/.agents/plans/v1-rc/PLAN.md
@@ -3,7 +3,7 @@
 # Waymark v1.0-RC Implementation Plan
 
 **Created:** 2026-01-08
-**Derived from:** SPEC.md, gold-standard-synthesis, fresh-eyes-review
+**Derived from:** SPEC.md, gold-standard-synthesis, fresh-eyes-review, 20260108-rc-plan-review, 20260108-rc-plan-opportunities
 **Status:** Ready for execution
 
 ## Overview
@@ -55,7 +55,7 @@ This plan synthesizes findings from three independent senior developer reviews a
 ### Detailed Requirements
 
 See @blockers.md for implementation details and code samples.
-<!-- note ::: block comment tests must assert `commentLeader === "/*"` or add `commentStyle` to ParsedHeader ref:#docs/plan/v1-rc/p0-block-comments #docs/plan #docs -->
+<!-- note ::: block comment tests assert `commentLeader === "/*"` (no new `commentStyle` field) ref:#docs/plan/v1-rc/p0-block-comments #docs/plan #docs -->
 
 ---
 
@@ -215,7 +215,7 @@ See @cli-improvements.md for exit code taxonomy, TTY handling, and Commander mig
 See @documentation.md for specific claims to fix.
 See @skill-structure.md for modular skill architecture.
 See @skill-command.md for CLI interface design.
-<!-- note ::: standardize on `wm skill show <section>`; remove `--section` references across docs/tests ref:#docs/plan/v1-rc/skills-cli #docs/plan #docs -->
+<!-- done ::: standardized on `wm skill show <section>`; `--section` references removed from docs ref:#docs/plan/v1-rc/skills-cli #docs/plan #docs -->
 
 ---
 
@@ -337,16 +337,19 @@ Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
 | 2026-01-08 | Schema coverage for all outputs (P1) | External tools need stable programmatic contracts |
 | 2026-01-08 | Unified output adapter (P1) | Consistent stdout/stderr routing, JSON/quiet mode enforcement |
 | 2026-01-08 | Contract test suite (P2) | Prevent regressions in IDs/relations across releases |
+| 2026-01-08 | `wm skill show <section>` subcommand | Matches CLI conventions; more discoverable than `--section` flag |
+| 2026-01-08 | Keep `examples/` separate from `references/` | Semantic separation; plan DoD expects distinct directories |
+| 2026-01-08 | Manifest uses top-level keys | Simpler than `structure` wrapper; `commands`, `references`, `examples` at root |
+| 2026-01-08 | `wm skill path` returns directory | Callers can join paths; more flexible than returning SKILL.md path |
+| 2026-01-08 | No `commentStyle` field in ParsedHeader | YAGNI; test assertions on `commentLeader` sufficient |
+| 2026-01-08 | Enforce `program.error()` for RC | RC = compliance-ready; Commander error contract required |
+| 2026-01-08 | Manual argv parsing allowed for RC | Pragmatic; explicit defer note for P4 cleanup |
+| 2026-01-08 | Cache integration deferred | Docs clarified; not blocking RC scope |
+| 2026-01-08 | Mention parsing tightened for RC | RC = compliance-ready; spec alignment required |
 
 ### Open Decisions (Require Resolution)
 
-| Decision | Options | Status |
-|----------|---------|--------|
-| Cache integration | Wire into scan vs remove docs claim | Pending investigation |
-| Spec as source of truth | Formalize derivations (schema/types/help) in CI | Pending design |
-| Mention parsing edge cases | Align mention parsing to spec to avoid false triggers | Pending spec review |
-| Skill manifest shape | `index.json` top-level vs `structure` wrapper | Pending alignment |
-| `wm skill path` output | Return directory vs SKILL.md file path | Pending decision |
+*All resolved as of 2026-01-08.*
 
 ---
 
@@ -364,5 +367,7 @@ Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
 - `/Users/mg/Developer/outfitter/waymark/.scratch/gold-standard-recommendations-a.md` - Review recommendations (A)
 - `/Users/mg/Developer/outfitter/waymark/.scratch/gold-standard-recommendations-b.md` - Review recommendations (B)
 - `/Users/mg/Developer/outfitter/waymark/.scratch/gold-standard-recommendations-c.md` - Review recommendations (C)
+- `/Users/mg/Developer/outfitter/waymark/.scratch/commander-gap-analysis.md` - CLI gaps and improvements
+- `/Users/mg/Developer/outfitter/waymark/.scratch/file-size-audit-grammar.md` - Grammar file size audit
 - `/Users/mg/Developer/outfitter/waymark/.scratch/20260108-rc-plan-review.md` - Plan review deltas
 - `/Users/mg/Developer/outfitter/waymark/.scratch/20260108-rc-plan-opportunities.md` - Additional opportunity backlog

--- a/.agents/plans/v1-rc/blockers.md
+++ b/.agents/plans/v1-rc/blockers.md
@@ -235,7 +235,7 @@ describe("block comment support", () => {
   it("parses CSS waymarks", () => {
     const result = parseHeader("/* tldr ::: button component styles */");
     expect(result?.type).toBe("tldr");
-    expect(result?.commentStyle).toBe("block");
+    expect(result?.commentLeader).toBe("/*");
   });
 
   it("strips trailing */ from content", () => {

--- a/.agents/plans/v1-rc/cli-improvements.md
+++ b/.agents/plans/v1-rc/cli-improvements.md
@@ -585,9 +585,9 @@ packages/cli/src/commands/skill.ts       # Command handler
 ```bash
 wm skill                         # Show full skill document (markdown)
 wm skill --json                  # Output as parsed JSON
-wm skill --section <name>        # Output specific section
 wm skill list                    # List available sections (commands, references, examples)
-wm skill show <command>          # Show skill info for specific command
+wm skill show <section>          # Show specific section (command or reference)
+wm skill show add                # Show add command documentation
 wm skill show workflows          # Show example workflows
 wm skill show agent-tasks        # Show common agent task patterns
 wm skill show batch-operations   # Show batch operation recipes

--- a/.agents/plans/v1-rc/skill-command.md
+++ b/.agents/plans/v1-rc/skill-command.md
@@ -289,10 +289,9 @@ git diff --name-only --cached | xargs wm fmt --write
 ```bash
 wm skill                    # Show full skill document (markdown)
 wm skill --json             # Output as JSON with parsed sections
-wm skill --section <name>   # Output specific section
+wm skill show <section>     # Output specific section (command or reference)
 wm skill list               # List available sections
-wm skill show <command>     # Show skill info for specific command
-wm skill path               # Print path to skill file (for agents to read directly)
+wm skill path               # Print path to skill directory (for agents to read directly)
 ```
 
 #### Command Interface
@@ -309,7 +308,6 @@ export function registerSkillCommand(program: Command): void {
     .command("skill")
     .description("Show agent-facing skill documentation")
     .option("--json", "Output as parsed JSON")
-    .option("--section <name>", "Show specific section")
     .action(handleSkill);
 
   skill
@@ -318,14 +316,14 @@ export function registerSkillCommand(program: Command): void {
     .action(handleSkillList);
 
   skill
-    .command("show <command>")
-    .description("Show skill info for a specific command")
+    .command("show <section>")
+    .description("Show specific section (command or reference)")
     .option("--json", "Output as JSON")
     .action(handleSkillShow);
 
   skill
     .command("path")
-    .description("Print path to skill file")
+    .description("Print path to skill directory")
     .action(handleSkillPath);
 }
 ```
@@ -366,10 +364,10 @@ Waymarks are structured comments using the `:::` sigil...
 }
 ```
 
-**Section (`--section commands.add`)**:
+**Show section (`wm skill show add`)**:
 
 ```text
-$ wm skill --section commands.add
+$ wm skill show add
 
 ### add
 
@@ -597,19 +595,19 @@ specific command help.
 
 ---
 
-## Open Questions
+## Resolved Questions
 
 1. **Skill versioning**: Should skill version match CLI version exactly?
-   - Recommendation: Yes, they ship together
+   - Decision: Yes, they ship together
 
 2. **Localization**: Support translated skills?
-   - Recommendation: Not for v1, English only
+   - Decision: Not for v1, English only
 
 3. **Skill discovery**: Should `wm --help` mention `wm skill`?
-   - Recommendation: Yes, add "For agent usage, see: wm skill"
+   - Decision: Yes, add "For agent usage, see: wm skill"
 
 4. **Deprecation timeline**: How long to keep `--prompt`?
-   - Recommendation: Warn for 2 minor versions, remove in next major
+   - Decision: Warn for 2 minor versions, remove in next major
 
 ---
 

--- a/.agents/plans/v1-rc/skill-structure.md
+++ b/.agents/plans/v1-rc/skill-structure.md
@@ -114,8 +114,8 @@ commands:
 ## Getting More Help
 
 - Command details: `wm skill show <command>` or `wm <command> --help`
-- JSON schemas: `wm skill --section schemas`
-- Workflows: `wm skill --section workflows`
+- JSON schemas: `wm skill show schemas`
+- Workflows: `wm skill show workflows`
 ```
 
 ---
@@ -266,18 +266,6 @@ key = value
 - Error message patterns
 - Recovery strategies
 - Debugging steps
-
-#### workflows.md
-
-**Purpose:** Multi-command workflow recipes for common tasks.
-
-**Content:**
-
-- Pre-commit validation workflow
-- CI integration workflow
-- Batch migration workflow
-- Codebase audit workflow
-- Agent task delegation workflow
 
 ---
 
@@ -455,19 +443,19 @@ wm skill path
 
 ---
 
-## Open Questions
+## Resolved Questions
 
 1. **Should command aliases be in separate files?**
-   - Recommendation: No, include aliases in frontmatter of primary command
+   - Decision: No, include aliases in frontmatter of primary command
 
 2. **How to handle graph mode documentation?**
-   - Recommendation: Document in `commands/find.md` with `--graph` section
+   - Decision: Document in `commands/find.md` with `--graph` section
 
 3. **Should we include examples in a separate directory?**
-   - Recommendation: No, keep examples inline in command docs. The `references/workflows.md` handles complex multi-command scenarios.
+   - Decision: Yes, keep `examples/` separate from `references/` for semantic clarity
 
 4. **Where does configuration documentation live?**
-   - Recommendation: Each command doc references config relevant to it. A future `references/config.md` could provide complete reference.
+   - Decision: Each command doc references config relevant to it. A future `references/config.md` could provide complete reference.
 
 ---
 


### PR DESCRIPTION
## Summary
- Align v1-rc plan statuses and milestones with review feedback.
- Update plan references across related v1-rc docs (blockers, skill docs).
- Refresh links and wording to match the latest plan structure.

## Testing
- bun check:all
