### PR TITLE
feat: add JSON schema validation with Ajv

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,11 +1,14 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "waymark",
       "devDependencies": {
         "@biomejs/biome": "^2.2.4",
         "@types/bun": "^1.2.22",
+        "ajv": "8.17.1",
+        "ajv-formats": "3.0.1",
         "lefthook": "^1.13.4",
         "markdownlint-cli2": "^0.18.1",
         "pino": "9.13.0",
@@ -307,7 +310,9 @@
 
     "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
 
-    "ajv": ["ajv@6.12.6", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g=="],
+    "ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
+
+    "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
 
     "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
@@ -443,6 +448,8 @@
 
     "fast-safe-stringify": ["fast-safe-stringify@2.1.1", "", {}, "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="],
 
+    "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
+
     "fastq": ["fastq@1.19.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ=="],
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
@@ -513,7 +520,7 @@
 
     "js-yaml": ["js-yaml@4.1.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA=="],
 
-    "json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
+    "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "jsonc-parser": ["jsonc-parser@3.3.1", "", {}, "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ=="],
 
@@ -701,6 +708,8 @@
 
     "regexp-tree": ["regexp-tree@0.1.27", "", { "bin": { "regexp-tree": "bin/regexp-tree" } }, "sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA=="],
 
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
     "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
 
     "rollup": ["rollup@4.52.2", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.52.2", "@rollup/rollup-android-arm64": "4.52.2", "@rollup/rollup-darwin-arm64": "4.52.2", "@rollup/rollup-darwin-x64": "4.52.2", "@rollup/rollup-freebsd-arm64": "4.52.2", "@rollup/rollup-freebsd-x64": "4.52.2", "@rollup/rollup-linux-arm-gnueabihf": "4.52.2", "@rollup/rollup-linux-arm-musleabihf": "4.52.2", "@rollup/rollup-linux-arm64-gnu": "4.52.2", "@rollup/rollup-linux-arm64-musl": "4.52.2", "@rollup/rollup-linux-loong64-gnu": "4.52.2", "@rollup/rollup-linux-ppc64-gnu": "4.52.2", "@rollup/rollup-linux-riscv64-gnu": "4.52.2", "@rollup/rollup-linux-riscv64-musl": "4.52.2", "@rollup/rollup-linux-s390x-gnu": "4.52.2", "@rollup/rollup-linux-x64-gnu": "4.52.2", "@rollup/rollup-linux-x64-musl": "4.52.2", "@rollup/rollup-openharmony-arm64": "4.52.2", "@rollup/rollup-win32-arm64-msvc": "4.52.2", "@rollup/rollup-win32-ia32-msvc": "4.52.2", "@rollup/rollup-win32-x64-gnu": "4.52.2", "@rollup/rollup-win32-x64-msvc": "4.52.2", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-I25/2QgoROE1vYV+NQ1En9T9UFB9Cmfm2CJ83zZOlaDpvz29wGQSZXWKw7MiNXau7wYgB/T9fVIdIuEQ+KbiiA=="],
@@ -857,6 +866,8 @@
 
     "zod-to-json-schema": ["zod-to-json-schema@3.24.6", "", { "peerDependencies": { "zod": "^3.24.1" } }, "sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg=="],
 
+    "@modelcontextprotocol/sdk/ajv": ["ajv@6.12.6", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g=="],
+
     "@modelcontextprotocol/sdk/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "@waymarks/cli/pino": ["pino@9.12.0", "", { "dependencies": { "atomic-sleep": "^1.0.0", "on-exit-leak-free": "^2.1.0", "pino-abstract-transport": "^2.0.0", "pino-std-serializers": "^7.0.0", "process-warning": "^5.0.0", "quick-format-unescaped": "^4.0.3", "real-require": "^0.2.0", "safe-stable-stringify": "^2.3.1", "slow-redact": "^0.3.0", "sonic-boom": "^4.0.1", "thread-stream": "^3.0.0" }, "bin": { "pino": "bin.js" } }, "sha512-0Gd0OezGvqtqMwgYxpL7P0pSHHzTJ0Lx992h+mNlMtRVfNnqweWmf0JmRWk5gJzHalyd2mxTzKjhiNbGS2Ztfw=="],
@@ -880,5 +891,7 @@
     "vitest/tinyexec": ["tinyexec@0.3.2", "", {}, "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA=="],
 
     "zod-to-json-schema/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@modelcontextprotocol/sdk/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,6 +37,8 @@
   "devDependencies": {
     "@biomejs/biome": "^2.2.4",
     "@types/bun": "^1.2.22",
+    "ajv": "8.17.1",
+    "ajv-formats": "3.0.1",
     "lefthook": "^1.13.4",
     "markdownlint-cli2": "^0.18.1",
     "pino": "9.13.0",

--- a/packages/cli/src/schema-conformance.test.ts
+++ b/packages/cli/src/schema-conformance.test.ts
@@ -1,0 +1,121 @@
+// tldr ::: validate CLI JSON outputs against published JSON schemas
+
+import { describe, test } from "bun:test";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { resolveConfig } from "@waymarks/core";
+import Ajv from "ajv/dist/2020";
+import addFormats from "ajv-formats";
+import { runDoctorCommand } from "./commands/doctor";
+import { lintFiles } from "./commands/lint";
+import { scanRecords } from "./commands/scan";
+import type { CommandContext } from "./types";
+import { renderRecords } from "./utils/output";
+
+type JsonRecord = Record<string, unknown>;
+
+type TempFile = {
+  dir: string;
+  file: string;
+  cleanup: () => Promise<void>;
+};
+
+const rootDir = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
+const schemasDir = join(rootDir, "schemas");
+
+async function loadSchema(name: string): Promise<JsonRecord> {
+  const raw = await readFile(join(schemasDir, name), "utf8");
+  return JSON.parse(raw) as JsonRecord;
+}
+
+async function createValidator(): Promise<Ajv> {
+  const ajv = new Ajv({ allErrors: true, strict: false });
+  addFormats(ajv);
+
+  const schemas = await Promise.all([
+    loadSchema("waymark-record.schema.json"),
+    loadSchema("waymark-scan-result.schema.json"),
+    loadSchema("lint-report.schema.json"),
+    loadSchema("doctor-report.schema.json"),
+  ]);
+
+  for (const schema of schemas) {
+    ajv.addSchema(schema);
+  }
+
+  return ajv;
+}
+
+function assertValid(ajv: Ajv, schemaId: string, payload: unknown): void {
+  const validate = ajv.getSchema(schemaId);
+  if (!validate) {
+    throw new Error(`Schema not registered: ${schemaId}`);
+  }
+  const valid = validate(payload);
+  if (!valid) {
+    throw new Error(
+      `${schemaId} validation failed: ${ajv.errorsText(validate.errors)}`
+    );
+  }
+}
+
+async function withTempFile(content: string): Promise<TempFile> {
+  const dir = await mkdtemp(join(tmpdir(), "waymark-schema-"));
+  const file = join(dir, "sample.ts");
+  await writeFile(file, content, "utf8");
+  return {
+    dir,
+    file,
+    cleanup: () => rm(dir, { recursive: true, force: true }),
+  };
+}
+
+describe("Schema conformance", () => {
+  test("scan output matches scan-result schema", async () => {
+    const { file, cleanup } = await withTempFile("// todo ::: schema check\n");
+    const config = resolveConfig();
+    const records = await scanRecords([file], config);
+    const output = renderRecords(records, "json");
+    const parsed = JSON.parse(output) as unknown;
+    const ajv = await createValidator();
+    assertValid(
+      ajv,
+      "https://outfitter.dev/schemas/waymark-scan-result.schema.json",
+      parsed
+    );
+    await cleanup();
+  });
+
+  test("lint report matches lint-report schema", async () => {
+    const { file, cleanup } = await withTempFile("// unknown ::: lint me\n");
+    const config = resolveConfig();
+    const report = await lintFiles([file], config.allowTypes, config);
+    const ajv = await createValidator();
+    assertValid(
+      ajv,
+      "https://outfitter.dev/schemas/lint-report.schema.json",
+      report
+    );
+    await cleanup();
+  });
+
+  test("doctor report matches doctor-report schema", async () => {
+    const { dir, cleanup } = await withTempFile("// todo ::: doctor check\n");
+    const config = resolveConfig();
+    const context: CommandContext = {
+      config,
+      globalOptions: {},
+      workspaceRoot: dir,
+    };
+    const report = await runDoctorCommand(context, { json: true });
+    const ajv = await createValidator();
+    assertValid(
+      ajv,
+      "https://outfitter.dev/schemas/doctor-report.schema.json",
+      report
+    );
+    await cleanup();
+  });
+});

--- a/packages/cli/src/utils/output.ts
+++ b/packages/cli/src/utils/output.ts
@@ -10,6 +10,12 @@ export type ScanOutputFormat = "text" | "json" | "jsonl";
 function cleanRecord(record: WaymarkRecord): Partial<WaymarkRecord> {
   const cleaned: Partial<WaymarkRecord> = { ...record };
 
+  if (cleaned.signals) {
+    const { current: _current, ...signals } = cleaned.signals;
+    // note ::: omit deprecated `current` signal from JSON output
+    cleaned.signals = signals;
+  }
+
   // Remove empty arrays
   if (Array.isArray(cleaned.relations) && cleaned.relations.length === 0) {
     cleaned.relations = undefined as unknown as WaymarkRecord["relations"];

--- a/schemas/doctor-report.schema.json
+++ b/schemas/doctor-report.schema.json
@@ -1,0 +1,113 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://outfitter.dev/schemas/doctor-report.schema.json",
+  "title": "WaymarkDoctorReport",
+  "description": "Health check report from the waymark CLI",
+  "type": "object",
+  "required": ["healthy", "timestamp", "checks", "issues", "summary"],
+  "$defs": {
+    "diagnosticIssue": {
+      "type": "object",
+      "required": ["severity", "category", "message"],
+      "properties": {
+        "severity": {
+          "type": "string",
+          "enum": ["error", "warning", "info"],
+          "description": "Severity of the issue"
+        },
+        "category": {
+          "type": "string",
+          "description": "Issue category"
+        },
+        "message": {
+          "type": "string",
+          "description": "Human-readable issue description"
+        },
+        "file": {
+          "type": "string",
+          "description": "File path associated with the issue"
+        },
+        "line": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Line number associated with the issue"
+        },
+        "suggestion": {
+          "type": "string",
+          "description": "Suggested remediation"
+        }
+      },
+      "additionalProperties": false
+    },
+    "checkResult": {
+      "type": "object",
+      "required": ["category", "name", "passed", "issues"],
+      "properties": {
+        "category": {
+          "type": "string",
+          "description": "Check category"
+        },
+        "name": {
+          "type": "string",
+          "description": "Check name"
+        },
+        "passed": {
+          "type": "boolean",
+          "description": "Whether the check passed"
+        },
+        "issues": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/diagnosticIssue" }
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "properties": {
+    "healthy": {
+      "type": "boolean",
+      "description": "Overall health status"
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Timestamp when the report was generated"
+    },
+    "checks": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/checkResult" }
+    },
+    "issues": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/diagnosticIssue" }
+    },
+    "summary": {
+      "type": "object",
+      "required": ["total", "errors", "warnings", "infos"],
+      "properties": {
+        "total": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Total number of issues"
+        },
+        "errors": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Total number of error issues"
+        },
+        "warnings": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Total number of warning issues"
+        },
+        "infos": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Total number of info issues"
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/lint-report.schema.json
+++ b/schemas/lint-report.schema.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://outfitter.dev/schemas/lint-report.schema.json",
+  "title": "WaymarkLintReport",
+  "description": "Lint report from the waymark CLI",
+  "type": "object",
+  "required": ["issues"],
+  "properties": {
+    "issues": {
+      "type": "array",
+      "description": "Lint issues found in the scanned files",
+      "items": {
+        "type": "object",
+        "required": ["file", "line", "rule", "severity", "message"],
+        "properties": {
+          "file": {
+            "type": "string",
+            "description": "File path where the issue was found"
+          },
+          "line": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Line number where the issue was found"
+          },
+          "rule": {
+            "type": "string",
+            "description": "Lint rule identifier"
+          },
+          "severity": {
+            "type": "string",
+            "enum": ["warn", "error"],
+            "description": "Severity of the lint issue"
+          },
+          "message": {
+            "type": "string",
+            "description": "Human-readable description of the issue"
+          },
+          "type": {
+            "type": "string",
+            "description": "Waymark marker type associated with the issue"
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/scan-result.schema.json
+++ b/schemas/scan-result.schema.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://outfitter.dev/schemas/scan-result.schema.json",
+  "$ref": "waymark-scan-result.schema.json"
+}

--- a/schemas/waymark-scan-result.schema.json
+++ b/schemas/waymark-scan-result.schema.json
@@ -2,76 +2,9 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://outfitter.dev/schemas/waymark-scan-result.schema.json",
   "title": "WaymarkScanResult",
-  "description": "Result of scanning files for waymarks",
-  "type": "object",
-  "required": ["records", "stats"],
-  "properties": {
-    "records": {
-      "type": "array",
-      "description": "All waymark records found",
-      "items": {
-        "$ref": "waymark-record.schema.json"
-      }
-    },
-    "stats": {
-      "type": "object",
-      "description": "Statistics about the scan",
-      "required": ["filesScanned", "totalWaymarks", "markerCounts"],
-      "properties": {
-        "filesScanned": {
-          "type": "integer",
-          "minimum": 0,
-          "description": "Number of files scanned"
-        },
-        "totalWaymarks": {
-          "type": "integer",
-          "minimum": 0,
-          "description": "Total number of waymarks found"
-        },
-        "markerCounts": {
-          "type": "object",
-          "description": "Count of waymarks by marker type",
-          "additionalProperties": {
-            "type": "integer",
-            "minimum": 0
-          }
-        },
-        "scanTimeMs": {
-          "type": "number",
-          "minimum": 0,
-          "description": "Time taken to scan in milliseconds"
-        }
-      },
-      "additionalProperties": false
-    },
-    "errors": {
-      "type": "array",
-      "description": "Errors encountered during scanning",
-      "items": {
-        "type": "object",
-        "required": ["file", "message"],
-        "properties": {
-          "file": {
-            "type": "string",
-            "description": "File where error occurred"
-          },
-          "line": {
-            "type": "integer",
-            "minimum": 1,
-            "description": "Line number where error occurred"
-          },
-          "message": {
-            "type": "string",
-            "description": "Error message"
-          },
-          "code": {
-            "type": "string",
-            "description": "Error code (e.g., 'WM001')"
-          }
-        },
-        "additionalProperties": false
-      }
-    }
-  },
-  "additionalProperties": false
+  "description": "JSON array of waymark records from a scan",
+  "type": "array",
+  "items": {
+    "$ref": "waymark-record.schema.json"
+  }
 }

--- a/scripts/check-spec-alignment.ts
+++ b/scripts/check-spec-alignment.ts
@@ -82,9 +82,7 @@ const schemaRelationKinds = readEnum(schema, [
   "kind",
   "enum",
 ]);
-if (!schemaRelationKinds) {
-  errors.push("Missing relation kind enum in waymark-record.schema.json.");
-} else {
+if (schemaRelationKinds) {
   const runtimeKinds = normalize(Object.values(RELATION_KIND_MAP));
   const schemaKinds = normalize(schemaRelationKinds);
   if (!arraysEqual(schemaKinds, runtimeKinds)) {
@@ -94,6 +92,8 @@ if (!schemaRelationKinds) {
       )}] runtime=[${runtimeKinds.join(", ")}].`
     );
   }
+} else {
+  errors.push("Missing relation kind enum in waymark-record.schema.json.");
 }
 
 const schemaMentionPattern = readString(schema, [


### PR DESCRIPTION
# Add JSON Schema Validation for CLI Outputs

This PR adds JSON schema validation for the CLI's output formats to ensure they conform to our published schemas. Key changes include:

- Added schema conformance tests that validate CLI outputs against JSON schemas
- Added new JSON schemas for doctor reports and lint reports
- Updated the waymark-scan-result schema to match the current output format
- Added Ajv and Ajv-formats as dev dependencies for schema validation
- Fixed the output formatter to omit deprecated `current` signal from JSON output
- Improved schema alignment checking in the existing scripts

The tests ensure that the scan, lint, and doctor commands produce output that conforms to our published schemas, providing better guarantees for API consumers.