### PR TITLE
feat(grammar): add support for block comment syntax

### DIFF
--- a/packages/grammar/src/content.ts
+++ b/packages/grammar/src/content.ts
@@ -64,7 +64,11 @@ export function processContentSegment(
   const closingIndex = working.lastIndexOf(SIGIL);
   if (closingIndex >= 0) {
     const afterSigil = working.slice(closingIndex + SIGIL.length).trim();
-    if (afterSigil.length === 0 || afterSigil === "-->" || afterSigil === "*/") {
+    if (
+      afterSigil.length === 0 ||
+      afterSigil === "-->" ||
+      afterSigil === "*/"
+    ) {
       closes = true;
       working = working.slice(0, closingIndex);
     }

--- a/packages/grammar/src/content.ts
+++ b/packages/grammar/src/content.ts
@@ -10,6 +10,7 @@ import type { WaymarkRecord } from "./types";
 
 const LEADING_SPACES_REGEX = /^\s+/;
 const HTML_COMMENT_CLOSE_REGEX = /\s*-->\s*$/;
+const BLOCK_COMMENT_CLOSE_REGEX = /\s*\*\/\s*$/;
 
 export type ContentSegment = {
   text: string;
@@ -33,6 +34,23 @@ export function stripHtmlCommentClosure(
   return content;
 }
 
+export function stripBlockCommentClosure(
+  content: string,
+  commentLeader: string
+): string {
+  if (commentLeader === "/*") {
+    return content.replace(BLOCK_COMMENT_CLOSE_REGEX, "");
+  }
+  return content;
+}
+
+function stripCommentClosure(content: string, commentLeader: string): string {
+  return stripBlockCommentClosure(
+    stripHtmlCommentClosure(content, commentLeader),
+    commentLeader
+  );
+}
+
 export function processContentSegment(
   segment: string,
   commentLeader: string
@@ -40,19 +58,19 @@ export function processContentSegment(
   let working = segment;
 
   working = working.replace(LEADING_SPACES_REGEX, "");
-  working = stripHtmlCommentClosure(working, commentLeader);
+  working = stripCommentClosure(working, commentLeader);
 
   let closes = false;
   const closingIndex = working.lastIndexOf(SIGIL);
   if (closingIndex >= 0) {
     const afterSigil = working.slice(closingIndex + SIGIL.length).trim();
-    if (afterSigil.length === 0 || afterSigil === "-->") {
+    if (afterSigil.length === 0 || afterSigil === "-->" || afterSigil === "*/") {
       closes = true;
       working = working.slice(0, closingIndex);
     }
   }
 
-  working = stripHtmlCommentClosure(working, commentLeader);
+  working = stripCommentClosure(working, commentLeader);
 
   return {
     text: working.trim(),
@@ -66,11 +84,12 @@ export function parseContinuation(
   inWaymarkContext: boolean
 ): ContinuationResult | null {
   const trimmed = line.trimStart();
-  if (!trimmed.startsWith(commentLeader)) {
+  const continuationLeader = resolveContinuationLeader(trimmed, commentLeader);
+  if (!continuationLeader) {
     return null;
   }
 
-  const afterLeader = trimmed.slice(commentLeader.length);
+  const afterLeader = trimmed.slice(continuationLeader.length);
 
   // Check if this line contains ::: (the sigil)
   const sigilIndex = afterLeader.indexOf(SIGIL);
@@ -101,7 +120,7 @@ export function parseContinuation(
     // Check if it's a known property key
     if (PROPERTY_KEYS.has(lowerKey)) {
       // This is a property continuation
-      const strippedValue = stripHtmlCommentClosure(afterSigil, commentLeader);
+      const strippedValue = stripCommentClosure(afterSigil, commentLeader);
       const propertyValue = strippedValue.trim();
       return {
         type: "property",
@@ -121,6 +140,26 @@ export function parseContinuation(
   }
 
   // Otherwise, this line has a marker and shouldn't be treated as a continuation
+  return null;
+}
+
+function resolveContinuationLeader(
+  trimmed: string,
+  commentLeader: string
+): string | null {
+  if (trimmed.startsWith(commentLeader)) {
+    return commentLeader;
+  }
+
+  if (commentLeader === "/*") {
+    if (trimmed.startsWith("*/")) {
+      return null;
+    }
+    if (trimmed.startsWith("*")) {
+      return "*";
+    }
+  }
+
   return null;
 }
 

--- a/packages/grammar/src/parser.test.ts
+++ b/packages/grammar/src/parser.test.ts
@@ -218,6 +218,35 @@ describe("parse", () => {
     );
   });
 
+  test("parses multi-line block comment continuations", () => {
+    const source = [
+      "/* todo ::: document block comment support",
+      " * ::: keeps continuation lines aligned",
+      " * ::: trims closer */",
+      "const noop = true;",
+    ].join("\n");
+
+    const records = parse(source, { file: "src/styles.css" });
+    expect(records).toHaveLength(1);
+    const record = records[0];
+
+    expect(record).toBeDefined();
+    if (!record) {
+      throw new Error("expected waymark record for block comment");
+    }
+
+    expect(record.commentLeader).toBe("/*");
+    expect(record.startLine).toBe(LINE_ONE);
+    expect(record.endLine).toBe(LINE_THREE);
+    expect(record.contentText).toBe(
+      [
+        "document block comment support",
+        "keeps continuation lines aligned",
+        "trims closer",
+      ].join("\n")
+    );
+  });
+
   test("parses property-as-marker in continuation context", () => {
     const source = [
       "// tldr  ::: payment processor entry point",


### PR DESCRIPTION
# Add support for block comment syntax in Waymark

This PR adds support for block comment syntax (`/* */`) in Waymark annotations. The implementation:

1. Adds a new regex pattern to detect block comment closures (`*/`)
2. Creates a `stripBlockCommentClosure` function to handle block comment syntax
3. Introduces a `stripCommentClosure` helper that handles both HTML and block comment closures
4. Adds logic to detect and process continuation lines in block comments (handling `*` prefix)
5. Includes a test case for multi-line block comment continuations

With this change, Waymark annotations can now be used in CSS, C-style languages, and other formats that use block comment syntax.