### PR TITLE
feat(cli): add config command to print resolved configuration

### DIFF
--- a/packages/cli/src/commands/config.test.ts
+++ b/packages/cli/src/commands/config.test.ts
@@ -1,0 +1,33 @@
+// tldr ::: tests for config command output [[cli/config-test]]
+
+import { describe, expect, test } from "bun:test";
+import { resolveConfig, type WaymarkConfig } from "@waymarks/core";
+import type { CommandContext } from "../types.ts";
+import { runConfigCommand } from "./config.ts";
+
+const context: CommandContext = {
+  config: resolveConfig(),
+  globalOptions: {},
+  workspaceRoot: process.cwd(),
+};
+
+describe("config command", () => {
+  test("prints merged configuration when --print is set", async () => {
+    const result = await runConfigCommand(context, { print: true });
+
+    expect(result.exitCode).toBe(0);
+    const parsed = JSON.parse(result.output) as WaymarkConfig;
+    expect(parsed).toEqual(context.config);
+  });
+
+  test("prints compact JSON when --json is set", async () => {
+    const result = await runConfigCommand(context, { print: true, json: true });
+    expect(result.output.includes("\n")).toBe(false);
+  });
+
+  test("requires --print flag", async () => {
+    await expect(runConfigCommand(context)).rejects.toThrow(
+      "Config command requires --print."
+    );
+  });
+});

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -1,0 +1,45 @@
+// tldr ::: config command helpers for printing resolved settings [[cli/config-print]]
+
+import type { WaymarkConfig } from "@waymarks/core";
+
+import { createUsageError } from "../errors.ts";
+import { ExitCode } from "../exit-codes.ts";
+import type { CommandContext } from "../types.ts";
+
+export type ConfigCommandOptions = {
+  print?: boolean;
+  json?: boolean;
+};
+
+export type ConfigCommandResult = {
+  output: string;
+  exitCode: number;
+};
+
+const PRETTY_JSON_INDENT = 2;
+
+function serializeConfig(
+  config: WaymarkConfig,
+  options: { compact?: boolean }
+): string {
+  const indent = options.compact ? undefined : PRETTY_JSON_INDENT;
+  return JSON.stringify(config, null, indent);
+}
+
+export function runConfigCommand(
+  context: CommandContext,
+  options: ConfigCommandOptions = {}
+): Promise<ConfigCommandResult> {
+  if (!options.print) {
+    throw createUsageError("Config command requires --print.");
+  }
+
+  const output = serializeConfig(context.config, {
+    compact: Boolean(options.json),
+  });
+
+  return {
+    output,
+    exitCode: ExitCode.success,
+  };
+}

--- a/packages/cli/src/commands/help/registry.ts
+++ b/packages/cli/src/commands/help/registry.ts
@@ -515,6 +515,33 @@ export const commands: HelpRegistry = {
       "wm init --preset minimal --force      # Overwrite with minimal config",
     ],
   },
+  config: {
+    name: "config",
+    usage: "wm config --print [options]",
+    description:
+      "Print resolved configuration (defaults merged with project/user or explicit config).",
+    flags: [
+      {
+        name: "print",
+        type: "boolean",
+        description: "Print merged configuration",
+      },
+      {
+        name: "json",
+        type: "boolean",
+        description: "Output compact JSON",
+      },
+      commonFlags.config,
+      commonFlags.scope,
+      commonFlags.help,
+    ],
+    examples: [
+      "wm config --print                     # Show merged configuration",
+      "wm --scope user config --print        # Show user config",
+      "wm --config ./custom.toml config --print",
+      "wm config --print --json              # Output compact JSON",
+    ],
+  },
   update: {
     name: "update",
     usage: "wm update [options]",


### PR DESCRIPTION
# Add `config` command to print resolved configuration

This PR adds a new `config` command to the CLI that allows users to print the resolved configuration (defaults merged with project/user settings). The command requires the `--print` flag and supports a `--json` option for compact output.

Key features:
- Print the fully resolved configuration with `wm config --print`
- View user-specific configuration with `wm --scope user config --print`
- Load custom config files with `wm --config ./custom.toml config --print`
- Output compact JSON with `wm config --print --json`

The implementation includes:
- New `config.ts` command module with serialization logic
- Comprehensive test coverage for the command
- Updated help registry with examples and documentation
- Global `--config` option for loading additional configuration files
- Refactored global options handling for consistency across commands