### PR TITLE
feat(cli): add skill command for agent-facing documentation

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -7,10 +7,11 @@
     "waymark": "dist/wm.js"
   },
   "files": [
-    "dist"
+    "dist",
+    "skills"
   ],
   "scripts": {
-    "build": "bun build src/index.ts --outfile dist/wm.js --target bun",
+    "build": "bun ../../scripts/sync-cli-skills.ts && bun build src/index.ts --outfile dist/wm.js --target bun",
     "dev": "bun build src/index.ts --outfile dist/wm.js --target bun --watch",
     "install:bin": "bun run build && sudo ln -sf \"$(pwd)/dist/wm.js\" /usr/local/bin/wm && echo 'wm installed to /usr/local/bin (waymark available via package bin)'",
     "uninstall:bin": "sudo rm -f /usr/local/bin/wm && echo 'wm removed from /usr/local/bin'",

--- a/packages/cli/src/__tests__/fixtures/help/root-help.txt
+++ b/packages/cli/src/__tests__/fixtures/help/root-help.txt
@@ -45,6 +45,7 @@ Commands:
   completions|complete          Generate shell completion scripts
   update                        check for and install CLI updates (npm global installs)
   help                          display help for command
+  skill                         show agent-facing skill documentation
 
 
 Topics:

--- a/packages/cli/src/commands/help/registry.ts
+++ b/packages/cli/src/commands/help/registry.ts
@@ -542,6 +542,28 @@ export const commands: HelpRegistry = {
       "wm config --print --json              # Output compact JSON",
     ],
   },
+  skill: {
+    name: "skill",
+    usage: "wm skill [options] [subcommand]",
+    description:
+      "Show agent-facing skill documentation (core, commands, references, and examples).",
+    flags: [
+      {
+        name: "json",
+        type: "boolean",
+        description: "Output structured JSON",
+      },
+      commonFlags.help,
+    ],
+    examples: [
+      "wm skill                            # Show core skill documentation",
+      "wm skill show add                   # Show add command docs",
+      "wm skill show workflows             # Show workflow examples",
+      "wm skill list                       # List available sections",
+      "wm skill --json                     # JSON output of all sections",
+      "wm skill show add --json            # JSON output for one section",
+    ],
+  },
   update: {
     name: "update",
     usage: "wm update [options]",

--- a/packages/cli/src/commands/skill.test.ts
+++ b/packages/cli/src/commands/skill.test.ts
@@ -1,0 +1,75 @@
+// tldr ::: tests for the wm skill command output paths [[cli/skill-test]]
+
+import { describe, expect, test } from "bun:test";
+import { fileURLToPath } from "node:url";
+import {
+  runSkillCommand,
+  runSkillListCommand,
+  runSkillPathCommand,
+  runSkillShowCommand,
+} from "./skill.ts";
+
+const skillDir = fileURLToPath(
+  new URL("../../../agents/skills/waymark", import.meta.url)
+);
+
+describe("skill command", () => {
+  test("prints core skill markdown by default", async () => {
+    const result = await runSkillCommand({}, { skillDir });
+    expect(result.exitCode).toBe(0);
+    expect(result.output).toContain("# Waymark CLI Skill");
+  });
+
+  test("prints command documentation via show", async () => {
+    const result = await runSkillShowCommand("add", {}, { skillDir });
+    expect(result.output).toContain("# wm add");
+  });
+
+  test("prints example documentation via show", async () => {
+    const result = await runSkillShowCommand("workflows", {}, { skillDir });
+    expect(result.output).toContain("# Workflows");
+  });
+
+  test("lists commands, references, and examples", async () => {
+    const result = await runSkillListCommand({ skillDir });
+    expect(result.output).toContain("Commands:");
+    expect(result.output).toContain("add");
+    expect(result.output).toContain("References:");
+    expect(result.output).toContain("schemas");
+    expect(result.output).toContain("Examples:");
+    expect(result.output).toContain("workflows");
+  });
+
+  test("outputs structured JSON when --json is set", async () => {
+    const result = await runSkillCommand({ json: true }, { skillDir });
+    const parsed = JSON.parse(result.output) as {
+      sections: { core: { content: string } };
+    };
+    expect(parsed.sections.core.content).toContain("# Waymark CLI Skill");
+  });
+
+  test("outputs structured JSON for show", async () => {
+    const result = await runSkillShowCommand(
+      "add",
+      { json: true },
+      { skillDir }
+    );
+    const parsed = JSON.parse(result.output) as {
+      kind: string;
+      content: string;
+    };
+    expect(parsed.kind).toBe("command");
+    expect(parsed.content).toContain("# wm add");
+  });
+
+  test("unknown sections throw usage errors", async () => {
+    await expect(
+      runSkillShowCommand("missing-section", {}, { skillDir })
+    ).rejects.toThrow("Unknown skill section");
+  });
+
+  test("prints skill directory path", () => {
+    const result = runSkillPathCommand({ skillDir });
+    expect(result.output).toBe(skillDir);
+  });
+});

--- a/packages/cli/src/commands/skill.ts
+++ b/packages/cli/src/commands/skill.ts
@@ -1,0 +1,198 @@
+// tldr ::: implement the wm skill command outputs [[cli/skill-command]]
+
+import { resolve } from "node:path";
+import { createUsageError } from "../errors.ts";
+import { ExitCode } from "../exit-codes.ts";
+import {
+  listSkillSections,
+  loadSkillData,
+  loadSkillManifest,
+  loadSkillSection,
+  resolveSkillDir,
+  type SkillSectionKind,
+} from "../skills/parser.ts";
+
+export type SkillCommandOptions = {
+  json?: boolean;
+};
+
+export type SkillCommandResult = {
+  output: string;
+  exitCode: number;
+};
+
+export type SkillCommandOverrides = {
+  skillDir?: string;
+};
+
+function resolveSkillDirectory(overrides: SkillCommandOverrides = {}): string {
+  if (overrides.skillDir) {
+    return resolve(overrides.skillDir);
+  }
+  return resolveSkillDir();
+}
+
+function formatJsonOutput(payload: unknown): string {
+  return JSON.stringify(payload, null, 2);
+}
+
+export async function runSkillCommand(
+  options: SkillCommandOptions = {},
+  overrides: SkillCommandOverrides = {}
+): Promise<SkillCommandResult> {
+  const skillDir = resolveSkillDirectory(overrides);
+
+  if (options.json) {
+    const skillData = await loadSkillData(skillDir);
+    return {
+      output: formatJsonOutput(skillData),
+      exitCode: ExitCode.success,
+    };
+  }
+
+  const manifest = await loadSkillManifest(skillDir);
+  const entryPath = manifest.entry || "SKILL.md";
+  const core = await loadSkillSection(skillDir, "core", "core", entryPath);
+
+  return {
+    output: core.content,
+    exitCode: ExitCode.success,
+  };
+}
+
+function resolveSkillSectionEntry(
+  section: string,
+  sectionMap: Record<string, string>,
+  kind: SkillSectionKind
+): { name: string; kind: SkillSectionKind; path: string } | null {
+  const path = sectionMap[section];
+  if (!path) {
+    return null;
+  }
+  return { name: section, kind, path };
+}
+
+function resolveSkillSection(
+  manifest: Awaited<ReturnType<typeof loadSkillManifest>>,
+  section: string
+): { name: string; kind: SkillSectionKind; path: string } | null {
+  const commandMatch = resolveSkillSectionEntry(
+    section,
+    manifest.commands ?? {},
+    "command"
+  );
+  if (commandMatch) {
+    return commandMatch;
+  }
+
+  const referenceMatch = resolveSkillSectionEntry(
+    section,
+    manifest.references ?? {},
+    "reference"
+  );
+  if (referenceMatch) {
+    const kind = referenceMatch.path.startsWith("examples/")
+      ? "example"
+      : "reference";
+    return {
+      ...referenceMatch,
+      kind,
+    };
+  }
+
+  if (section === "skill" || section === "core") {
+    return {
+      name: "core",
+      kind: "core",
+      path: manifest.entry || "SKILL.md",
+    };
+  }
+
+  return null;
+}
+
+export async function runSkillShowCommand(
+  section: string,
+  options: SkillCommandOptions = {},
+  overrides: SkillCommandOverrides = {}
+): Promise<SkillCommandResult> {
+  const skillDir = resolveSkillDirectory(overrides);
+  const manifest = await loadSkillManifest(skillDir);
+  const resolved = resolveSkillSection(manifest, section);
+
+  if (!resolved) {
+    throw createUsageError(`Unknown skill section: ${section}`);
+  }
+
+  const content = await loadSkillSection(
+    skillDir,
+    resolved.name,
+    resolved.kind,
+    resolved.path
+  );
+
+  if (options.json) {
+    return {
+      output: formatJsonOutput(content),
+      exitCode: ExitCode.success,
+    };
+  }
+
+  return {
+    output: content.content,
+    exitCode: ExitCode.success,
+  };
+}
+
+export async function runSkillListCommand(
+  overrides: SkillCommandOverrides = {}
+): Promise<SkillCommandResult> {
+  const skillDir = resolveSkillDirectory(overrides);
+  const manifest = await loadSkillManifest(skillDir);
+  const sections = listSkillSections(manifest);
+  const lines: string[] = [];
+
+  lines.push("Commands:");
+  if (sections.commands.length === 0) {
+    lines.push("  (none)");
+  } else {
+    for (const name of sections.commands) {
+      lines.push(`  ${name}`);
+    }
+  }
+
+  lines.push("");
+  lines.push("References:");
+  if (sections.references.length === 0) {
+    lines.push("  (none)");
+  } else {
+    for (const name of sections.references) {
+      lines.push(`  ${name}`);
+    }
+  }
+
+  lines.push("");
+  lines.push("Examples:");
+  if (sections.examples.length === 0) {
+    lines.push("  (none)");
+  } else {
+    for (const name of sections.examples) {
+      lines.push(`  ${name}`);
+    }
+  }
+
+  return {
+    output: lines.join("\n"),
+    exitCode: ExitCode.success,
+  };
+}
+
+export function runSkillPathCommand(
+  overrides: SkillCommandOverrides = {}
+): SkillCommandResult {
+  const skillDir = resolveSkillDirectory(overrides);
+  return {
+    output: skillDir,
+    exitCode: ExitCode.success,
+  };
+}

--- a/packages/cli/src/skills/parser.ts
+++ b/packages/cli/src/skills/parser.ts
@@ -1,0 +1,263 @@
+// tldr ::: load and normalize skill docs for the wm skill command [[cli/skill-parser]]
+
+import { existsSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export type SkillManifest = {
+  name: string;
+  version: string;
+  description?: string;
+  entry: string;
+  commands?: Record<string, string>;
+  references?: Record<string, string>;
+  triggers?: string[];
+};
+
+export type SkillSectionKind = "core" | "command" | "reference" | "example";
+
+export type SkillSection = {
+  name: string;
+  kind: SkillSectionKind;
+  path: string;
+  content: string;
+  frontmatter?: string;
+};
+
+export type SkillSections = {
+  core: SkillSection;
+  commands: Record<string, SkillSection>;
+  references: Record<string, SkillSection>;
+  examples: Record<string, SkillSection>;
+};
+
+export type SkillData = SkillManifest & {
+  sections: SkillSections;
+};
+
+const SKILL_DIR_ENV = "WAYMARK_SKILL_DIR";
+const SKILL_DIR_CACHE: { value?: string } = {};
+const SKILL_MANIFEST_FILE = "index.json";
+const SKILL_SEARCH_DEPTH = 6;
+const SKILL_DIR_CANDIDATES = [
+  join("skills", "waymark"),
+  join("agents", "skills", "waymark"),
+  join("packages", "agents", "skills", "waymark"),
+];
+
+function normalizeLineEndings(value: string): string {
+  return value.replace(/\r\n/g, "\n");
+}
+
+function consumeCommentBlock(
+  lines: string[],
+  startIndex: number
+): { collected: string[]; nextIndex: number } {
+  const collected: string[] = [];
+  let index = startIndex;
+
+  while (index < lines.length) {
+    const line = lines[index] ?? "";
+    collected.push(line);
+    index += 1;
+    if (line.includes("-->")) {
+      break;
+    }
+  }
+
+  return { collected, nextIndex: index };
+}
+
+function consumePreamble(lines: string[]): {
+  preamble: string[];
+  index: number;
+} {
+  const preamble: string[] = [];
+  let index = 0;
+
+  while (index < lines.length) {
+    const line = lines[index] ?? "";
+    const trimmed = line.trim();
+    if (trimmed.length === 0) {
+      preamble.push(line);
+      index += 1;
+      continue;
+    }
+    if (trimmed.startsWith("<!--")) {
+      const { collected, nextIndex } = consumeCommentBlock(lines, index);
+      preamble.push(...collected);
+      index = nextIndex;
+      continue;
+    }
+    break;
+  }
+
+  return { preamble, index };
+}
+
+function readFrontmatter(
+  lines: string[],
+  startIndex: number
+): { frontmatter: string[]; nextIndex: number; closed: boolean } {
+  if ((lines[startIndex] ?? "").trim() !== "---") {
+    return { frontmatter: [], nextIndex: startIndex, closed: false };
+  }
+
+  const frontmatter: string[] = [];
+  let index = startIndex + 1;
+
+  while (index < lines.length && (lines[index] ?? "").trim() !== "---") {
+    frontmatter.push(lines[index] ?? "");
+    index += 1;
+  }
+
+  if (index >= lines.length) {
+    return { frontmatter: [], nextIndex: startIndex, closed: false };
+  }
+
+  return { frontmatter, nextIndex: index + 1, closed: true };
+}
+
+function extractFrontmatter(raw: string): {
+  frontmatter?: string;
+  body: string;
+} {
+  const normalized = normalizeLineEndings(raw);
+  const lines = normalized.split("\n");
+  const { preamble, index } = consumePreamble(lines);
+  const { frontmatter, nextIndex, closed } = readFrontmatter(lines, index);
+
+  if (!closed) {
+    return { body: normalized };
+  }
+
+  const bodyLines = [...preamble, ...lines.slice(nextIndex)];
+  return {
+    frontmatter: frontmatter.join("\n").trimEnd(),
+    body: bodyLines.join("\n").trimStart(),
+  };
+}
+
+export function resolveSkillDir(): string {
+  if (SKILL_DIR_CACHE.value) {
+    return SKILL_DIR_CACHE.value;
+  }
+
+  const envOverride = process.env[SKILL_DIR_ENV];
+  if (envOverride) {
+    const candidate = resolve(envOverride);
+    if (existsSync(join(candidate, SKILL_MANIFEST_FILE))) {
+      SKILL_DIR_CACHE.value = candidate;
+      return candidate;
+    }
+  }
+
+  let currentDir = dirname(fileURLToPath(import.meta.url));
+  for (let depth = 0; depth < SKILL_SEARCH_DEPTH; depth += 1) {
+    for (const suffix of SKILL_DIR_CANDIDATES) {
+      const candidate = resolve(currentDir, suffix);
+      if (existsSync(join(candidate, SKILL_MANIFEST_FILE))) {
+        SKILL_DIR_CACHE.value = candidate;
+        return candidate;
+      }
+    }
+    const parent = dirname(currentDir);
+    if (parent === currentDir) {
+      break;
+    }
+    currentDir = parent;
+  }
+
+  throw new Error(
+    "Skill directory not found. Set WAYMARK_SKILL_DIR to override."
+  );
+}
+
+export async function loadSkillManifest(
+  skillDir: string
+): Promise<SkillManifest> {
+  const manifestPath = join(skillDir, SKILL_MANIFEST_FILE);
+  const raw = await readFile(manifestPath, "utf8");
+  return JSON.parse(raw) as SkillManifest;
+}
+
+export async function loadSkillSection(
+  skillDir: string,
+  sectionName: string,
+  kind: SkillSectionKind,
+  relativePath: string
+): Promise<SkillSection> {
+  const fullPath = join(skillDir, relativePath);
+  const raw = await readFile(fullPath, "utf8");
+  const { body, frontmatter } = extractFrontmatter(raw);
+  return {
+    name: sectionName,
+    kind,
+    path: fullPath,
+    content: body.trimEnd(),
+    ...(frontmatter ? { frontmatter } : {}),
+  };
+}
+
+export async function loadSkillData(skillDir: string): Promise<SkillData> {
+  const manifest = await loadSkillManifest(skillDir);
+  const entryPath = manifest.entry || "SKILL.md";
+  const core = await loadSkillSection(skillDir, "core", "core", entryPath);
+
+  const commandsEntries = Object.entries(manifest.commands ?? {});
+  const referencesEntries = Object.entries(manifest.references ?? {});
+  const commands: Record<string, SkillSection> = {};
+  const references: Record<string, SkillSection> = {};
+  const examples: Record<string, SkillSection> = {};
+
+  for (const [name, relativePath] of commandsEntries) {
+    commands[name] = await loadSkillSection(
+      skillDir,
+      name,
+      "command",
+      relativePath
+    );
+  }
+
+  for (const [name, relativePath] of referencesEntries) {
+    const kind = relativePath.startsWith("examples/") ? "example" : "reference";
+    const target = kind === "example" ? examples : references;
+    target[name] = await loadSkillSection(skillDir, name, kind, relativePath);
+  }
+
+  return {
+    ...manifest,
+    sections: {
+      core,
+      commands,
+      references,
+      examples,
+    },
+  };
+}
+
+export function listSkillSections(manifest: SkillManifest): {
+  commands: string[];
+  references: string[];
+  examples: string[];
+} {
+  const commandNames = Object.keys(manifest.commands ?? {});
+  const referenceEntries = Object.entries(manifest.references ?? {});
+  const references: string[] = [];
+  const examples: string[] = [];
+
+  for (const [name, relativePath] of referenceEntries) {
+    if (relativePath.startsWith("examples/")) {
+      examples.push(name);
+    } else {
+      references.push(name);
+    }
+  }
+
+  return {
+    commands: commandNames.sort(),
+    references: references.sort(),
+    examples: examples.sort(),
+  };
+}

--- a/scripts/sync-cli-skills.ts
+++ b/scripts/sync-cli-skills.ts
@@ -1,0 +1,14 @@
+// tldr ::: copy agent skill docs into the CLI package for distribution [[cli/skill-sync]]
+
+import { cp, mkdir, rm } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const sourceDir = resolve(repoRoot, "packages/agents/skills/waymark");
+const targetRoot = resolve(repoRoot, "packages/cli/skills");
+const targetDir = join(targetRoot, "waymark");
+
+await mkdir(targetRoot, { recursive: true });
+await rm(targetDir, { recursive: true, force: true });
+await cp(sourceDir, targetDir, { recursive: true });


### PR DESCRIPTION
# Add `wm skill` command to display agent-facing skill documentation

This PR adds a new `wm skill` command that allows users to view the agent-facing skill documentation directly from the CLI. The command provides access to core documentation, command references, and workflow examples.

Key features:
- Added `wm skill` command with subcommands:
  - `wm skill` - Shows core skill documentation
  - `wm skill show <section>` - Displays specific command or example docs
  - `wm skill list` - Lists all available documentation sections
  - `wm skill path` - Prints the skill directory path
- Added JSON output option for structured data access
- Implemented skill documentation parser with frontmatter support
- Added build script to sync skill documentation from agents package
- Included skills directory in CLI package distribution

The implementation includes comprehensive tests for all command paths and ensures documentation is properly formatted and accessible.