### PR TITLE
refactor: move roundtrip test from grammar to core package

### DIFF
--- a/packages/core/src/__tests__/contracts/roundtrip.test.ts
+++ b/packages/core/src/__tests__/contracts/roundtrip.test.ts
@@ -2,7 +2,7 @@
 
 import { describe, expect, it } from "bun:test";
 import { parse, type WaymarkRecord } from "@waymarks/grammar";
-import { formatText } from "../../../core/src/format.ts";
+import { formatText } from "../../format.ts";
 
 const SOURCE = [
   "// TODO  ::: Review docs see:Alpha priority:high #perf @alice",


### PR DESCRIPTION
Moved roundtrip test from grammar package to core package

This PR relocates the roundtrip test from `packages/grammar/src/__tests__/roundtrip.test.ts` to `packages/core/src/__tests__/contracts/roundtrip.test.ts` and updates the import path for `formatText` to reflect the new file location.