### PR TITLE
style(grammar): format conditional with line breaks

### DIFF
--- a/packages/grammar/src/content.ts
+++ b/packages/grammar/src/content.ts
@@ -64,7 +64,11 @@ export function processContentSegment(
   const closingIndex = working.lastIndexOf(SIGIL);
   if (closingIndex >= 0) {
     const afterSigil = working.slice(closingIndex + SIGIL.length).trim();
-    if (afterSigil.length === 0 || afterSigil === "-->" || afterSigil === "*/") {
+    if (
+      afterSigil.length === 0 ||
+      afterSigil === "-->" ||
+      afterSigil === "*/"
+    ) {
       closes = true;
       working = working.slice(0, closingIndex);
     }


### PR DESCRIPTION
Reformatted conditional statement in `processContentSegment` function for better readability by breaking a long condition into multiple lines.