### PR TITLE
fix(core): make ID generation deterministic

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -50,7 +50,7 @@ export const DEFAULT_CONFIG: WaymarkConfig = {
   },
   ids: {
     mode: "prompt",
-    length: 8,
+    length: 7,
     rememberUserChoice: true,
     trackHistory: true,
     assignOnRefresh: false,

--- a/packages/core/src/ids.test.ts
+++ b/packages/core/src/ids.test.ts
@@ -1,0 +1,74 @@
+// tldr ::: deterministic ID generation tests covering default length and stability
+
+import { describe, expect, it } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DEFAULT_CONFIG } from "./config.ts";
+import { JsonIdIndex } from "./id-index.ts";
+import {
+  fingerprintContent,
+  fingerprintContext,
+  WaymarkIdManager,
+  type WaymarkIdMetadata,
+} from "./ids.ts";
+
+const DEFAULT_ID_LENGTH = 7;
+
+function createWorkspace(prefix = "waymark-ids-"): Promise<string> {
+  return mkdtemp(join(tmpdir(), prefix));
+}
+
+async function cleanupWorkspace(path: string | undefined): Promise<void> {
+  if (path?.startsWith(join(tmpdir(), "waymark-ids-"))) {
+    await rm(path, { recursive: true, force: true });
+  }
+}
+
+describe("WaymarkIdManager", () => {
+  it("defaults to 7-character IDs", () => {
+    expect(DEFAULT_CONFIG.ids.length).toBe(DEFAULT_ID_LENGTH);
+  });
+
+  it("generates deterministic IDs across fresh manager instances", async () => {
+    const workspaceA = await createWorkspace();
+    const workspaceB = await createWorkspace();
+
+    try {
+      const idConfig = { ...DEFAULT_CONFIG.ids, mode: "auto" };
+      const metadata: WaymarkIdMetadata = {
+        file: "/repo/src/app.ts",
+        line: 12,
+        type: "todo",
+        content: "add coverage",
+        contentHash: fingerprintContent("add coverage"),
+        contextHash: fingerprintContext("/repo/src/app.ts:12"),
+        sourceType: "cli",
+      };
+
+      const managerA = new WaymarkIdManager(
+        idConfig,
+        new JsonIdIndex({ workspaceRoot: workspaceA })
+      );
+      const managerB = new WaymarkIdManager(
+        idConfig,
+        new JsonIdIndex({ workspaceRoot: workspaceB })
+      );
+
+      const idA = await managerA.reserveId(metadata);
+      const idB = await managerB.reserveId(metadata);
+
+      expect(idA).toBeDefined();
+      expect(idB).toBeDefined();
+      expect(idA).toBe(idB);
+
+      if (!idA) {
+        throw new Error("Expected reserved ID");
+      }
+      expect(idA.slice(2, -2)).toHaveLength(DEFAULT_CONFIG.ids.length);
+    } finally {
+      await cleanupWorkspace(workspaceA);
+      await cleanupWorkspace(workspaceB);
+    }
+  });
+});

--- a/packages/core/src/ids.ts
+++ b/packages/core/src/ids.ts
@@ -163,7 +163,7 @@ export class WaymarkIdManager {
   }
 
   private async generateUniqueId(metadata: WaymarkIdMetadata): Promise<string> {
-    const baseInput = `${metadata.file}|${metadata.line}|${metadata.type}|${metadata.content}|${Date.now()}`;
+    const baseInput = `${metadata.file}|${metadata.line}|${metadata.type}|${metadata.content}`;
     let attempt = 0;
     const maxAttempts = 25;
 


### PR DESCRIPTION
## Summary
- Ensure ID generation is deterministic across runs and environments.
- Add tests to lock in deterministic ID behavior and config handling.
- Adjust core ID helpers to avoid nondeterministic ordering.

## Testing
- bun check:all


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests for ID generation, validating deterministic behavior and consistent length requirements across independent instances.

* **Refactor**
  * Reduced default ID length from 8 to 7 characters.
  * ID generation is now deterministic, producing consistent results for identical inputs without time-based variation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->