### PR TITLE
style: reorder imports in CLI entrypoint

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -3,9 +3,9 @@
 // tldr ::: waymark CLI entrypoint bootstrap
 
 import {
-  __test as programTest,
   createProgram as programCreateProgram,
   runCli as programRunCli,
+  __test as programTest,
   runMain,
 } from "./program.ts";
 


### PR DESCRIPTION
Reordered imports in packages/cli/src/index.ts to maintain alphabetical order, moving `__test as programTest` after the other imports from program.ts.