### PR TITLE
chore: reorder imports alphabetically

### DIFF
--- a/packages/cli/src/commands/scan.ts
+++ b/packages/cli/src/commands/scan.ts
@@ -5,9 +5,9 @@ import { performance } from "node:perf_hooks";
 
 import {
   parse,
+  WaymarkCache,
   type WaymarkConfig,
   type WaymarkRecord,
-  WaymarkCache,
 } from "@waymarks/core";
 
 import { expandInputPaths } from "../utils/fs";

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -11,7 +11,7 @@ import { expandFormatPaths, formatFile } from "./commands/fmt";
 import { graphRecords } from "./commands/graph";
 import { lintFiles } from "./commands/lint";
 import type { ModifyPayload } from "./commands/modify";
-import { parseScanArgs, scanRecords, type ScanMetrics } from "./commands/scan";
+import { parseScanArgs, type ScanMetrics, scanRecords } from "./commands/scan";
 import {
   runUnifiedCommand,
   type UnifiedCommandResult,


### PR DESCRIPTION
Reordered imports in CLI package for better organization and consistency. Specifically, reordered imports in `scan.ts` to place `WaymarkCache` before other types from `@waymarks/core`, and reordered imports in `index.test.ts` to alphabetize the named imports from `./commands/scan`.