### PR TITLE
fix(core): make remove transactional

### DIFF
--- a/packages/core/src/remove.ts
+++ b/packages/core/src/remove.ts
@@ -402,7 +402,7 @@ async function applyMatchesForFile(
         file: removal.record.file,
         line: removal.record.startLine,
         removed: removal.removedLines.join(context.originalEol),
-        status: "success",
+        status: "success" as const,
       }))
     );
     return;
@@ -434,7 +434,7 @@ async function applyMatchesForFile(
       file: removal.record.file,
       line: removal.record.startLine,
       removed: removal.removedLines.join(context.originalEol),
-      status: "success",
+      status: "success" as const,
     }))
   );
 


### PR DESCRIPTION
## Summary
- Make waymark removal transactional via atomic file writes.
- Expand remove tests to cover transactional behavior and success results.
- Ensure removal results use literal status to satisfy strict typing.

## Testing
- bun check:all


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive test coverage for removal operation failure scenarios to verify that index entries and file content remain unchanged when write operations fail unexpectedly.

* **Bug Fixes**
  * Enhanced removal operations with atomic write mechanisms to prevent partial file updates, ensuring data consistency and integrity are maintained when failures occur during removal operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->