### PR TITLE
feat(cli): add cache support for faster repeated scans

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,10 +134,10 @@ The CLI relies on the core formatter and parser helpers exported from `@waymarks
 
 ### Cache Usage
 
-The SQLite cache infrastructure exists but CLI scans do not populate it yet. Cache
-integration is planned for a future release. For now, the cache is available
-programmatically via `@waymarks/core` (see `WaymarkCache`), and `wm doctor` reports
-cache directory health.
+The CLI can populate and reuse the SQLite cache for faster repeated scans by
+passing the global `--cache` flag (disabled by default). The cache is also
+available programmatically via `@waymarks/core` (see `WaymarkCache`), and
+`wm doctor` reports cache directory health.
 
 ### Exit Codes
 

--- a/packages/cli/src/commands/find.ts
+++ b/packages/cli/src/commands/find.ts
@@ -8,7 +8,7 @@ import { handleMentionFlag } from "../utils/flags/mention";
 import { handleTagFlag } from "../utils/flags/tag";
 import { handleTldrFlag } from "../utils/flags/tldr";
 import { handleTypeFlag } from "../utils/flags/type";
-import { scanRecords } from "./scan";
+import { type ScanRuntimeOptions, scanRecords } from "./scan";
 
 export type FindCommandOptions = {
   filePath: string;
@@ -17,6 +17,7 @@ export type FindCommandOptions = {
   mentions?: string[];
   outputFormat?: "json" | "jsonl";
   config: WaymarkConfig;
+  scanOptions?: ScanRuntimeOptions;
 };
 
 /**
@@ -25,8 +26,8 @@ export type FindCommandOptions = {
 export async function findRecords(
   options: FindCommandOptions
 ): Promise<WaymarkRecord[]> {
-  const { filePath, types, tags, mentions, config } = options;
-  const records = await scanRecords([filePath], config);
+  const { filePath, types, tags, mentions, config, scanOptions } = options;
+  const records = await scanRecords([filePath], config, scanOptions);
 
   const query: Parameters<typeof searchRecords>[1] = {};
   if (types && types.length > 0) {

--- a/packages/cli/src/commands/graph.ts
+++ b/packages/cli/src/commands/graph.ts
@@ -6,15 +6,23 @@ import {
   type WaymarkRecord,
 } from "@waymarks/core";
 
-import { scanRecords } from "./scan";
+import { type ScanRuntimeOptions, scanRecords } from "./scan";
 
 export type ParsedGraphArgs = {
   filePaths: string[];
   json: boolean;
 };
 
-export async function graphRecords(filePaths: string[], config: WaymarkConfig) {
-  const records: WaymarkRecord[] = await scanRecords(filePaths, config);
+export async function graphRecords(
+  filePaths: string[],
+  config: WaymarkConfig,
+  scanOptions?: ScanRuntimeOptions
+) {
+  const records: WaymarkRecord[] = await scanRecords(
+    filePaths,
+    config,
+    scanOptions
+  );
   return buildRelationGraph(records).edges;
 }
 

--- a/packages/cli/src/commands/unified/index.ts
+++ b/packages/cli/src/commands/unified/index.ts
@@ -36,7 +36,9 @@ export async function runUnifiedCommand(
 
   // Graph mode: extract relation edges
   if (isGraphMode) {
-    const edges = await graphRecords(filePaths, context.config);
+    const edges = await graphRecords(filePaths, context.config, {
+      cache: context.globalOptions.cache,
+    });
     if (outputFormat === "json") {
       return { output: JSON.stringify(edges) };
     }
@@ -55,7 +57,9 @@ export async function runUnifiedCommand(
   }
 
   // Scan + filter mode (find behavior)
-  const records = await scanRecords(filePaths, context.config);
+  const records = await scanRecords(filePaths, context.config, {
+    cache: context.globalOptions.cache,
+  });
   const filtered = applyFilters(records, options);
 
   // If JSON output requested, use renderRecords

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -9,6 +9,7 @@ export type GlobalOptions = {
   configPath?: string;
   scope?: CliScopeOption;
   logLevel?: LogLevel;
+  cache?: boolean;
 };
 
 export type CommandContext = {


### PR DESCRIPTION
# Add SQLite Cache Support for CLI Scans

This PR enables the SQLite cache for CLI scans, allowing faster repeated scans of the same files. The cache is disabled by default but can be enabled with the global `--cache` flag.

Key changes:
- Added cache integration to the `scanRecords` function
- Updated the README to document the cache functionality
- Added cache support to all commands that use scanning (find, graph, unified)
- Implemented file modification tracking to determine when to use cached results
- Added scan metrics to track cache performance (files parsed vs. cached)
- Created tests to verify cache functionality

The cache significantly improves performance for repeated scans by storing parsed waymarks and only re-parsing files that have changed since the last scan.