### PR TITLE
refactor(cli): replace parseAddArgs with buildAddArgs for structured input

### DIFF
--- a/packages/cli/src/commands/modify.ts
+++ b/packages/cli/src/commands/modify.ts
@@ -15,6 +15,7 @@ import {
 import inquirer from "inquirer";
 
 import type { CommandContext } from "../types.ts";
+import { parseFileLineTarget } from "../utils/file-line.ts";
 import { logger } from "../utils/logger.ts";
 import { assertPromptAllowed } from "../utils/prompts.ts";
 import { readStream } from "../utils/stdin.ts";
@@ -450,22 +451,10 @@ async function resolveTarget(
     throw new Error("Target argument is required when --id is not provided");
   }
 
-  const parsed = parseFileLine(targetArg);
-  return parsed;
-}
-
-function parseFileLine(value: string): ModifyTarget {
-  const colonIndex = value.lastIndexOf(":");
-  if (colonIndex === -1) {
-    throw new Error(`Invalid target format: ${value}`);
-  }
-  const file = value.slice(0, colonIndex);
-  const lineRaw = value.slice(colonIndex + 1);
-  const line = Number.parseInt(lineRaw, 10);
-  if (!Number.isFinite(line) || line <= 0) {
-    throw new Error(`Invalid line number in target: ${value}`);
-  }
-  return { file, line };
+  return parseFileLineTarget(targetArg, {
+    missingSeparator: `Invalid target format: ${targetArg}`,
+    invalidLine: `Invalid line number in target: ${targetArg}`,
+  });
 }
 
 async function resolveTargetFromId(

--- a/packages/cli/src/commands/remove.test.ts
+++ b/packages/cli/src/commands/remove.test.ts
@@ -6,7 +6,7 @@ import { join } from "node:path";
 import { JsonIdIndex, resolveConfig } from "@waymarks/core";
 
 import type { CommandContext } from "../types";
-import { parseRemoveArgs, runRemoveCommand } from "./remove";
+import { buildRemoveArgs, runRemoveCommand } from "./remove";
 
 const JSON_VALIDATION_ERROR_REGEX = /JSON validation failed/;
 
@@ -14,21 +14,18 @@ async function ensureDir(path: string): Promise<void> {
   await mkdir(path, { recursive: true });
 }
 
-describe("parseRemoveArgs", () => {
+describe("buildRemoveArgs", () => {
   test("parses positional file:line arguments and ids", () => {
-    const parsed = parseRemoveArgs([
-      "src/auth.ts:10",
-      "--id",
-      "[[abc]]",
-      "--type",
-      "todo",
-      "--tag",
-      "#cleanup",
-      "--file",
-      "src/auth.ts",
-      "--contains",
-      "cleanup",
-    ]);
+    const parsed = buildRemoveArgs({
+      targets: ["src/auth.ts:10"],
+      options: {
+        id: ["[[abc]]"],
+        type: "todo",
+        tag: ["#cleanup"],
+        file: ["src/auth.ts"],
+        contains: "cleanup",
+      },
+    });
 
     const ExpectedSpecCount = 3;
     expect(parsed.specs).toHaveLength(ExpectedSpecCount);
@@ -74,11 +71,10 @@ describe("runRemoveCommand", () => {
       "utf8"
     );
 
-    const parsed = parseRemoveArgs([
-      "--write",
-      `${filePath}:1`,
-      `${filePath}:3`,
-    ]);
+    const parsed = buildRemoveArgs({
+      targets: [`${filePath}:1`, `${filePath}:3`],
+      options: { write: true },
+    });
 
     const preview = await runRemoveCommand(parsed, context, {
       writeOverride: false,
@@ -121,7 +117,10 @@ describe("runRemoveCommand", () => {
       updatedAt: Date.now(),
     });
 
-    const parsed = parseRemoveArgs(["--write", "--id", "[[test-456]]"]);
+    const parsed = buildRemoveArgs({
+      targets: [],
+      options: { write: true, id: ["[[test-456]]"] },
+    });
 
     const actual = await runRemoveCommand(parsed, context, {
       writeOverride: true,
@@ -160,7 +159,10 @@ describe("runRemoveCommand", () => {
     const jsonPath = join(workspace, "removals.json");
     await writeFile(jsonPath, JSON.stringify(spec), "utf8");
 
-    const parsed = parseRemoveArgs(["--from", jsonPath, "--write", "--json"]);
+    const parsed = buildRemoveArgs({
+      targets: [],
+      options: { from: jsonPath, write: true, json: true },
+    });
     const actual = await runRemoveCommand(parsed, context, {
       writeOverride: true,
     });
@@ -183,7 +185,10 @@ describe("runRemoveCommand", () => {
     });
     await writeFile(invalidJsonPath, invalidJson, "utf8");
 
-    const parsed = parseRemoveArgs(["--from", invalidJsonPath]);
+    const parsed = buildRemoveArgs({
+      targets: [],
+      options: { from: invalidJsonPath },
+    });
 
     await expect(runRemoveCommand(parsed, context)).rejects.toThrow(
       JSON_VALIDATION_ERROR_REGEX
@@ -199,7 +204,10 @@ describe("runRemoveCommand", () => {
     });
     await writeFile(invalidJsonPath, invalidJson, "utf8");
 
-    const parsed = parseRemoveArgs(["--from", invalidJsonPath]);
+    const parsed = buildRemoveArgs({
+      targets: [],
+      options: { from: invalidJsonPath },
+    });
 
     await expect(runRemoveCommand(parsed, context)).rejects.toThrow(
       JSON_VALIDATION_ERROR_REGEX
@@ -216,7 +224,10 @@ describe("runRemoveCommand", () => {
     });
     await writeFile(invalidJsonPath, invalidJson, "utf8");
 
-    const parsed = parseRemoveArgs(["--from", invalidJsonPath]);
+    const parsed = buildRemoveArgs({
+      targets: [],
+      options: { from: invalidJsonPath },
+    });
 
     await expect(runRemoveCommand(parsed, context)).rejects.toThrow(
       JSON_VALIDATION_ERROR_REGEX
@@ -252,12 +263,10 @@ describe("runRemoveCommand", () => {
     });
     await writeFile(validJsonPath, validJson, "utf8");
 
-    const parsed = parseRemoveArgs([
-      "--from",
-      validJsonPath,
-      "--write",
-      "--json",
-    ]);
+    const parsed = buildRemoveArgs({
+      targets: [],
+      options: { from: validJsonPath, write: true, json: true },
+    });
 
     const result = await runRemoveCommand(parsed, context, {
       writeOverride: true,

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -1011,10 +1011,13 @@ describe("Commander integration", () => {
     expect(receivedOptions?.graph).toBe(true);
   });
 
-  test("add command forwards --json flag to parser", async () => {
+  test("add command forwards --json flag to builder", async () => {
     const addModule = await import("./commands/add");
     const contextModule = await import("./utils/context");
-    const parseSpy = spyOn(addModule, "parseAddArgs");
+    const buildSpy = spyOn(addModule, "buildAddArgs").mockReturnValue({
+      specs: [],
+      options: { write: false, json: true, jsonl: false },
+    });
     const runSpy = spyOn(addModule, "runAddCommand").mockResolvedValue({
       results: [],
       summary: { total: 0, successful: 0, failed: 0, filesModified: 0 },
@@ -1034,14 +1037,14 @@ describe("Commander integration", () => {
         "--json",
       ]);
       expect(result.exitCode).toBe(0);
-      expect(parseSpy).toHaveBeenCalled();
-      const tokens = parseSpy.mock.calls[0]?.[0] ?? [];
-      expect(tokens).toContain("--json");
+      expect(buildSpy).toHaveBeenCalled();
+      const input = buildSpy.mock.calls[0]?.[0];
+      expect(input?.options.json).toBe(true);
       expect(runSpy).toHaveBeenCalled();
       const parsedArgs = runSpy.mock.calls[0]?.[0];
       expect(parsedArgs?.options.json).toBe(true);
     } finally {
-      parseSpy.mockRestore();
+      buildSpy.mockRestore();
       runSpy.mockRestore();
       contextSpy.mockRestore();
     }
@@ -1095,10 +1098,17 @@ describe("Commander integration", () => {
     }
   });
 
-  test("rm command forwards --json flag to parser", async () => {
+  test("rm command forwards --json flag to builder", async () => {
     const removeModule = await import("./commands/remove");
     const contextModule = await import("./utils/context");
-    const parseSpy = spyOn(removeModule, "parseRemoveArgs");
+    const buildSpy = spyOn(removeModule, "buildRemoveArgs").mockReturnValue({
+      specs: [],
+      options: {
+        write: false,
+        json: true,
+        jsonl: false,
+      },
+    });
     const runSpy = spyOn(removeModule, "runRemoveCommand").mockResolvedValue({
       results: [],
       summary: { total: 0, successful: 0, failed: 0, filesModified: 0 },
@@ -1117,14 +1127,14 @@ describe("Commander integration", () => {
     try {
       const result = await runCliCaptured(["rm", "src/sample.ts:1", "--json"]);
       expect(result.exitCode).toBe(0);
-      expect(parseSpy).toHaveBeenCalled();
-      const tokens = parseSpy.mock.calls[0]?.[0] ?? [];
-      expect(tokens).toContain("--json");
+      expect(buildSpy).toHaveBeenCalled();
+      const input = buildSpy.mock.calls[0]?.[0];
+      expect(input?.options.json).toBe(true);
       expect(runSpy).toHaveBeenCalled();
       const parsedArgs = runSpy.mock.calls[0]?.[0];
       expect(parsedArgs?.options.json).toBe(true);
     } finally {
-      parseSpy.mockRestore();
+      buildSpy.mockRestore();
       runSpy.mockRestore();
       contextSpy.mockRestore();
     }

--- a/packages/cli/src/utils/file-line.ts
+++ b/packages/cli/src/utils/file-line.ts
@@ -1,0 +1,28 @@
+// tldr ::: shared parser for FILE:LINE inputs
+
+export type FileLineTarget = {
+  file: string;
+  line: number;
+};
+
+type FileLineParseMessages = {
+  missingSeparator: string;
+  invalidLine: string;
+};
+
+export function parseFileLineTarget(
+  value: string,
+  messages: FileLineParseMessages
+): FileLineTarget {
+  const colonIndex = value.lastIndexOf(":");
+  if (colonIndex === -1) {
+    throw new Error(messages.missingSeparator);
+  }
+  const file = value.slice(0, colonIndex).trim();
+  const lineValue = value.slice(colonIndex + 1).trim();
+  const line = Number.parseInt(lineValue, 10);
+  if (!(file && Number.isFinite(line)) || line <= 0) {
+    throw new Error(messages.invalidLine);
+  }
+  return { file, line };
+}

--- a/packages/cli/src/utils/properties.ts
+++ b/packages/cli/src/utils/properties.ts
@@ -1,0 +1,23 @@
+// tldr ::: parse property key/value arguments for CLI flags
+
+export type PropertyEntry = {
+  key: string;
+  value: string;
+};
+
+const PROPERTY_ERROR_MESSAGE =
+  "--property expects key=value or key:value format";
+
+export function parsePropertyEntry(value: string): PropertyEntry {
+  const separatorIndex =
+    value.indexOf("=") >= 0 ? value.indexOf("=") : value.indexOf(":");
+  if (separatorIndex === -1) {
+    throw new Error(PROPERTY_ERROR_MESSAGE);
+  }
+  const key = value.slice(0, separatorIndex).trim();
+  const propValue = value.slice(separatorIndex + 1).trim();
+  if (!(key && propValue)) {
+    throw new Error(PROPERTY_ERROR_MESSAGE);
+  }
+  return { key, value: propValue };
+}


### PR DESCRIPTION
# Refactor CLI Command Argument Handling

This PR refactors the argument handling for the `add` and `remove` commands to improve maintainability and type safety. The changes replace the manual token-based parsing with a more structured approach using typed objects.

Key improvements:

- Renamed `parseAddArgs` to `buildAddArgs` and changed its interface to accept a structured input object instead of raw tokens
- Created a similar `buildRemoveArgs` function with the same pattern
- Extracted shared utility functions to dedicated modules:
  - `parseFileLineTarget` for handling FILE:LINE arguments
  - `parsePropertyEntry` for handling key-value property arguments
- Updated all tests to use the new interfaces
- Simplified the main CLI entry point by removing complex token manipulation logic
- Improved type safety with dedicated input types for command options

These changes make the code more maintainable by:
1. Reducing duplication between command handlers
2. Providing better type checking for command options
3. Making the flow from Commander to command execution more direct
4. Centralizing validation logic in the appropriate modules

The refactoring maintains all existing functionality while making future extensions easier to implement.