### PR TITLE
fix(cli): correct cache status check logic in doctor command

### DIFF
--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -269,14 +269,7 @@ async function checkCacheStatus(): Promise<CheckResult[]> {
         message: "Cache directory not found (will be created on first scan)",
         suggestion: "Run `wm find` to initialize the cache",
       });
-    } else if (!existsSync(cacheDb)) {
-      issues.push({
-        severity: "info",
-        category: "environment",
-        message: "Cache directory exists but cache database is missing",
-        suggestion: "Run `wm find` to populate the cache database",
-      });
-    } else {
+    } else if (existsSync(cacheDb)) {
       const stats = await stat(cacheDb);
       const sizeMb = stats.size / BYTES_PER_MB;
       issues.push({
@@ -284,6 +277,13 @@ async function checkCacheStatus(): Promise<CheckResult[]> {
         category: "environment",
         message: `Cache database present (${sizeMb.toFixed(2)} MB)`,
         file: cacheDb,
+      });
+    } else {
+      issues.push({
+        severity: "info",
+        category: "environment",
+        message: "Cache directory exists but cache database is missing",
+        suggestion: "Run `wm find` to populate the cache database",
       });
     }
   } catch (_error) {


### PR DESCRIPTION
Fix inverted logic in cache status check

This PR fixes a logical error in the `checkCacheStatus` function where the conditions for checking the cache database were inverted. Previously, the code was incorrectly reporting that the cache database was missing when it was actually present, and vice versa. The fix properly displays the correct message based on whether the cache database exists or not.