### PR TITLE
test(core): add property-based tests for normalization functions

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -84,6 +84,7 @@
       },
       "devDependencies": {
         "@types/bun": "1.2.22",
+        "fast-check": "4.5.3",
       },
     },
     "packages/grammar": {
@@ -443,6 +444,8 @@
 
     "exsolve": ["exsolve@1.0.7", "", {}, "sha512-VO5fQUzZtI6C+vx4w/4BWJpg3s/5l+6pRQEHzFRM8WFi4XffSP1Z+4qi7GbjWbvRQEbdIco5mIMq+zX4rPuLrw=="],
 
+    "fast-check": ["fast-check@4.5.3", "", { "dependencies": { "pure-rand": "^7.0.0" } }, "sha512-IE9csY7lnhxBnA8g/WI5eg/hygA6MGWJMSNfFRrBlXUciADEhS1EDB0SIsMSvzubzIlOBbVITSsypCsW717poA=="],
+
     "fast-copy": ["fast-copy@3.0.2", "", {}, "sha512-dl0O9Vhju8IrcLndv2eU4ldt1ftXMqqfgN4H1cpmGV7P6jeB9FwpN9a2c8DPGE1Ys88rNUJVYDHq73CGAGOPfQ=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
@@ -712,6 +715,8 @@
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
     "punycode.js": ["punycode.js@2.3.1", "", {}, "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA=="],
+
+    "pure-rand": ["pure-rand@7.0.1", "", {}, "sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ=="],
 
     "qs": ["qs@6.14.0", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w=="],
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -27,6 +27,7 @@
     "zod": "4.1.12"
   },
   "devDependencies": {
-    "@types/bun": "1.2.22"
+    "@types/bun": "1.2.22",
+    "fast-check": "4.5.3"
   }
 }

--- a/packages/core/src/__tests__/properties/normalize.test.ts
+++ b/packages/core/src/__tests__/properties/normalize.test.ts
@@ -1,0 +1,93 @@
+// tldr ::: property-based checks for core normalization helpers
+
+import { describe, expect, it } from "bun:test";
+import fc from "fast-check";
+import {
+  normalizeCanonicals,
+  normalizeMentions,
+  normalizeTags,
+  normalizeType,
+} from "../../normalize.ts";
+
+const STRING_ARBITRARY = fc.string({ maxLength: 48 });
+const STRING_ARRAY_ARBITRARY = fc.array(STRING_ARBITRARY, { maxLength: 24 });
+
+function isSorted(values: string[]): boolean {
+  for (let index = 1; index < values.length; index += 1) {
+    const previous = values[index - 1] ?? "";
+    const current = values[index] ?? "";
+    if (previous.localeCompare(current) > 0) {
+      return false;
+    }
+  }
+  return true;
+}
+
+describe("normalize (property-based)", () => {
+  it("normalizeTags is idempotent, unique, and sorted", () => {
+    fc.assert(
+      fc.property(STRING_ARRAY_ARBITRARY, (tags) => {
+        const once = normalizeTags(tags);
+        const twice = normalizeTags(once);
+
+        expect(twice).toEqual(once);
+        expect(new Set(once).size).toBe(once.length);
+        expect(isSorted(once)).toBe(true);
+        for (const tag of once) {
+          expect(tag).toBe(tag.trim().toLowerCase());
+        }
+      }),
+      { numRuns: 75 }
+    );
+  });
+
+  it("normalizeCanonicals is idempotent and canonicalizes tokens", () => {
+    fc.assert(
+      fc.property(STRING_ARRAY_ARBITRARY, (tokens) => {
+        const once = normalizeCanonicals(tokens);
+        const twice = normalizeCanonicals(once);
+
+        expect(twice).toEqual(once);
+        expect(new Set(once).size).toBe(once.length);
+        expect(isSorted(once)).toBe(true);
+        for (const token of once) {
+          if (token.length === 0) {
+            expect(token).toBe("");
+            continue;
+          }
+          expect(token.startsWith("#")).toBe(true);
+          expect(token).toBe(token.trim().toLowerCase());
+        }
+      }),
+      { numRuns: 75 }
+    );
+  });
+
+  it("normalizeMentions is idempotent and trims whitespace", () => {
+    fc.assert(
+      fc.property(STRING_ARRAY_ARBITRARY, (mentions) => {
+        const once = normalizeMentions(mentions);
+        const twice = normalizeMentions(once);
+
+        expect(twice).toEqual(once);
+        expect(new Set(once).size).toBe(once.length);
+        expect(isSorted(once)).toBe(true);
+        for (const mention of once) {
+          expect(mention).toBe(mention.trim());
+        }
+      }),
+      { numRuns: 75 }
+    );
+  });
+
+  it("normalizeType is idempotent for any string", () => {
+    fc.assert(
+      fc.property(STRING_ARBITRARY, (input) => {
+        const once = normalizeType(input);
+        const twice = normalizeType(once);
+        expect(twice).toBe(once);
+      }),
+      { numRuns: 75 }
+    );
+  });
+});


### PR DESCRIPTION
# Add property-based tests for normalization helpers

Added property-based tests for core normalization functions using fast-check. The tests verify that:

- `normalizeTags` is idempotent, produces unique and sorted results, and properly trims/lowercases tags
- `normalizeCanonicals` is idempotent, properly formats tokens with '#' prefix, and handles sorting/uniqueness
- `normalizeMentions` is idempotent, trims whitespace, and maintains uniqueness and sorting
- `normalizeType` is idempotent for any string input

These tests help ensure the normalization functions maintain their expected properties across a wide range of inputs.