### PR TITLE
feat(cli): add support for custom package managers in update command

### DIFF
--- a/packages/cli/src/commands/update.test.ts
+++ b/packages/cli/src/commands/update.test.ts
@@ -54,4 +54,31 @@ describe("runUpdateCommand", () => {
 
     __setChildRunner();
   });
+
+  test("rejects unsupported update commands", async () => {
+    const result = await runUpdateCommand({ command: "rm" });
+    expect(result.exitCode).toBe(1);
+    expect(result.skipped).toBe(true);
+    expect(result.message).toContain("Unsupported update command");
+  });
+
+  test("accepts allowed update command override", async () => {
+    const calls: Array<{ command: string; args: string[] }> = [];
+    __setChildRunner((command, args) => {
+      calls.push({ command, args });
+      return Promise.resolve(0);
+    });
+
+    const result = await runUpdateCommand({
+      command: "pnpm",
+      force: true,
+      yes: true,
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(calls[0]?.command).toBe("pnpm");
+    expect(calls[0]?.args).toEqual(["install", "-g", "@waymarks/cli"]);
+
+    __setChildRunner();
+  });
 });


### PR DESCRIPTION
# Enhanced Update Command with Support for Multiple Package Managers

This PR improves the CLI's update command by adding support for multiple package managers beyond npm. The update command now:

- Adds an allowlist of supported package managers: npm, pnpm, bun, and yarn
- Validates user-provided package manager commands against the allowlist
- Refactors the update logic into smaller, more focused functions for better maintainability
- Improves error handling and user feedback for invalid commands
- Adds comprehensive tests for the new functionality

The changes make the update process more flexible for users with different package manager preferences while maintaining security by restricting commands to a known safe set.