### PR TITLE
test(cli): add help output snapshot tests

### DIFF
--- a/packages/cli/src/__tests__/fixtures/help/config-help.txt
+++ b/packages/cli/src/__tests__/fixtures/help/config-help.txt
@@ -1,0 +1,7 @@
+wm config [options]
+print resolved configuration
+
+Options:
+  --print     print merged configuration (default: false)
+  --json      output compact JSON (default: false)
+  --help, -h  display help for command

--- a/packages/cli/src/__tests__/fixtures/help/find-help.txt
+++ b/packages/cli/src/__tests__/fixtures/help/find-help.txt
@@ -1,0 +1,31 @@
+wm find [options] [paths...]
+scan and filter waymarks in files or directories
+
+Arguments:
+  paths                                   files or directories to scan
+
+
+Options:
+  --type <types...>, -t                   filter by waymark type(s)
+  --tag <tags...>                         filter by tag(s)
+  --mention <mentions...>                 filter by mention(s)
+  --flagged, -F                           filter for flagged (~) waymarks
+  --starred, -S                           filter for starred (*) waymarks
+  --tldr                                  shorthand for --type tldr
+  --graph                                 show dependency graph
+  --long                                  show detailed record information
+  --tree                                  group output by directory structure
+  --flat                                  show flat list (default)
+  --compact                               compact output format
+  --no-wrap                               disable line wrapping
+  --group <by>                            group by: file, dir, type
+  --sort <by>                             sort by: file, line, type, modified
+  --context <n>, -C                       show N lines of context
+  --after <n>, -A, --after-context <n>    show N lines after match
+  --before <n>, -B, --before-context <n>  show N lines before match
+  --limit <n>, -n                         limit number of results
+  --page <n>                              page number (with --limit)
+  --interactive                           interactively select a waymark
+  --pretty                                (deprecated: use --text) output as pretty-printed JSON
+  --prompt                                show agent-facing prompt instead of help
+  --help, -h                              display help for command

--- a/packages/cli/src/__tests__/fixtures/help/root-help.txt
+++ b/packages/cli/src/__tests__/fixtures/help/root-help.txt
@@ -1,0 +1,51 @@
+wm [options] [command] [paths...]
+Waymark CLI - scan, filter, format, and manage waymarks
+
+Quick Start:
+  wm [paths...]             Scan and filter waymarks (default: current directory)
+  wm find --graph           Show dependency graph
+  wm fmt <file> --write     Format waymarks in file
+  wm rm <file:line> --write Remove waymark from file
+  wm init                   Initialize waymark configuration
+
+Global Options:
+  --version, -v                 output the current version
+  --prompt                      show agent-facing documentation
+  --no-input                    fail if interactive input required
+  --scope <scope>, -s           config scope (default|project|user) (choices: "default", "project", "user", default: "default")
+  --config <path>               load additional config file (JSON/YAML/TOML)
+
+
+Logging:
+  --verbose                     enable verbose logging (info level)
+  --debug                       enable debug logging
+  --quiet, -q                   only show errors
+
+
+Output Formats:
+  --json                        Output as JSON array
+  --jsonl                       Output as JSON Lines (newline-delimited)
+  --text                        Output as human-readable formatted text
+
+
+Color:
+  --no-color                    disable ANSI colors
+
+
+Commands:
+  find                          scan and filter waymarks in files or directories
+  add                           add waymarks into files
+  edit                          edit existing waymarks
+  rm                            remove waymarks from files
+  fmt                           format and normalize waymark syntax in files
+  lint                          validate waymark structure and enforce quality rules
+  init                          initialize waymark configuration
+  config                        print resolved configuration
+  doctor                        run health checks and diagnostics
+  completions|complete          Generate shell completion scripts
+  update                        check for and install CLI updates (npm global installs)
+  help                          display help for command
+
+
+Topics:
+  Run 'wm help <topic>' for syntax guides (syntax, tldr, todo, signals, tags)

--- a/packages/cli/src/help-snapshots.test.ts
+++ b/packages/cli/src/help-snapshots.test.ts
@@ -1,0 +1,48 @@
+// tldr ::: snapshot checks for CLI help output [[cli/help-snapshots]]
+
+import { beforeAll, describe, expect, test } from "bun:test";
+import { readFile } from "node:fs/promises";
+import type { Command } from "commander";
+
+let program: Command;
+
+async function loadSnapshot(name: string): Promise<string> {
+  const baseUrl = new URL("./__tests__/fixtures/help/", import.meta.url);
+  return await readFile(new URL(`${name}-help.txt`, baseUrl), "utf8");
+}
+
+function normalizeHelp(output: string): string {
+  return `${output.trimEnd()}\n`;
+}
+
+function requireCommand(target: string): Command {
+  const command = program.commands.find((cmd) => cmd.name() === target);
+  if (!command) {
+    throw new Error(`Missing command: ${target}`);
+  }
+  return command;
+}
+
+beforeAll(async () => {
+  const module = await import("./index.ts");
+  program = await module.createProgram();
+});
+
+describe("help snapshots", () => {
+  test("root help output is stable", async () => {
+    const snapshot = await loadSnapshot("root");
+    expect(normalizeHelp(program.helpInformation())).toBe(snapshot);
+  });
+
+  test("find help output is stable", async () => {
+    const snapshot = await loadSnapshot("find");
+    const findHelp = requireCommand("find").helpInformation();
+    expect(normalizeHelp(findHelp)).toBe(snapshot);
+  });
+
+  test("config help output is stable", async () => {
+    const snapshot = await loadSnapshot("config");
+    const configHelp = requireCommand("config").helpInformation();
+    expect(normalizeHelp(configHelp)).toBe(snapshot);
+  });
+});


### PR DESCRIPTION
# Add CLI help output snapshot tests

This PR adds snapshot tests for CLI help output to ensure the help text remains stable across changes. The tests verify that the help output for the root command, `find` command, and `config` command match expected snapshots.

The implementation:
- Creates a new test file `help-snapshots.test.ts` that loads the CLI program and compares its help output against stored snapshots
- Adds fixture files containing the expected help text for each command
- Includes utility functions to normalize help text and load snapshot files
- Uses Bun's test framework to run the snapshot comparisons

These tests will help catch unintended changes to command help text, ensuring consistent documentation for users.