### PR TITLE
refactor: organize imports and add type annotation

### DIFF
--- a/packages/cli/src/commands/register.ts
+++ b/packages/cli/src/commands/register.ts
@@ -1,13 +1,13 @@
 // tldr ::: commander command registration for waymark CLI
 
-import { Command, InvalidArgumentError } from "commander";
+import { type Command, InvalidArgumentError } from "commander";
 import { createUsageError } from "../errors.ts";
 import type { ModifyCliOptions } from "../types.ts";
+import { parsePropertyEntry } from "../utils/properties.ts";
 import type { ConfigCommandOptions } from "./config.ts";
 import type { DoctorCommandOptions } from "./doctor.ts";
 import { getTopicHelp, helpTopicNames } from "./help/index.ts";
 import type { SkillCommandOptions } from "./skill.ts";
-import { parsePropertyEntry } from "../utils/properties.ts";
 
 const POSITION_ERROR = "--position must be 'before' or 'after'";
 const ORDER_ERROR = "--order expects an integer";

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -23,6 +23,7 @@ import { helpTopicNames } from "./commands/help/index.ts";
 import { runInitCommand } from "./commands/init.ts";
 import { lintFiles as runLint } from "./commands/lint.ts";
 import { type ModifyOptions, runModifyCommand } from "./commands/modify.ts";
+import { registerCommands } from "./commands/register.ts";
 import {
   buildRemoveArgs,
   type ParsedRemoveArgs,
@@ -43,10 +44,13 @@ import {
   runUpdateCommand,
   type UpdateCommandOptions,
 } from "./commands/update.ts";
-import { registerCommands } from "./commands/register.ts";
 import { CliError, createUsageError } from "./errors.ts";
 import { ExitCode } from "./exit-codes.ts";
-import type { CommandContext, GlobalOptions, ModifyCliOptions } from "./types.ts";
+import type {
+  CommandContext,
+  GlobalOptions,
+  ModifyCliOptions,
+} from "./types.ts";
 import { createContext } from "./utils/context.ts";
 import { logger } from "./utils/logger.ts";
 import { normalizeScope } from "./utils/options.ts";


### PR DESCRIPTION
This PR improves import organization and type declarations in the CLI codebase. It adds the `type` keyword to the `Command` import from "commander" in the register.ts file, making it clear that it's a type import. The PR also reorders imports in both register.ts and program.ts for better consistency, grouping related imports together. Additionally, it formats the type imports in program.ts by breaking them into multiple lines for improved readability.