### PR TITLE
fix(core): add type annotations for WaymarkIdConfig

### DIFF
--- a/packages/core/src/__tests__/contracts/ids.test.ts
+++ b/packages/core/src/__tests__/contracts/ids.test.ts
@@ -13,6 +13,7 @@ import {
   WaymarkIdManager,
   type WaymarkIdMetadata,
 } from "../../ids.ts";
+import type { WaymarkIdConfig } from "../../types.ts";
 
 const WORKSPACE_PREFIX = "waymark-contract-ids-";
 
@@ -46,7 +47,7 @@ describe("ID contracts", () => {
 
     try {
       const metadata = buildMetadata();
-      const config = { ...DEFAULT_CONFIG.ids, mode: "auto" };
+      const config: WaymarkIdConfig = { ...DEFAULT_CONFIG.ids, mode: "auto" };
       const managerA = new WaymarkIdManager(
         config,
         new JsonIdIndex({ workspaceRoot: workspaceA })
@@ -73,7 +74,11 @@ describe("ID contracts", () => {
 
     try {
       const metadata = buildMetadata();
-      const config = { ...DEFAULT_CONFIG.ids, mode: "auto", length: 9 };
+      const config: WaymarkIdConfig = {
+        ...DEFAULT_CONFIG.ids,
+        mode: "auto",
+        length: 9,
+      };
       const manager = new WaymarkIdManager(
         config,
         new JsonIdIndex({ workspaceRoot: workspace })

--- a/packages/core/src/remove.ts
+++ b/packages/core/src/remove.ts
@@ -402,7 +402,7 @@ async function applyMatchesForFile(
         file: removal.record.file,
         line: removal.record.startLine,
         removed: removal.removedLines.join(context.originalEol),
-        status: "success",
+        status: "success" as const,
       }))
     );
     return;
@@ -434,7 +434,7 @@ async function applyMatchesForFile(
       file: removal.record.file,
       line: removal.record.startLine,
       removed: removal.removedLines.join(context.originalEol),
-      status: "success",
+      status: "success" as const,
     }))
   );
 


### PR DESCRIPTION
This PR adds explicit type annotations to improve type safety in the codebase. It adds a missing import for `WaymarkIdConfig` in the ID contracts test file and explicitly types variables that use this type. Additionally, it adds `as const` type assertions to string literals in the `remove.ts` file to ensure the `status` property is correctly typed as a literal "success" rather than a generic string.