### PR TITLE
test(core): add contract tests for ID generation and relation normalization

### DIFF
--- a/packages/core/src/__tests__/contracts/ids.test.ts
+++ b/packages/core/src/__tests__/contracts/ids.test.ts
@@ -1,0 +1,95 @@
+// tldr ::: contract coverage for deterministic waymark ID generation
+
+import { describe, expect, it } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { DEFAULT_CONFIG } from "../../config.ts";
+import { JsonIdIndex } from "../../id-index.ts";
+import {
+  fingerprintContent,
+  fingerprintContext,
+  WaymarkIdManager,
+  type WaymarkIdMetadata,
+} from "../../ids.ts";
+
+const WORKSPACE_PREFIX = "waymark-contract-ids-";
+
+function createWorkspace(): Promise<string> {
+  return mkdtemp(join(tmpdir(), WORKSPACE_PREFIX));
+}
+
+async function cleanupWorkspace(path: string | undefined): Promise<void> {
+  if (path?.startsWith(join(tmpdir(), WORKSPACE_PREFIX))) {
+    await rm(path, { recursive: true, force: true });
+  }
+}
+
+function buildMetadata(): WaymarkIdMetadata {
+  const content = "review roundtrip contracts";
+  return {
+    file: "/repo/src/contract.ts",
+    line: 42,
+    type: "todo",
+    content,
+    contentHash: fingerprintContent(content),
+    contextHash: fingerprintContext("/repo/src/contract.ts:42"),
+    sourceType: "cli",
+  };
+}
+
+describe("ID contracts", () => {
+  it("produces deterministic IDs across fresh managers", async () => {
+    const workspaceA = await createWorkspace();
+    const workspaceB = await createWorkspace();
+
+    try {
+      const metadata = buildMetadata();
+      const config = { ...DEFAULT_CONFIG.ids, mode: "auto" };
+      const managerA = new WaymarkIdManager(
+        config,
+        new JsonIdIndex({ workspaceRoot: workspaceA })
+      );
+      const managerB = new WaymarkIdManager(
+        config,
+        new JsonIdIndex({ workspaceRoot: workspaceB })
+      );
+
+      const idA = await managerA.reserveId(metadata);
+      const idB = await managerB.reserveId(metadata);
+
+      expect(idA).toBeDefined();
+      expect(idB).toBeDefined();
+      expect(idA).toBe(idB);
+    } finally {
+      await cleanupWorkspace(workspaceA);
+      await cleanupWorkspace(workspaceB);
+    }
+  });
+
+  it("respects configured length and bracket format", async () => {
+    const workspace = await createWorkspace();
+
+    try {
+      const metadata = buildMetadata();
+      const config = { ...DEFAULT_CONFIG.ids, mode: "auto", length: 9 };
+      const manager = new WaymarkIdManager(
+        config,
+        new JsonIdIndex({ workspaceRoot: workspace })
+      );
+
+      const id = await manager.reserveId(metadata);
+
+      expect(id).toBeDefined();
+      if (!id) {
+        throw new Error("Expected generated ID");
+      }
+      expect(id.startsWith("[[")).toBe(true);
+      expect(id.endsWith("]]")).toBe(true);
+      expect(id.slice(2, -2)).toHaveLength(config.length);
+    } finally {
+      await cleanupWorkspace(workspace);
+    }
+  });
+});

--- a/packages/core/src/__tests__/contracts/relations.test.ts
+++ b/packages/core/src/__tests__/contracts/relations.test.ts
@@ -1,0 +1,28 @@
+// tldr ::: contract coverage for relation extraction and normalization
+
+import { describe, expect, it } from "bun:test";
+import { parse } from "@waymarks/grammar";
+
+import { normalizeRelations } from "../../normalize.ts";
+
+describe("relation contracts", () => {
+  it("normalizes relation kinds and tokens consistently", () => {
+    const source =
+      "// todo ::: validate relations see:Alpha docs:Spec from:Source replaces:Legacy";
+    const records = parse(source, { file: "src/contracts.ts" });
+
+    expect(records).toHaveLength(1);
+    const record = records[0];
+    if (!record) {
+      throw new Error("Expected parsed waymark record");
+    }
+
+    const normalized = normalizeRelations(record.relations);
+    expect(normalized).toEqual([
+      { kind: "docs", token: "#spec" },
+      { kind: "from", token: "#source" },
+      { kind: "replaces", token: "#legacy" },
+      { kind: "see", token: "#alpha" },
+    ]);
+  });
+});


### PR DESCRIPTION
# Add Contract Tests for Waymark ID Generation and Relation Handling

This PR adds two new contract test files to ensure consistent behavior in core functionality:

1. `ids.test.ts`: Tests for deterministic waymark ID generation, verifying that:
   - Different ID managers produce the same IDs for identical content
   - Generated IDs respect configured length and bracket format settings

2. `relations.test.ts`: Tests for relation extraction and normalization, ensuring:
   - Relations are properly normalized with consistent kinds and tokens
   - The sorting and formatting of relations works as expected

These tests help guarantee that our ID generation remains deterministic across environments and that relation handling maintains consistent behavior.