### PR TITLE
feat(cli): update add/rm commands with improved options and positioning

### DIFF
--- a/packages/agents/skills/waymark/commands/add.md
+++ b/packages/agents/skills/waymark/commands/add.md
@@ -19,21 +19,26 @@ wm add --from <json-file>
 | --- | --- | --- |
 | `<file:line>` | Yes* | Target location (required unless `--from`) |
 | `<type>` | Yes* | Waymark type (todo, fix, note, tldr, etc.) |
-| `<content>` | Yes* | Content text (use `-` to read stdin) |
+| `<content>` | Yes* | Content text |
 
 ## Options
 
 | Option | Short | Description | Default |
 | --- | --- | --- | --- |
 | `--from <file>` |  | Read JSON/JSONL input (use `-` for stdin) | none |
+| `--type <type>` |  | Set type when not provided positionally | none |
+| `--content <text>` |  | Set content when not provided positionally | none |
+| `--position <before\|after>` |  | Insert relative to the line | none |
+| `--before` |  | Shorthand for `--position before` | false |
+| `--after` |  | Shorthand for `--position after` | false |
 | `--mention <actor>` |  | Add mention(s) | none |
 | `--tag <tag>` |  | Add tag(s) | none |
 | `--property <kv>` |  | Add property key:value | none |
-| `--ref <token>` |  | Set canonical reference | none |
-| `--source <token>` |  | Add dependency relation | none |
-| `--see <token>` |  | Add reference relation | none |
-| `--replaces <token>` |  | Add replaces relation | none |
-| `--signal <~\|*>` |  | Add flagged/starred signals | none |
+| `--continuation <text>` |  | Add continuation line | none |
+| `--flagged` | `-F` | Add flagged signal | false |
+| `--starred` |  | Add starred signal | false |
+| `--order <n>` |  | Insertion order (batch) | none |
+| `--id <id>` |  | Reserve specific ID | none |
 | `--write` | `-w` | Apply changes (default preview) | false |
 | `--json` |  | JSON array output | false |
 | `--jsonl` |  | JSON lines output | false |

--- a/packages/agents/skills/waymark/commands/rm.md
+++ b/packages/agents/skills/waymark/commands/rm.md
@@ -4,7 +4,7 @@
 
 ## Synopsis
 
-Remove waymarks by location, ID, or filter criteria. Preview by default.
+Remove waymarks by location, ID, or filters. Preview by default.
 
 ## Syntax
 
@@ -12,7 +12,7 @@ Remove waymarks by location, ID, or filter criteria. Preview by default.
 wm rm <file:line> [options]
 wm rm --id <id> [options]
 wm rm --from <json-file> [options]
-wm rm [filters] <paths...> [options]
+wm rm --type <type> --file <path> [options]
 ```
 
 ## Options
@@ -21,17 +21,17 @@ wm rm [filters] <paths...> [options]
 | --- | --- | --- | --- |
 | `--id <id>` |  | Remove by ID | none |
 | `--from <file>` |  | Read JSON input (use `-` for stdin) | none |
-| `--criteria <query>` |  | Filter query string | none |
 | `--type <type>` |  | Filter by type | none |
 | `--mention <mention>` |  | Filter by mention | none |
 | `--tag <tag>` |  | Filter by tag | none |
-| `--flagged` |  | Filter flagged | false |
-| `--starred` |  | Filter starred | false |
-| `--contains <text>` |  | Filter by content | none |
+| `--property <kv>` |  | Filter by property | none |
+| `--file <path>` |  | Filter by file path | none |
+| `--content-pattern <regex>` |  | Filter by content regex | none |
+| `--contains <text>` |  | Filter by content substring | none |
+| `--flagged` | `-F` | Filter flagged | false |
+| `--starred` | `-S` | Filter starred | false |
 | `--reason <text>` |  | Record removal reason | none |
 | `--write` | `-w` | Apply removal | false |
-| `--yes` | `-y` | Skip confirmation prompt | false |
-| `--confirm` |  | Always prompt | false |
 | `--json` |  | JSON array output | false |
 | `--jsonl` |  | JSON lines output | false |
 
@@ -41,7 +41,7 @@ wm rm [filters] <paths...> [options]
 wm rm src/auth.ts:42
 wm rm src/auth.ts:42 --write --reason "cleanup"
 wm rm --id [[a3k9m2p]] --write
-wm rm --type done . --write
+wm rm --type done --file src/ --write
 cat removals.json | wm rm --from - --write --json
 ```
 

--- a/packages/cli/src/commands/add.test.ts
+++ b/packages/cli/src/commands/add.test.ts
@@ -135,7 +135,7 @@ describe("runAddCommand", () => {
     await writeFile(invalidJsonPath, invalidJson, "utf8");
 
     const parsed = parseAddArgs(["--from", invalidJsonPath]);
-    const config = resolveConfig({});
+    const config = resolveConfig({ ids: { mode: "auto" } });
     const context: CommandContext = {
       config,
       workspaceRoot: testWorkspace,
@@ -164,7 +164,7 @@ describe("runAddCommand", () => {
     await writeFile(invalidJsonPath, invalidJson, "utf8");
 
     const parsed = parseAddArgs(["--from", invalidJsonPath]);
-    const config = resolveConfig({});
+    const config = resolveConfig({ ids: { mode: "auto" } });
     const context: CommandContext = {
       config,
       workspaceRoot: testWorkspace,
@@ -208,7 +208,7 @@ describe("runAddCommand", () => {
     await writeFile(validJsonPath, validJson, "utf8");
 
     const parsed = parseAddArgs(["--from", validJsonPath, "--write", "--json"]);
-    const config = resolveConfig({});
+    const config = resolveConfig({ ids: { mode: "auto" } });
     const context: CommandContext = {
       config,
       workspaceRoot: testWorkspace,
@@ -242,7 +242,7 @@ describe("runAddCommand", () => {
     await writeFile(batchJsonPath, batchJson, "utf8");
 
     const parsed = parseAddArgs(["--from", batchJsonPath, "--write"]);
-    const config = resolveConfig({});
+    const config = resolveConfig({ ids: { mode: "auto" } });
     const context: CommandContext = {
       config,
       workspaceRoot: testWorkspace,
@@ -277,7 +277,7 @@ describe("runAddCommand", () => {
     await writeFile(wrapperJsonPath, wrapperJson, "utf8");
 
     const parsed = parseAddArgs(["--from", wrapperJsonPath, "--write"]);
-    const config = resolveConfig({});
+    const config = resolveConfig({ ids: { mode: "auto" } });
     const context: CommandContext = {
       config,
       workspaceRoot: testWorkspace,
@@ -316,7 +316,7 @@ describe("runAddCommand", () => {
 
     try {
       const parsed = parseAddArgs(["--from", "-", "--write"]);
-      const config = resolveConfig({});
+      const config = resolveConfig({ ids: { mode: "auto" } });
       const context: CommandContext = {
         config,
         workspaceRoot: testWorkspace,

--- a/packages/cli/src/commands/help/registry.ts
+++ b/packages/cli/src/commands/help/registry.ts
@@ -187,8 +187,8 @@ export const commands: HelpRegistry = {
       {
         name: "content",
         type: "string",
-        placeholder: "text|-",
-        description: "Waymark content (use '-' to read from stdin)",
+        placeholder: "text",
+        description: "Waymark content text",
       },
       {
         name: "position",
@@ -225,40 +225,10 @@ export const commands: HelpRegistry = {
         description: "Add property (repeatable)",
       },
       {
-        name: "see",
-        type: "string",
-        placeholder: "token",
-        description: "Add reference relation (repeatable, creates canonical)",
-      },
-      {
-        name: "docs",
-        type: "string",
-        placeholder: "url",
-        description: "Add documentation link (repeatable)",
-      },
-      {
-        name: "source",
-        type: "string",
-        placeholder: "token",
-        description: "Add dependency relation (from:#token, repeatable)",
-      },
-      {
-        name: "replaces",
-        type: "string",
-        placeholder: "token",
-        description: "Add supersedes relation (repeatable)",
-      },
-      {
         name: "continuation",
         type: "string",
         placeholder: "text",
         description: "Add continuation line (repeatable)",
-      },
-      {
-        name: "signal",
-        type: "string",
-        placeholder: "~|*",
-        description: "Add signal (~ flagged, * starred)",
       },
       {
         name: "flagged",
@@ -423,7 +393,7 @@ export const commands: HelpRegistry = {
       },
       {
         name: "flagged",
-        alias: "R",
+        alias: "F",
         type: "boolean",
         description: "Filter by flagged signal (~)",
       },
@@ -432,17 +402,6 @@ export const commands: HelpRegistry = {
         alias: "S",
         type: "boolean",
         description: "Filter by starred signal (*)",
-      },
-      {
-        name: "yes",
-        alias: "y",
-        type: "boolean",
-        description: "Skip confirmation prompt",
-      },
-      {
-        name: "confirm",
-        type: "boolean",
-        description: "Force confirmation prompt",
       },
       commonFlags.json,
       commonFlags.jsonl,
@@ -453,7 +412,7 @@ export const commands: HelpRegistry = {
       "wm rm src/auth.ts:42                  # Preview removal",
       "wm rm src/auth.ts:42 --write          # Actually remove",
       "wm rm --id [[a3k9m2p]] --write        # Remove by ID",
-      "wm rm --type todo --tag #wip --write --yes  # Batch removal",
+      "wm rm --type todo --tag #wip --file src/ --write  # Batch removal",
       'wm rm src/auth.ts:42 --write --reason "cleanup"',
     ],
   },

--- a/packages/cli/src/commands/remove.test.ts
+++ b/packages/cli/src/commands/remove.test.ts
@@ -50,7 +50,7 @@ describe("runRemoveCommand", () => {
     workspace = await mkdtemp(join(tmpdir(), "waymark-remove-cli-"));
     await ensureDir(join(workspace, ".waymark"));
     context = {
-      config: resolveConfig(),
+      config: resolveConfig({ ids: { mode: "auto" } }),
       workspaceRoot: workspace,
       globalOptions: {},
     };


### PR DESCRIPTION
# Enhanced Waymark CLI Command Options

This PR updates the `add` and `rm` commands with improved options and clearer documentation:

## Add Command Enhancements
- Added positioning options (`--before`, `--after`, `--position`) to control waymark placement
- Added `--type` and `--content` flags for alternative syntax
- Added `--continuation` option for multi-line waymarks
- Added `--flagged` and `--starred` options to replace the generic `--signal`
- Added `--order` option for batch operations
- Added `--id` option to reserve specific IDs
- Removed redundant relation options (`--see`, `--source`, `--replaces`)

## Remove Command Improvements
- Simplified filter syntax with direct flag options instead of query strings
- Added `--file` option to filter by file path
- Added `--content-pattern` for regex-based content filtering
- Added `--property` filter option
- Removed confirmation prompts (`--yes`, `--confirm`) for simpler workflow
- Updated examples and documentation to match new syntax

These changes make the CLI more intuitive and provide better control over waymark placement and filtering.