### PR TITLE
fix(mcp): cap todos results + tighten id tests

### DIFF
--- a/apps/mcp/src/resources/todos.test.ts
+++ b/apps/mcp/src/resources/todos.test.ts
@@ -5,10 +5,7 @@ import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 
-import {
-  MAX_TODOS_RESULTS,
-  handleTodosResource,
-} from "./todos";
+import { handleTodosResource, MAX_TODOS_RESULTS } from "./todos";
 
 const EXTRA_TODO_COUNT = 1;
 const SMALL_TODO_COUNT = 2;
@@ -68,13 +65,11 @@ describe("handleTodosResource", () => {
     const workspace = await mkdtemp(join(tmpdir(), "waymark-mcp-todos-"));
     const todoCount = MAX_TODOS_RESULTS + EXTRA_TODO_COUNT;
     try {
-      const lines = Array.from({ length: todoCount }, (_, index) =>
-        `// todo ::: task ${index + TASK_NUMBER_OFFSET}`
+      const lines = Array.from(
+        { length: todoCount },
+        (_, index) => `// todo ::: task ${index + TASK_NUMBER_OFFSET}`
       );
-      await writeFixture(
-        join(workspace, "src", "many.ts"),
-        lines.join("\n")
-      );
+      await writeFixture(join(workspace, "src", "many.ts"), lines.join("\n"));
 
       const response = await withWorkspace(workspace, () =>
         handleTodosResource()

--- a/apps/mcp/src/resources/todos.test.ts
+++ b/apps/mcp/src/resources/todos.test.ts
@@ -1,0 +1,94 @@
+// tldr ::: tests for MCP todos resource truncation and output shape
+
+import { describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+
+import {
+  MAX_TODOS_RESULTS,
+  handleTodosResource,
+} from "./todos";
+
+const EXTRA_TODO_COUNT = 1;
+const SMALL_TODO_COUNT = 2;
+const TASK_NUMBER_OFFSET = 1;
+
+async function withWorkspace<T>(
+  workspace: string,
+  action: () => Promise<T>
+): Promise<T> {
+  const previousCwd = process.cwd();
+  process.chdir(workspace);
+  try {
+    return await action();
+  } finally {
+    process.chdir(previousCwd);
+  }
+}
+
+async function writeFixture(path: string, contents: string): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, contents, "utf8");
+}
+
+describe("handleTodosResource", () => {
+  test("returns todos without truncation", async () => {
+    const workspace = await mkdtemp(join(tmpdir(), "waymark-mcp-todos-"));
+    try {
+      await writeFixture(
+        join(workspace, "src", "sample.ts"),
+        [
+          "// todo ::: add telemetry",
+          "// note ::: ignored for todos",
+          "// todo ::: add retries",
+          "",
+        ].join("\n")
+      );
+
+      const response = await withWorkspace(workspace, () =>
+        handleTodosResource()
+      );
+      const text = String(response.contents?.[0]?.text ?? "");
+      const payload = JSON.parse(text) as {
+        todos: Array<{ content: string }>;
+        truncated: boolean;
+      };
+
+      expect(payload.truncated).toBe(false);
+      expect(payload.todos).toHaveLength(SMALL_TODO_COUNT);
+      expect(payload.todos[0]?.content).toContain("add telemetry");
+      expect(payload.todos[1]?.content).toContain("add retries");
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+
+  test("truncates when todo count exceeds max", async () => {
+    const workspace = await mkdtemp(join(tmpdir(), "waymark-mcp-todos-"));
+    const todoCount = MAX_TODOS_RESULTS + EXTRA_TODO_COUNT;
+    try {
+      const lines = Array.from({ length: todoCount }, (_, index) =>
+        `// todo ::: task ${index + TASK_NUMBER_OFFSET}`
+      );
+      await writeFixture(
+        join(workspace, "src", "many.ts"),
+        lines.join("\n")
+      );
+
+      const response = await withWorkspace(workspace, () =>
+        handleTodosResource()
+      );
+      const text = String(response.contents?.[0]?.text ?? "");
+      const payload = JSON.parse(text) as {
+        todos: Array<{ content: string }>;
+        truncated: boolean;
+      };
+
+      expect(payload.truncated).toBe(true);
+      expect(payload.todos).toHaveLength(MAX_TODOS_RESULTS);
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+});

--- a/apps/mcp/src/resources/todos.ts
+++ b/apps/mcp/src/resources/todos.ts
@@ -11,23 +11,24 @@ import {
   normalizePathForOutput,
 } from "../utils/filesystem";
 
+export const MAX_TODOS_CONCURRENCY = 8;
+export const MAX_TODOS_RESULTS = 2000;
+
 export async function handleTodosResource() {
-  const { records } = await collectRecords(["."], {});
-  const todos = records
-    .filter((record) => record.type.toLowerCase() === MARKERS.todo)
-    .map((record) => ({
-      file: record.file,
-      line: record.startLine,
-      content: record.contentText,
-      raw: record.raw,
-    }));
+  const { records, truncated } = await collectRecords(["."], {});
+  const todos = records.map((record) => ({
+    file: record.file,
+    line: record.startLine,
+    content: record.contentText,
+    raw: record.raw,
+  }));
 
   return {
     contents: [
       {
         uri: TODOS_RESOURCE_URI,
         mimeType: "application/json",
-        text: JSON.stringify(todos, null, 2),
+        text: JSON.stringify({ todos, truncated }, null, 2),
       },
     ],
   };
@@ -36,10 +37,10 @@ export async function handleTodosResource() {
 async function collectRecords(
   inputs: string[],
   options: { configPath?: string; scope?: string }
-): Promise<{ records: WaymarkRecord[] }> {
+): Promise<{ records: WaymarkRecord[]; truncated: boolean }> {
   let filePaths = await expandInputPaths(inputs);
   if (filePaths.length === 0) {
-    return { records: [] };
+    return { records: [], truncated: false };
   }
 
   const config = await loadConfig({
@@ -50,18 +51,42 @@ async function collectRecords(
   filePaths = applySkipPaths(filePaths, config.skipPaths ?? []);
 
   const records: WaymarkRecord[] = [];
-  await Promise.all(
-    filePaths.map(async (filePath) => {
+  let truncated = false;
+
+  await processWithLimit(
+    filePaths,
+    MAX_TODOS_CONCURRENCY,
+    async (filePath) => {
+      if (records.length >= MAX_TODOS_RESULTS) {
+        truncated = true;
+        return;
+      }
       const source = await readFile(filePath, "utf8").catch(() => null);
       if (typeof source !== "string") {
         return;
       }
       const parsed = parse(source, { file: normalizePathForOutput(filePath) });
-      records.push(...parsed);
-    })
+      const todos = parsed.filter(
+        (record) => record.type.toLowerCase() === MARKERS.todo
+      );
+      if (todos.length === 0) {
+        return;
+      }
+      const remaining = MAX_TODOS_RESULTS - records.length;
+      if (remaining <= 0) {
+        truncated = true;
+        return;
+      }
+      if (todos.length > remaining) {
+        records.push(...todos.slice(0, remaining));
+        truncated = true;
+        return;
+      }
+      records.push(...todos);
+    }
   );
 
-  return { records };
+  return { records, truncated };
 }
 
 export const todosResourceDefinition = {
@@ -70,3 +95,25 @@ export const todosResourceDefinition = {
   description: "All todo waymarks discovered in the repository",
   mimeType: "application/json",
 };
+
+async function processWithLimit(
+  filePaths: string[],
+  limit: number,
+  handler: (filePath: string) => Promise<void>
+): Promise<void> {
+  if (filePaths.length === 0) {
+    return;
+  }
+  const queue = [...filePaths];
+  const workerCount = Math.min(limit, queue.length);
+  const workers = Array.from({ length: workerCount }, async () => {
+    while (queue.length > 0) {
+      const filePath = queue.shift();
+      if (!filePath) {
+        return;
+      }
+      await handler(filePath);
+    }
+  });
+  await Promise.all(workers);
+}

--- a/apps/mcp/src/resources/todos.ts
+++ b/apps/mcp/src/resources/todos.ts
@@ -53,38 +53,34 @@ async function collectRecords(
   const records: WaymarkRecord[] = [];
   let truncated = false;
 
-  await processWithLimit(
-    filePaths,
-    MAX_TODOS_CONCURRENCY,
-    async (filePath) => {
-      if (records.length >= MAX_TODOS_RESULTS) {
-        truncated = true;
-        return;
-      }
-      const source = await readFile(filePath, "utf8").catch(() => null);
-      if (typeof source !== "string") {
-        return;
-      }
-      const parsed = parse(source, { file: normalizePathForOutput(filePath) });
-      const todos = parsed.filter(
-        (record) => record.type.toLowerCase() === MARKERS.todo
-      );
-      if (todos.length === 0) {
-        return;
-      }
-      const remaining = MAX_TODOS_RESULTS - records.length;
-      if (remaining <= 0) {
-        truncated = true;
-        return;
-      }
-      if (todos.length > remaining) {
-        records.push(...todos.slice(0, remaining));
-        truncated = true;
-        return;
-      }
-      records.push(...todos);
+  await processWithLimit(filePaths, MAX_TODOS_CONCURRENCY, async (filePath) => {
+    if (records.length >= MAX_TODOS_RESULTS) {
+      truncated = true;
+      return;
     }
-  );
+    const source = await readFile(filePath, "utf8").catch(() => null);
+    if (typeof source !== "string") {
+      return;
+    }
+    const parsed = parse(source, { file: normalizePathForOutput(filePath) });
+    const todos = parsed.filter(
+      (record) => record.type.toLowerCase() === MARKERS.todo
+    );
+    if (todos.length === 0) {
+      return;
+    }
+    const remaining = MAX_TODOS_RESULTS - records.length;
+    if (remaining <= 0) {
+      truncated = true;
+      return;
+    }
+    if (todos.length > remaining) {
+      records.push(...todos.slice(0, remaining));
+      truncated = true;
+      return;
+    }
+    records.push(...todos);
+  });
 
   return { records, truncated };
 }

--- a/packages/core/src/ids.test.ts
+++ b/packages/core/src/ids.test.ts
@@ -12,6 +12,7 @@ import {
   WaymarkIdManager,
   type WaymarkIdMetadata,
 } from "./ids.ts";
+import type { WaymarkIdConfig } from "./types.ts";
 
 const DEFAULT_ID_LENGTH = 7;
 
@@ -35,7 +36,7 @@ describe("WaymarkIdManager", () => {
     const workspaceB = await createWorkspace();
 
     try {
-      const idConfig = { ...DEFAULT_CONFIG.ids, mode: "auto" };
+      const idConfig: WaymarkIdConfig = { ...DEFAULT_CONFIG.ids, mode: "auto" };
       const metadata: WaymarkIdMetadata = {
         file: "/repo/src/app.ts",
         line: 12,


### PR DESCRIPTION
## Summary
- Cap todos results and concurrency in the MCP resource.
- Add/adjust todos resource tests and tighten ID test typing.
- Normalize todos resource formatting for consistency.

## Testing
- bun check:all


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added result limit handling for todo queries with truncation detection to indicate when results are capped
  * Improved concurrent processing for better performance when handling large todo collections

* **Tests**
  * Added comprehensive unit tests to validate todo resource output and truncation behavior across different scenarios

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->