### PR TITLE
test(grammar): add parse/format roundtrip test

### DIFF
--- a/packages/grammar/src/__tests__/roundtrip.test.ts
+++ b/packages/grammar/src/__tests__/roundtrip.test.ts
@@ -1,0 +1,41 @@
+// tldr ::: parse/format roundtrip contract for waymark grammar
+
+import { describe, expect, it } from "bun:test";
+import { parse, type WaymarkRecord } from "@waymarks/grammar";
+import { formatText } from "../../../core/src/format.ts";
+
+const SOURCE = [
+  "// TODO  ::: Review docs see:Alpha priority:high #perf @alice",
+  "//       ::: follow up with docs:Spec",
+].join("\n");
+
+function pickRecord(record: WaymarkRecord) {
+  return {
+    type: record.type,
+    contentText: record.contentText,
+    properties: record.properties,
+    relations: record.relations,
+    canonicals: record.canonicals,
+    mentions: record.mentions,
+    tags: record.tags,
+    signals: record.signals,
+    commentLeader: record.commentLeader,
+  };
+}
+
+describe("parse/format roundtrip", () => {
+  it("preserves record semantics after formatting", () => {
+    const options = { file: "src/roundtrip.ts" };
+    const original = parse(SOURCE, options).map(pickRecord);
+    const { formattedText } = formatText(SOURCE, options);
+    const formatted = parse(formattedText, options).map(pickRecord);
+
+    expect(formatted).toEqual(original);
+
+    const { formattedText: formattedAgain } = formatText(
+      formattedText,
+      options
+    );
+    expect(formattedAgain).toBe(formattedText);
+  });
+});


### PR DESCRIPTION
Added a roundtrip test for Waymark grammar parsing and formatting

This PR adds a new test file that verifies the parse/format roundtrip contract for the Waymark grammar. The test ensures that when a source text is parsed, then formatted, and then parsed again, the semantic content of the records remains identical. It also verifies that formatting is idempotent by checking that formatting an already formatted text produces the same result.