### PR TITLE
docs: add CONTRIBUTING.md with development workflow guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,45 @@
+<!-- tldr ::: contributor workflow for the Waymark repository -->
+
+# Contributing
+
+Thanks for helping improve Waymark! This guide covers the local setup,
+development workflow, and expectations for pull requests.
+
+## Prerequisites
+
+- **Bun 1.2.22** (matches the `packageManager` version in `package.json`)
+- Git + Graphite (`gt`) when working in Graphite-synced repos
+
+## Setup
+
+1. Install dependencies: `bun install`
+2. Run the CLI locally: `bun dev:cli`
+3. Run the core package in watch mode: `bun dev:core`
+
+## Development Workflow
+
+- Use conventional commits.
+- Work on short-lived branches off `main`.
+- Prefer Graphite stacks (`gt log`, `gt create`, `gt submit`) when configured.
+- Keep PRs small and focused; feature-flag incomplete work.
+
+## Testing & Checks
+
+Run the checks that CI will enforce:
+
+- `bun test` — run tests
+- `bun check:all` — lint, typecheck, tests, and spec alignment
+- `bun ci:local` — full CI simulation (recommended before pushing)
+- `bun ci:validate` — tests/types/build (quick pre-push validation)
+
+## Docs & Waymarks
+
+- Add `<!-- tldr ::: ... -->` at the top of new Markdown files.
+- Use the `:::` sigil for new waymarks and keep them greppable.
+- Verify patterns with `rg ':::'` before committing.
+
+## Pull Requests
+
+- Keep branches up to date with `main` (rebase preferred).
+- Squash-merge after checks pass.
+- If you address `@coderabbitai` feedback, reply on the PR with a summary.


### PR DESCRIPTION
# Add CONTRIBUTING.md with development workflow guidelines

This PR adds a new CONTRIBUTING.md file that provides guidance for contributors to the Waymark repository. The document includes:

- Setup instructions for local development with Bun
- Development workflow recommendations using conventional commits and Graphite
- Testing and validation commands to run before submitting code
- Documentation standards including the use of "tldr" comments and waymarks
- Pull request expectations and review process

The guidelines help standardize the contribution process and ensure code quality through consistent practices.