### PR TITLE
feat(cli): validate JSON outputs + improve CLI UX

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,11 +1,14 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "waymark",
       "devDependencies": {
         "@biomejs/biome": "^2.2.4",
         "@types/bun": "^1.2.22",
+        "ajv": "8.17.1",
+        "ajv-formats": "3.0.1",
         "lefthook": "^1.13.4",
         "markdownlint-cli2": "^0.18.1",
         "pino": "9.13.0",
@@ -307,7 +310,9 @@
 
     "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
 
-    "ajv": ["ajv@6.12.6", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g=="],
+    "ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
+
+    "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
 
     "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
@@ -443,6 +448,8 @@
 
     "fast-safe-stringify": ["fast-safe-stringify@2.1.1", "", {}, "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="],
 
+    "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
+
     "fastq": ["fastq@1.19.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ=="],
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
@@ -513,7 +520,7 @@
 
     "js-yaml": ["js-yaml@4.1.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA=="],
 
-    "json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
+    "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "jsonc-parser": ["jsonc-parser@3.3.1", "", {}, "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ=="],
 
@@ -701,6 +708,8 @@
 
     "regexp-tree": ["regexp-tree@0.1.27", "", { "bin": { "regexp-tree": "bin/regexp-tree" } }, "sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA=="],
 
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
     "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
 
     "rollup": ["rollup@4.52.2", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.52.2", "@rollup/rollup-android-arm64": "4.52.2", "@rollup/rollup-darwin-arm64": "4.52.2", "@rollup/rollup-darwin-x64": "4.52.2", "@rollup/rollup-freebsd-arm64": "4.52.2", "@rollup/rollup-freebsd-x64": "4.52.2", "@rollup/rollup-linux-arm-gnueabihf": "4.52.2", "@rollup/rollup-linux-arm-musleabihf": "4.52.2", "@rollup/rollup-linux-arm64-gnu": "4.52.2", "@rollup/rollup-linux-arm64-musl": "4.52.2", "@rollup/rollup-linux-loong64-gnu": "4.52.2", "@rollup/rollup-linux-ppc64-gnu": "4.52.2", "@rollup/rollup-linux-riscv64-gnu": "4.52.2", "@rollup/rollup-linux-riscv64-musl": "4.52.2", "@rollup/rollup-linux-s390x-gnu": "4.52.2", "@rollup/rollup-linux-x64-gnu": "4.52.2", "@rollup/rollup-linux-x64-musl": "4.52.2", "@rollup/rollup-openharmony-arm64": "4.52.2", "@rollup/rollup-win32-arm64-msvc": "4.52.2", "@rollup/rollup-win32-ia32-msvc": "4.52.2", "@rollup/rollup-win32-x64-gnu": "4.52.2", "@rollup/rollup-win32-x64-msvc": "4.52.2", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-I25/2QgoROE1vYV+NQ1En9T9UFB9Cmfm2CJ83zZOlaDpvz29wGQSZXWKw7MiNXau7wYgB/T9fVIdIuEQ+KbiiA=="],
@@ -857,6 +866,8 @@
 
     "zod-to-json-schema": ["zod-to-json-schema@3.24.6", "", { "peerDependencies": { "zod": "^3.24.1" } }, "sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg=="],
 
+    "@modelcontextprotocol/sdk/ajv": ["ajv@6.12.6", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g=="],
+
     "@modelcontextprotocol/sdk/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "@waymarks/cli/pino": ["pino@9.12.0", "", { "dependencies": { "atomic-sleep": "^1.0.0", "on-exit-leak-free": "^2.1.0", "pino-abstract-transport": "^2.0.0", "pino-std-serializers": "^7.0.0", "process-warning": "^5.0.0", "quick-format-unescaped": "^4.0.3", "real-require": "^0.2.0", "safe-stable-stringify": "^2.3.1", "slow-redact": "^0.3.0", "sonic-boom": "^4.0.1", "thread-stream": "^3.0.0" }, "bin": { "pino": "bin.js" } }, "sha512-0Gd0OezGvqtqMwgYxpL7P0pSHHzTJ0Lx992h+mNlMtRVfNnqweWmf0JmRWk5gJzHalyd2mxTzKjhiNbGS2Ztfw=="],
@@ -880,5 +891,7 @@
     "vitest/tinyexec": ["tinyexec@0.3.2", "", {}, "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA=="],
 
     "zod-to-json-schema/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@modelcontextprotocol/sdk/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,6 +37,8 @@
   "devDependencies": {
     "@biomejs/biome": "^2.2.4",
     "@types/bun": "^1.2.22",
+    "ajv": "8.17.1",
+    "ajv-formats": "3.0.1",
     "lefthook": "^1.13.4",
     "markdownlint-cli2": "^0.18.1",
     "pino": "9.13.0",

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -6,6 +6,7 @@ import { homedir } from "node:os";
 import { join, resolve } from "node:path";
 import inquirer from "inquirer";
 import { logger } from "../utils/logger.ts";
+import { assertPromptAllowed } from "../utils/prompts.ts";
 
 type ConfigFormat = "toml" | "jsonc" | "yaml" | "yml";
 type ConfigPreset = "full" | "minimal";
@@ -41,6 +42,7 @@ export async function runInitCommand(
     scope = validateScope(options.scope ?? "project");
     force = options.force ?? false;
   } else {
+    assertPromptAllowed("configuration selection");
     const answers = await inquirer.prompt<{
       format: ConfigFormat;
       preset: ConfigPreset;

--- a/packages/cli/src/commands/modify.ts
+++ b/packages/cli/src/commands/modify.ts
@@ -16,6 +16,7 @@ import inquirer from "inquirer";
 
 import type { CommandContext } from "../types.ts";
 import { logger } from "../utils/logger.ts";
+import { assertPromptAllowed } from "../utils/prompts.ts";
 import { readStream } from "../utils/stdin.ts";
 
 export type ModifyOptions = {
@@ -498,6 +499,7 @@ async function runInteractiveSession(
   baseContent: string,
   options: ModifyOptions
 ): Promise<ModifyOptions> {
+  assertPromptAllowed("interactive editing");
   logger.info(
     "Interactive mode: Backspace on an empty input to go back. Press Esc to cancel."
   );

--- a/packages/cli/src/commands/unified/index.ts
+++ b/packages/cli/src/commands/unified/index.ts
@@ -15,6 +15,8 @@ export type UnifiedCommandResult = {
   records?: WaymarkRecord[];
 };
 
+const DEFAULT_CHALK_LEVEL = chalk.level;
+
 /**
  * Unified command handler that intelligently routes to scan/find/map/graph behavior
  * based on flags and arguments provided.
@@ -28,6 +30,8 @@ export async function runUnifiedCommand(
   // Disable chalk colors if --no-color flag is set
   if (noColor) {
     chalk.level = 0;
+  } else {
+    chalk.level = DEFAULT_CHALK_LEVEL;
   }
 
   // Graph mode: extract relation edges

--- a/packages/cli/src/commands/update.test.ts
+++ b/packages/cli/src/commands/update.test.ts
@@ -54,4 +54,31 @@ describe("runUpdateCommand", () => {
 
     __setChildRunner();
   });
+
+  test("rejects unsupported update commands", async () => {
+    const result = await runUpdateCommand({ command: "rm" });
+    expect(result.exitCode).toBe(1);
+    expect(result.skipped).toBe(true);
+    expect(result.message).toContain("Unsupported update command");
+  });
+
+  test("accepts allowed update command override", async () => {
+    const calls: Array<{ command: string; args: string[] }> = [];
+    __setChildRunner((command, args) => {
+      calls.push({ command, args });
+      return Promise.resolve(0);
+    });
+
+    const result = await runUpdateCommand({
+      command: "pnpm",
+      force: true,
+      yes: true,
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(calls[0]?.command).toBe("pnpm");
+    expect(calls[0]?.args).toEqual(["install", "-g", "@waymarks/cli"]);
+
+    __setChildRunner();
+  });
 });

--- a/packages/cli/src/errors.ts
+++ b/packages/cli/src/errors.ts
@@ -1,0 +1,21 @@
+// tldr ::: CLI error helpers for consistent exit codes [[cli/errors]]
+
+import { ExitCode } from "./exit-codes.ts";
+
+export class CliError extends Error {
+  exitCode: ExitCode;
+
+  constructor(message: string, exitCode: ExitCode) {
+    super(message);
+    this.name = "CliError";
+    this.exitCode = exitCode;
+  }
+}
+
+export function createUsageError(message: string): CliError {
+  return new CliError(message, ExitCode.usageError);
+}
+
+export function createConfigError(message: string): CliError {
+  return new CliError(message, ExitCode.configError);
+}

--- a/packages/cli/src/exit-codes.ts
+++ b/packages/cli/src/exit-codes.ts
@@ -1,0 +1,11 @@
+// tldr ::: standardized CLI exit codes for waymark commands [[cli/exit-codes]]
+
+export const ExitCode = {
+  success: 0,
+  failure: 1,
+  usageError: 2,
+  configError: 3,
+  ioError: 4,
+} as const;
+
+export type ExitCode = (typeof ExitCode)[keyof typeof ExitCode];

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -4,7 +4,7 @@
 
 import tab from "@bomb.sh/tab/commander";
 import type { WaymarkConfig } from "@waymarks/core";
-import { Command, Option } from "commander";
+import { Command, CommanderError, Option } from "commander";
 import simpleUpdateNotifier from "simple-update-notifier";
 import { parseAddArgs, runAddCommand } from "./commands/add.ts";
 import {
@@ -29,12 +29,18 @@ import {
   runUpdateCommand,
   type UpdateCommandOptions,
 } from "./commands/update.ts";
+import { CliError, createUsageError } from "./errors.ts";
+import { ExitCode } from "./exit-codes.ts";
 import type { CommandContext } from "./types.ts";
 import { loadPrompt } from "./utils/content-loader.ts";
 import { createContext } from "./utils/context.ts";
 import { logger } from "./utils/logger.ts";
 import { normalizeScope } from "./utils/options.ts";
-import { confirmWrite, selectWaymark } from "./utils/prompts.ts";
+import {
+  confirmWrite,
+  selectWaymark,
+  setPromptPolicy,
+} from "./utils/prompts.ts";
 
 const STDOUT = process.stdout;
 const STDERR = process.stderr;
@@ -45,6 +51,55 @@ function writeStdout(message: string): void {
 
 function writeStderr(message: string): void {
   STDERR.write(`${message}\n`);
+}
+
+function resolveCommanderExitCode(error: CommanderError): ExitCode {
+  if (error.exitCode === 0) {
+    return ExitCode.success;
+  }
+  if (error.code.startsWith("commander.")) {
+    return ExitCode.usageError;
+  }
+  return (error.exitCode ?? ExitCode.failure) as ExitCode;
+}
+
+function resolveExitCode(error: unknown): ExitCode {
+  if (error instanceof CliError) {
+    return error.exitCode;
+  }
+  if (error instanceof CommanderError) {
+    return resolveCommanderExitCode(error);
+  }
+  if (
+    error &&
+    typeof error === "object" &&
+    "code" in error &&
+    typeof (error as NodeJS.ErrnoException).code === "string"
+  ) {
+    return ExitCode.ioError;
+  }
+  return ExitCode.failure;
+}
+
+function resolveErrorMessage(error: unknown): string {
+  if (error instanceof Error && error.message.trim().length > 0) {
+    return error.message;
+  }
+  if (typeof error === "string" && error.trim().length > 0) {
+    return error;
+  }
+  return "Unexpected error";
+}
+
+function handleCommandError(program: Command, error: unknown): never {
+  if (error instanceof CommanderError) {
+    throw error;
+  }
+  const message = resolveErrorMessage(error);
+  const exitCode = resolveExitCode(error);
+  const code =
+    exitCode === ExitCode.usageError ? "WAYMARK_USAGE" : "WAYMARK_ERROR";
+  return program.error(message, { exitCode, code });
 }
 
 // Command handlers extracted for complexity management
@@ -59,8 +114,10 @@ async function handleFormatCommand(
       writeStdout(promptText);
       return;
     }
-    writeStderr("No agent prompt available for this command");
-    process.exit(1);
+    throw new CliError(
+      "No agent prompt available for this command",
+      ExitCode.failure
+    );
   }
 
   const scopeValue = program.opts().scope as string;
@@ -102,7 +159,7 @@ async function handleFormatCommand(
         writeStdout(`${filePath}: formatted (${edits.length} edits)`);
       } else {
         writeStdout("Write cancelled");
-        process.exit(1);
+        throw new CliError("Write cancelled", ExitCode.failure);
       }
     } else {
       writeStdout(formattedText);
@@ -121,8 +178,10 @@ async function handleLintCommand(
       writeStdout(promptText);
       return;
     }
-    writeStderr("No agent prompt available for this command");
-    process.exit(1);
+    throw new CliError(
+      "No agent prompt available for this command",
+      ExitCode.failure
+    );
   }
 
   const scopeValue = program.opts().scope as string;
@@ -156,7 +215,7 @@ async function handleLintCommand(
   ).length;
 
   if (errorCount > 0) {
-    process.exit(1);
+    throw new CliError("Lint errors detected", ExitCode.failure);
   }
 }
 
@@ -171,34 +230,40 @@ async function handleAddCommand(
       writeStdout(promptText);
       return;
     }
-    writeStderr("No agent prompt available for this command");
-    process.exit(1);
+    throw new CliError(
+      "No agent prompt available for this command",
+      ExitCode.failure
+    );
   }
 
   const argvTokens = process.argv.slice(2);
   const commandNames = new Set([command.name(), ...command.aliases()]);
   const commandIndex = argvTokens.findIndex((token) => commandNames.has(token));
   const tokens = commandIndex >= 0 ? argvTokens.slice(commandIndex + 1) : [];
-  const filteredTokens = tokens.filter((token) => token !== "--prompt");
+  const filteredTokens = tokens.filter(
+    (token) => token !== "--prompt" && token !== "--no-input"
+  );
 
   const scopeValue = program.opts().scope as string;
   const globalOpts = { scope: normalizeScope(scopeValue) };
   const context = await createContext(globalOpts);
 
+  let parsed: ReturnType<typeof parseAddArgs>;
   try {
-    const parsed = parseAddArgs(filteredTokens);
-    const result = await runAddCommand(parsed, context);
-
-    if (result.output.length > 0) {
-      writeStdout(result.output);
-    }
-
-    if (result.exitCode !== 0) {
-      process.exit(result.exitCode);
-    }
+    parsed = parseAddArgs(filteredTokens);
   } catch (error) {
-    writeStderr(error instanceof Error ? error.message : String(error));
-    process.exit(1);
+    const message = error instanceof Error ? error.message : String(error);
+    throw createUsageError(message);
+  }
+
+  const result = await runAddCommand(parsed, context);
+
+  if (result.output.length > 0) {
+    writeStdout(result.output);
+  }
+
+  if (result.exitCode !== 0) {
+    throw new CliError("Add command failed", ExitCode.failure);
   }
 }
 
@@ -240,8 +305,10 @@ function handlePromptOption(
     writeStdout(promptText);
     return true;
   }
-  writeStderr("No agent prompt available for this command");
-  process.exit(1);
+  throw new CliError(
+    "No agent prompt available for this command",
+    ExitCode.failure
+  );
 }
 
 function extractCommandTokens(_program: Command, command: Command): string[] {
@@ -253,15 +320,15 @@ function extractCommandTokens(_program: Command, command: Command): string[] {
   }
   return argvTokens
     .slice(commandIndex + 1)
-    .filter((token) => token !== "--prompt");
+    .filter((token) => token !== "--prompt" && token !== "--no-input");
 }
 
 function parseRemoveArgsOrExit(tokens: string[]): ParsedRemoveArgs {
   try {
     return parseRemoveArgs(tokens);
   } catch (error) {
-    writeStderr(error instanceof Error ? error.message : String(error));
-    process.exit(1);
+    const message = error instanceof Error ? error.message : String(error);
+    throw createUsageError(message);
   }
 }
 
@@ -274,7 +341,7 @@ async function executeRemovalWriteFlow(
     if (preview.output.length > 0) {
       writeStdout(preview.output);
     }
-    process.exit(preview.exitCode);
+    throw new CliError("Remove preview failed", ExitCode.failure);
   }
 
   const structuredOutput = preview.options.json || preview.options.jsonl;
@@ -291,7 +358,7 @@ async function executeRemovalWriteFlow(
   }
 
   if (actual.exitCode !== 0) {
-    process.exit(actual.exitCode);
+    throw new CliError("Remove command failed", ExitCode.failure);
   }
 }
 
@@ -318,14 +385,12 @@ async function resolveInteractiveTarget(
 ): Promise<{ target: string; id?: string | undefined }> {
   const records = await scanRecords([workspaceRoot], config);
   if (records.length === 0) {
-    writeStderr("No waymarks found to edit.");
-    process.exit(1);
+    throw new CliError("No waymarks found to edit.", ExitCode.failure);
   }
 
   const selected = await selectWaymark({ records });
   if (!selected) {
-    writeStderr("No waymark selected.");
-    process.exit(1);
+    throw new CliError("No waymark selected.", ExitCode.failure);
   }
 
   const target = `${selected.file}:${selected.startLine}`;
@@ -427,7 +492,7 @@ async function handleModifyCommand(
   }
 
   if (rawOptions.json && rawOptions.jsonl) {
-    throw new Error("--json and --jsonl cannot be used together");
+    throw createUsageError("--json and --jsonl cannot be used together");
   }
 
   const scopeValue = program.opts().scope as string;
@@ -464,7 +529,7 @@ async function handleModifyCommand(
   }
 
   if (result.exitCode !== 0) {
-    process.exit(result.exitCode);
+    throw new CliError("Edit command failed", ExitCode.failure);
   }
 }
 
@@ -476,7 +541,7 @@ function outputRemovalPreview(
   }
 
   if (preview.exitCode !== 0) {
-    process.exit(preview.exitCode);
+    throw new CliError("Remove preview failed", ExitCode.failure);
   }
 }
 
@@ -517,7 +582,7 @@ async function handleUpdateAction(
   }
 
   if (result.exitCode !== 0) {
-    process.exit(result.exitCode);
+    throw new CliError(result.message ?? "wm update failed", ExitCode.failure);
   }
 }
 
@@ -665,7 +730,7 @@ async function handleDoctorCommand(
 
   // Exit with appropriate code
   if (!report.healthy) {
-    process.exit(1);
+    throw new CliError("Doctor found issues", ExitCode.failure);
   }
 }
 
@@ -680,8 +745,7 @@ async function handleUnifiedCommand(
       writeStdout(promptText);
       return;
     }
-    writeStderr("No agent prompt available");
-    process.exit(1);
+    throw new CliError("No agent prompt available", ExitCode.failure);
   }
 
   const scopeValue = program.opts().scope as string;
@@ -689,7 +753,13 @@ async function handleUnifiedCommand(
   const context = await createContext(globalOpts);
 
   const args = buildArgsFromOptions(paths, options);
-  const unifiedOptions = parseUnifiedArgs(args);
+  let unifiedOptions: ReturnType<typeof parseUnifiedArgs>;
+  try {
+    unifiedOptions = parseUnifiedArgs(args);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw createUsageError(message);
+  }
   const result = await runUnifiedCommand(unifiedOptions, context);
 
   // Handle interactive selection
@@ -756,7 +826,7 @@ type OptionSection = {
 const ROOT_OPTION_SECTIONS: OptionSection[] = [
   {
     title: "Global Options",
-    longs: ["--help", "--version", "--prompt", "--scope"],
+    longs: ["--help", "--version", "--prompt", "--no-input", "--scope"],
   },
   {
     title: "Logging",
@@ -898,6 +968,10 @@ export async function createProgram(): Promise<Command> {
   });
 
   const program = new Command();
+  program.exitOverride((error) => {
+    const exitCode = resolveCommanderExitCode(error);
+    process.exit(exitCode);
+  });
 
   const jsonOption = new Option("--json", "Output as JSON array");
   const jsonlOption = new Option(
@@ -938,6 +1012,7 @@ export async function createProgram(): Promise<Command> {
       "default"
     )
     .option("--prompt", "show agent-facing documentation")
+    .option("--no-input", "fail if interactive input required")
     .option("--verbose", "enable verbose logging (info level)")
     .option("--debug", "enable debug logging")
     .option("--quiet, -q", "only show errors")
@@ -947,11 +1022,21 @@ export async function createProgram(): Promise<Command> {
     .option("--no-color", "disable ANSI colors")
     .addHelpText(
       "afterAll",
-      "\nNote: Use --prompt flag with any command to see agent-facing documentation"
+      `
+Exit Codes:
+  0  Success
+  1  Waymark error
+  2  Usage error (invalid flags or arguments)
+  3  Configuration error
+  4  I/O error (file not found, permission denied)
+
+Note: Use --prompt flag with any command to see agent-facing documentation
+`
     )
     .hook("preAction", (thisCommand) => {
       // Configure logger based on flags
       const opts = thisCommand.opts();
+      setPromptPolicy({ noInput: Boolean(opts.noInput) });
       if (opts.debug) {
         logger.level = "debug";
       } else if (opts.verbose) {
@@ -968,37 +1053,44 @@ export async function createProgram(): Promise<Command> {
     .option("--prompt", "show agent-facing prompt instead of help")
     .description("display help for command")
     .action((commandName?: string, options?: { prompt?: boolean }) => {
-      if (options?.prompt) {
-        const promptText = loadPrompt(commandName || "unified");
-        if (promptText) {
-          writeStdout(promptText);
-        } else {
-          writeStderr("No agent prompt available for this command");
-          process.exit(1);
+      try {
+        if (options?.prompt) {
+          const promptText = loadPrompt(commandName || "unified");
+          if (promptText) {
+            writeStdout(promptText);
+          } else {
+            throw new CliError(
+              "No agent prompt available for this command",
+              ExitCode.failure
+            );
+          }
+          return;
         }
-        return;
-      }
 
-      if (!commandName) {
-        program.help();
-        return;
-      }
+        if (!commandName) {
+          program.help();
+          return;
+        }
 
-      const cmd = program.commands.find((c) => c.name() === commandName);
-      if (cmd) {
-        cmd.help();
-        return;
-      }
+        const cmd = program.commands.find((c) => c.name() === commandName);
+        if (cmd) {
+          cmd.help();
+          return;
+        }
 
-      const topicHelp = getTopicHelp(commandName);
-      if (topicHelp) {
-        writeStdout(topicHelp);
-        return;
-      }
+        const topicHelp = getTopicHelp(commandName);
+        if (topicHelp) {
+          writeStdout(topicHelp);
+          return;
+        }
 
-      writeStderr(`Unknown command or topic: ${commandName}`);
-      writeStdout(`Available topics: ${helpTopicNames.join(", ")}`);
-      program.help();
+        if (helpTopicNames.length > 0) {
+          writeStdout(`Available topics: ${helpTopicNames.join(", ")}`);
+        }
+        throw createUsageError(`Unknown command or topic: ${commandName}`);
+      } catch (error) {
+        handleCommandError(program, error);
+      }
     });
 
   // Format command
@@ -1046,8 +1138,7 @@ See 'wm fmt --prompt' for agent-facing documentation.
         try {
           await handleFormatCommand(program, paths, options);
         } catch (error) {
-          writeStderr(error instanceof Error ? error.message : String(error));
-          process.exit(1);
+          handleCommandError(program, error);
         }
       }
     );
@@ -1107,8 +1198,12 @@ See 'wm add --prompt' for agent-facing documentation.
     `
     )
     .action(async function (this: Command, ...actionArgs: unknown[]) {
-      const options = (actionArgs.at(-1) ?? {}) as { prompt?: boolean };
-      await handleAddCommand(program, this, options);
+      try {
+        const options = (actionArgs.at(-1) ?? {}) as { prompt?: boolean };
+        await handleAddCommand(program, this, options);
+      } catch (error) {
+        handleCommandError(program, error);
+      }
     });
 
   const editCmd = program
@@ -1171,8 +1266,7 @@ Notes:
             : { ...program.opts(), ...options };
         await handleModifyCommand(program, this, target, mergedOptions);
       } catch (error) {
-        writeStderr(error instanceof Error ? error.message : String(error));
-        process.exit(1);
+        handleCommandError(program, error);
       }
     });
 
@@ -1230,8 +1324,12 @@ See 'wm rm --prompt' for agent-facing documentation.
     `
     )
     .action(async function (this: Command, ...actionArgs: unknown[]) {
-      const options = (actionArgs.at(-1) ?? {}) as { prompt?: boolean };
-      await handleRemoveCommand(program, this, options);
+      try {
+        const options = (actionArgs.at(-1) ?? {}) as { prompt?: boolean };
+        await handleRemoveCommand(program, this, options);
+      } catch (error) {
+        handleCommandError(program, error);
+      }
     });
 
   program
@@ -1244,7 +1342,13 @@ See 'wm rm --prompt' for agent-facing documentation.
       "--command <command>",
       "override the underlying update command (defaults to npm)"
     )
-    .action(handleUpdateAction);
+    .action(async (options) => {
+      try {
+        await handleUpdateAction(options);
+      } catch (error) {
+        handleCommandError(program, error);
+      }
+    });
 
   // Lint command
   program
@@ -1290,8 +1394,7 @@ See 'wm lint --prompt' for agent-facing documentation.
         try {
           await handleLintCommand(program, paths, options);
         } catch (error) {
-          writeStderr(error instanceof Error ? error.message : String(error));
-          process.exit(1);
+          handleCommandError(program, error);
         }
       }
     );
@@ -1318,8 +1421,7 @@ See 'wm lint --prompt' for agent-facing documentation.
         try {
           await runInitCommand(options);
         } catch (error) {
-          writeStderr(error instanceof Error ? error.message : String(error));
-          process.exit(1);
+          handleCommandError(program, error);
         }
       }
     );
@@ -1384,8 +1486,7 @@ See 'wm doctor --prompt' for agent-facing documentation.
       try {
         await handleDoctorCommand(program, { ...options, paths });
       } catch (error) {
-        writeStderr(error instanceof Error ? error.message : String(error));
-        process.exit(2); // Internal error
+        handleCommandError(program, error);
       }
     });
 
@@ -1499,8 +1600,7 @@ See 'wm find --prompt' for agent-facing documentation.
             : { ...program.opts(), ...options };
         await handleUnifiedCommand(program, paths, mergedOptions);
       } catch (error) {
-        writeStderr(error instanceof Error ? error.message : String(error));
-        process.exit(1);
+        handleCommandError(program, error);
       }
     });
 
@@ -1524,8 +1624,7 @@ See 'wm find --help' for all available options and comprehensive documentation.
         const mergedOptions = { ...program.opts(), ...options };
         await handleUnifiedCommand(program, paths, mergedOptions);
       } catch (error) {
-        writeStderr(error instanceof Error ? error.message : String(error));
-        process.exit(1);
+        handleCommandError(program, error);
       }
     });
 
@@ -1551,26 +1650,68 @@ if (import.meta.main) {
   createProgram()
     .then((program) => program.parseAsync(process.argv))
     .catch((error) => {
-      writeStderr(error instanceof Error ? error.message : String(error));
-      process.exit(1);
+      const message = resolveErrorMessage(error);
+      const exitCode = resolveExitCode(error);
+      writeStderr(message);
+      process.exit(exitCode);
     });
 }
 
 // For testing
-export async function runCli(argv: string[]): Promise<{ exitCode: number }> {
+export async function runCli(argv: string[]): Promise<{
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}> {
   const previousArgv = [...process.argv];
   const cliArgv = ["node", "wm", ...argv];
   process.argv = [...cliArgv];
+  const stdoutChunks: string[] = [];
+  const stderrChunks: string[] = [];
+  const originalStdoutWrite = process.stdout.write.bind(process.stdout);
+  const originalStderrWrite = process.stderr.write.bind(process.stderr);
 
+  const capture =
+    (chunks: string[]) =>
+    (
+      chunk: string | Uint8Array,
+      encoding?: BufferEncoding,
+      callback?: () => void
+    ): boolean => {
+      const text =
+        typeof chunk === "string"
+          ? chunk
+          : Buffer.from(chunk).toString(encoding ?? "utf8");
+      chunks.push(text);
+      if (callback) {
+        callback();
+      }
+      return true;
+    };
+
+  process.stdout.write = capture(stdoutChunks) as typeof process.stdout.write;
+  process.stderr.write = capture(stderrChunks) as typeof process.stderr.write;
+
+  let exitCode = ExitCode.success;
   try {
     const program = await createProgram();
+    program.exitOverride((error) => {
+      throw error;
+    });
     await program.parseAsync(cliArgv);
-    return { exitCode: 0 };
-  } catch (_error) {
-    return { exitCode: 1 };
+  } catch (error) {
+    exitCode = resolveExitCode(error);
   } finally {
     process.argv = previousArgv;
+    process.stdout.write = originalStdoutWrite;
+    process.stderr.write = originalStderrWrite;
   }
+
+  return {
+    exitCode,
+    stdout: stdoutChunks.join(""),
+    stderr: stderrChunks.join(""),
+  };
 }
 
 export const __test = {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -752,7 +752,9 @@ async function handleDoctorCommand(
   }
 }
 
-function parseUnifiedOptions(args: string[]): ReturnType<typeof parseUnifiedArgs> {
+function parseUnifiedOptions(
+  args: string[]
+): ReturnType<typeof parseUnifiedArgs> {
   try {
     return parseUnifiedArgs(args);
   } catch (error) {
@@ -775,7 +777,7 @@ async function handleUnifiedInteractiveSelection(
   options: Record<string, unknown>,
   result: Awaited<ReturnType<typeof runUnifiedCommand>>
 ): Promise<boolean> {
-  if (!options.interactive || !result.records || result.records.length === 0) {
+  if (!(options.interactive && result.records) || result.records.length === 0) {
     return false;
   }
   const selected = await selectWaymark({ records: result.records });
@@ -819,10 +821,12 @@ async function handleUnifiedCommand(
   const result = await runUnifiedCommand(unifiedOptions, context);
 
   const didSelect = await handleUnifiedInteractiveSelection(options, result);
-  if (!didSelect && result.output.length > 0) {
-    if (shouldEmitUnifiedOutput(unifiedOptions, options)) {
-      writeStdout(result.output);
-    }
+  if (
+    !didSelect &&
+    result.output.length > 0 &&
+    shouldEmitUnifiedOutput(unifiedOptions, options)
+  ) {
+    writeStdout(result.output);
   }
 }
 

--- a/packages/cli/src/schema-conformance.test.ts
+++ b/packages/cli/src/schema-conformance.test.ts
@@ -1,0 +1,121 @@
+// tldr ::: validate CLI JSON outputs against published JSON schemas
+
+import { describe, test } from "bun:test";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { resolveConfig } from "@waymarks/core";
+import Ajv from "ajv/dist/2020";
+import addFormats from "ajv-formats";
+import { runDoctorCommand } from "./commands/doctor";
+import { lintFiles } from "./commands/lint";
+import { scanRecords } from "./commands/scan";
+import type { CommandContext } from "./types";
+import { renderRecords } from "./utils/output";
+
+type JsonRecord = Record<string, unknown>;
+
+type TempFile = {
+  dir: string;
+  file: string;
+  cleanup: () => Promise<void>;
+};
+
+const rootDir = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
+const schemasDir = join(rootDir, "schemas");
+
+async function loadSchema(name: string): Promise<JsonRecord> {
+  const raw = await readFile(join(schemasDir, name), "utf8");
+  return JSON.parse(raw) as JsonRecord;
+}
+
+async function createValidator(): Promise<Ajv> {
+  const ajv = new Ajv({ allErrors: true, strict: false });
+  addFormats(ajv);
+
+  const schemas = await Promise.all([
+    loadSchema("waymark-record.schema.json"),
+    loadSchema("waymark-scan-result.schema.json"),
+    loadSchema("lint-report.schema.json"),
+    loadSchema("doctor-report.schema.json"),
+  ]);
+
+  for (const schema of schemas) {
+    ajv.addSchema(schema);
+  }
+
+  return ajv;
+}
+
+function assertValid(ajv: Ajv, schemaId: string, payload: unknown): void {
+  const validate = ajv.getSchema(schemaId);
+  if (!validate) {
+    throw new Error(`Schema not registered: ${schemaId}`);
+  }
+  const valid = validate(payload);
+  if (!valid) {
+    throw new Error(
+      `${schemaId} validation failed: ${ajv.errorsText(validate.errors)}`
+    );
+  }
+}
+
+async function withTempFile(content: string): Promise<TempFile> {
+  const dir = await mkdtemp(join(tmpdir(), "waymark-schema-"));
+  const file = join(dir, "sample.ts");
+  await writeFile(file, content, "utf8");
+  return {
+    dir,
+    file,
+    cleanup: () => rm(dir, { recursive: true, force: true }),
+  };
+}
+
+describe("Schema conformance", () => {
+  test("scan output matches scan-result schema", async () => {
+    const { file, cleanup } = await withTempFile("// todo ::: schema check\n");
+    const config = resolveConfig();
+    const records = await scanRecords([file], config);
+    const output = renderRecords(records, "json");
+    const parsed = JSON.parse(output) as unknown;
+    const ajv = await createValidator();
+    assertValid(
+      ajv,
+      "https://outfitter.dev/schemas/waymark-scan-result.schema.json",
+      parsed
+    );
+    await cleanup();
+  });
+
+  test("lint report matches lint-report schema", async () => {
+    const { file, cleanup } = await withTempFile("// unknown ::: lint me\n");
+    const config = resolveConfig();
+    const report = await lintFiles([file], config.allowTypes, config);
+    const ajv = await createValidator();
+    assertValid(
+      ajv,
+      "https://outfitter.dev/schemas/lint-report.schema.json",
+      report
+    );
+    await cleanup();
+  });
+
+  test("doctor report matches doctor-report schema", async () => {
+    const { dir, cleanup } = await withTempFile("// todo ::: doctor check\n");
+    const config = resolveConfig();
+    const context: CommandContext = {
+      config,
+      globalOptions: {},
+      workspaceRoot: dir,
+    };
+    const report = await runDoctorCommand(context, { json: true });
+    const ajv = await createValidator();
+    assertValid(
+      ajv,
+      "https://outfitter.dev/schemas/doctor-report.schema.json",
+      report
+    );
+    await cleanup();
+  });
+});

--- a/packages/cli/src/utils/context.ts
+++ b/packages/cli/src/utils/context.ts
@@ -1,6 +1,7 @@
 // tldr ::: context creation helpers for waymark CLI commands
 
 import { loadConfigFromDisk } from "@waymarks/core";
+import { createConfigError } from "../errors.ts";
 import type { CommandContext, GlobalOptions } from "../types.ts";
 import { resolveWorkspaceRoot } from "./workspace.ts";
 
@@ -15,7 +16,13 @@ export async function createContext(
     ...(configPath ? { explicitPath: configPath } : {}),
   } as const;
 
-  const config = await loadConfigFromDisk(loadOptions);
+  let config: Awaited<ReturnType<typeof loadConfigFromDisk>>;
+  try {
+    config = await loadConfigFromDisk(loadOptions);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw createConfigError(message);
+  }
   const workspaceRoot = resolveWorkspaceRoot(loadOptions.cwd);
 
   return { config, globalOptions, workspaceRoot };

--- a/packages/cli/src/utils/display/formatters/long.ts
+++ b/packages/cli/src/utils/display/formatters/long.ts
@@ -1,6 +1,7 @@
 // tldr ::: long format display for waymark records showing all properties
 
 import type { WaymarkRecord } from "@waymarks/core";
+import { sanitizeInlineText } from "../sanitize";
 
 /**
  * Format records with long display (all properties shown)
@@ -14,28 +15,40 @@ export function formatLong(records: WaymarkRecord[]): string {
     lines.push(
       `  Signals: flagged=${record.signals.flagged}, starred=${record.signals.starred}`
     );
-    lines.push(`  Content: ${record.contentText}`);
+    lines.push(`  Content: ${sanitizeInlineText(record.contentText)}`);
 
     if (Object.keys(record.properties).length > 0) {
       lines.push("  Properties:");
       for (const [key, value] of Object.entries(record.properties)) {
-        lines.push(`    ${key}: ${value}`);
+        lines.push(
+          `    ${sanitizeInlineText(key)}: ${sanitizeInlineText(value)}`
+        );
       }
     }
 
     if (record.relations.length > 0) {
       lines.push("  Relations:");
       for (const rel of record.relations) {
-        lines.push(`    ${rel.kind}: ${rel.token}`);
+        lines.push(
+          `    ${sanitizeInlineText(rel.kind)}: ${sanitizeInlineText(rel.token)}`
+        );
       }
     }
 
     if (record.mentions.length > 0) {
-      lines.push(`  Mentions: ${record.mentions.join(", ")}`);
+      lines.push(
+        `  Mentions: ${record.mentions
+          .map((mention) => sanitizeInlineText(mention))
+          .join(", ")}`
+      );
     }
 
     if (record.tags.length > 0) {
-      lines.push(`  Tags: ${record.tags.join(", ")}`);
+      lines.push(
+        `  Tags: ${record.tags
+          .map((tag) => sanitizeInlineText(tag))
+          .join(", ")}`
+      );
     }
 
     lines.push(""); // Blank line between records

--- a/packages/cli/src/utils/display/formatters/styles.ts
+++ b/packages/cli/src/utils/display/formatters/styles.ts
@@ -7,6 +7,7 @@ import {
   TAG_REGEX,
 } from "@waymarks/grammar";
 import chalk from "chalk";
+import { sanitizeInlineText } from "../sanitize";
 
 // Regex for extracting leading whitespace from property matches
 const LEADING_SPACE_REGEX = /^\s*/;
@@ -222,8 +223,9 @@ export function styleFilePath(path: string): string {
  * Order matters: tags first (to avoid conflict with properties containing colons)
  */
 export function styleContent(content: string): string {
+  const sanitized = sanitizeInlineText(content);
   // Mask code blocks to prevent property matching inside them
-  const { masked, blocks } = maskCodeBlocks(content);
+  const { masked, blocks } = maskCodeBlocks(sanitized);
   let result = masked;
 
   // 1. Style #tags first (handles #perf:hotpath before property detection)

--- a/packages/cli/src/utils/display/formatters/text.ts
+++ b/packages/cli/src/utils/display/formatters/text.ts
@@ -2,6 +2,7 @@
 
 import { readFileSync } from "node:fs";
 import type { WaymarkRecord } from "@waymarks/core";
+import { sanitizeInlineText } from "../sanitize";
 import type { DisplayOptions } from "../types";
 
 /** Default line number width (3 digits = column 4 for colon) */
@@ -15,7 +16,8 @@ export function formatRecordSimple(record: WaymarkRecord): string {
     (record.signals.flagged ? "~" : "") + (record.signals.starred ? "*" : "");
   // Pad line numbers to 3 digits (aligned to column 4) unless > 999
   const lineStr = String(record.startLine).padStart(LINE_NUMBER_WIDTH, " ");
-  return `${record.file}:${lineStr}: // ${signals}${record.type} ::: ${record.contentText}`;
+  const content = sanitizeInlineText(record.contentText);
+  return `${record.file}:${lineStr}: // ${signals}${record.type} ::: ${content}`;
 }
 
 /**
@@ -45,7 +47,7 @@ export function formatRecordWithContext(
 
     for (let i = startLine; i <= endLine; i++) {
       const lineNum = i + 1;
-      const content = fileLines[i];
+      const content = sanitizeInlineText(fileLines[i] ?? "");
       const paddedLineNum = String(lineNum).padStart(lineWidth, " ");
       lines.push(`${paddedLineNum}: ${content}`);
     }

--- a/packages/cli/src/utils/display/formatters/tree.ts
+++ b/packages/cli/src/utils/display/formatters/tree.ts
@@ -2,6 +2,7 @@
 
 import { dirname } from "node:path";
 import type { WaymarkRecord } from "@waymarks/core";
+import { sanitizeInlineText } from "../sanitize";
 
 /**
  * Format a single directory section for tree display
@@ -23,8 +24,9 @@ function formatTreeDirectory(
     const isLastRecord = j === dirRecords.length - 1;
     const prefix = isLast ? "  " : "│ ";
     const branch = isLastRecord ? "└─" : "├─";
+    const content = sanitizeInlineText(record.contentText);
     lines.push(
-      `${prefix}${branch} ${record.file}:${record.startLine}: ${record.type} - ${record.contentText}`
+      `${prefix}${branch} ${record.file}:${record.startLine}: ${record.type} - ${content}`
     );
   }
 

--- a/packages/cli/src/utils/display/grouping.ts
+++ b/packages/cli/src/utils/display/grouping.ts
@@ -4,6 +4,7 @@ import { dirname } from "node:path";
 import type { WaymarkRecord } from "@waymarks/core";
 import type { GroupBy } from "../../commands/unified/types";
 import { formatRecordSimple } from "./formatters/text";
+import { sanitizeInlineText } from "./sanitize";
 import type { DisplayOptions } from "./types";
 
 /**
@@ -86,7 +87,7 @@ export function formatGrouped(
   for (const groupKey of groupKeys) {
     const groupItems = grouped.get(groupKey) || [];
 
-    lines.push(`\n=== ${groupKey} ===\n`);
+    lines.push(`\n=== ${sanitizeInlineText(groupKey)} ===\n`);
 
     for (const record of groupItems) {
       lines.push(formatRecordSimple(record));

--- a/packages/cli/src/utils/display/sanitize.ts
+++ b/packages/cli/src/utils/display/sanitize.ts
@@ -1,0 +1,8 @@
+// tldr ::: sanitize control characters from CLI output [[cli/sanitize-output]]
+
+const CONTROL_CHAR_PATTERN = "[\\u0000-\\u001F\\u007F]";
+const CONTROL_CHAR_REGEX = new RegExp(CONTROL_CHAR_PATTERN, "g");
+
+export function sanitizeInlineText(value: string): string {
+  return value.replace(CONTROL_CHAR_REGEX, "");
+}

--- a/packages/cli/src/utils/output.ts
+++ b/packages/cli/src/utils/output.ts
@@ -10,6 +10,12 @@ export type ScanOutputFormat = "text" | "json" | "jsonl";
 function cleanRecord(record: WaymarkRecord): Partial<WaymarkRecord> {
   const cleaned: Partial<WaymarkRecord> = { ...record };
 
+  if (cleaned.signals) {
+    const { current: _current, ...signals } = cleaned.signals;
+    // note ::: omit deprecated `current` signal from JSON output
+    cleaned.signals = signals;
+  }
+
   // Remove empty arrays
   if (Array.isArray(cleaned.relations) && cleaned.relations.length === 0) {
     cleaned.relations = undefined as unknown as WaymarkRecord["relations"];

--- a/packages/cli/src/utils/prompts.ts
+++ b/packages/cli/src/utils/prompts.ts
@@ -4,6 +4,7 @@ import type { WaymarkRecord } from "@waymarks/grammar";
 import inquirer from "inquirer";
 import { CliError } from "../errors.ts";
 import { ExitCode } from "../exit-codes.ts";
+import { canPrompt } from "./terminal.ts";
 
 type PromptBlockReason = "no-input" | "no-tty" | undefined;
 
@@ -19,8 +20,7 @@ export function setPromptPolicy(options: {
   noInput?: boolean;
   isTty?: boolean;
 }): void {
-  const isTty =
-    options.isTty ?? Boolean(process.stdin.isTTY && process.stdout.isTTY);
+  const isTty = options.isTty ?? canPrompt();
 
   if (options.noInput) {
     promptPolicy = { allowed: false, reason: "no-input" };

--- a/packages/cli/src/utils/prompts.ts
+++ b/packages/cli/src/utils/prompts.ts
@@ -2,6 +2,55 @@
 
 import type { WaymarkRecord } from "@waymarks/grammar";
 import inquirer from "inquirer";
+import { CliError } from "../errors.ts";
+import { ExitCode } from "../exit-codes.ts";
+
+type PromptBlockReason = "no-input" | "no-tty" | undefined;
+
+type PromptPolicy = {
+  allowed: boolean;
+  reason?: PromptBlockReason;
+};
+
+let promptPolicy: PromptPolicy = { allowed: true };
+
+// note ::: central prompt policy for --no-input enforcement [[cli/no-input]]
+export function setPromptPolicy(options: {
+  noInput?: boolean;
+  isTty?: boolean;
+}): void {
+  const isTty =
+    options.isTty ?? Boolean(process.stdin.isTTY && process.stdout.isTTY);
+
+  if (options.noInput) {
+    promptPolicy = { allowed: false, reason: "no-input" };
+    return;
+  }
+
+  if (!isTty) {
+    promptPolicy = { allowed: false, reason: "no-tty" };
+    return;
+  }
+
+  promptPolicy = { allowed: true };
+}
+
+export function assertPromptAllowed(action: string): void {
+  if (promptPolicy.allowed) {
+    return;
+  }
+
+  const reason = promptPolicy.reason;
+  const details =
+    reason === "no-input"
+      ? "because --no-input was specified"
+      : "because the terminal is not interactive";
+
+  throw new CliError(
+    `Cannot prompt for ${action} ${details}.`,
+    ExitCode.usageError
+  );
+}
 
 export type ConfirmOptions = {
   message: string;
@@ -9,6 +58,7 @@ export type ConfirmOptions = {
 };
 
 export async function confirm(options: ConfirmOptions): Promise<boolean> {
+  assertPromptAllowed("confirmation");
   const { confirmed } = await inquirer.prompt<{ confirmed: boolean }>([
     {
       type: "confirm",
@@ -53,6 +103,7 @@ type WaymarkChoice = {
 export async function selectWaymark(
   options: SelectWaymarkOptions
 ): Promise<WaymarkRecord | undefined> {
+  assertPromptAllowed("selection");
   const { records, pageSize = 15 } = options;
 
   if (records.length === 0) {

--- a/packages/cli/src/utils/terminal.ts
+++ b/packages/cli/src/utils/terminal.ts
@@ -1,0 +1,53 @@
+// tldr ::: terminal detection helpers for CLI output [[cli/terminal]]
+
+export type TerminalInfo = {
+  isTty: boolean;
+  supportsColor: boolean;
+  width: number;
+};
+
+const DEFAULT_TERMINAL_WIDTH = 80;
+
+function hasNoColor(): boolean {
+  return process.env.NO_COLOR !== undefined;
+}
+
+function hasForceColor(): boolean {
+  return process.env.FORCE_COLOR !== undefined;
+}
+
+function isDumbTerminal(): boolean {
+  return process.env.TERM === "dumb";
+}
+
+export function canPrompt(): boolean {
+  return Boolean(process.stdin.isTTY && process.stdout.isTTY);
+}
+
+export function shouldUseColor(noColorFlag?: boolean): boolean {
+  if (noColorFlag) {
+    return false;
+  }
+  if (hasNoColor()) {
+    return false;
+  }
+  if (hasForceColor()) {
+    return true;
+  }
+  if (!process.stdout.isTTY) {
+    return false;
+  }
+  if (isDumbTerminal()) {
+    return false;
+  }
+  return true;
+}
+
+export function getTerminalInfo(): TerminalInfo {
+  const isTty = Boolean(process.stdout.isTTY);
+  const width = isTty
+    ? (process.stdout.columns ?? DEFAULT_TERMINAL_WIDTH)
+    : DEFAULT_TERMINAL_WIDTH;
+  const supportsColor = shouldUseColor();
+  return { isTty, supportsColor, width };
+}

--- a/packages/core/src/__tests__/contracts/ids.test.ts
+++ b/packages/core/src/__tests__/contracts/ids.test.ts
@@ -1,0 +1,95 @@
+// tldr ::: contract coverage for deterministic waymark ID generation
+
+import { describe, expect, it } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { DEFAULT_CONFIG } from "../../config.ts";
+import { JsonIdIndex } from "../../id-index.ts";
+import {
+  fingerprintContent,
+  fingerprintContext,
+  WaymarkIdManager,
+  type WaymarkIdMetadata,
+} from "../../ids.ts";
+
+const WORKSPACE_PREFIX = "waymark-contract-ids-";
+
+function createWorkspace(): Promise<string> {
+  return mkdtemp(join(tmpdir(), WORKSPACE_PREFIX));
+}
+
+async function cleanupWorkspace(path: string | undefined): Promise<void> {
+  if (path?.startsWith(join(tmpdir(), WORKSPACE_PREFIX))) {
+    await rm(path, { recursive: true, force: true });
+  }
+}
+
+function buildMetadata(): WaymarkIdMetadata {
+  const content = "review roundtrip contracts";
+  return {
+    file: "/repo/src/contract.ts",
+    line: 42,
+    type: "todo",
+    content,
+    contentHash: fingerprintContent(content),
+    contextHash: fingerprintContext("/repo/src/contract.ts:42"),
+    sourceType: "cli",
+  };
+}
+
+describe("ID contracts", () => {
+  it("produces deterministic IDs across fresh managers", async () => {
+    const workspaceA = await createWorkspace();
+    const workspaceB = await createWorkspace();
+
+    try {
+      const metadata = buildMetadata();
+      const config = { ...DEFAULT_CONFIG.ids, mode: "auto" };
+      const managerA = new WaymarkIdManager(
+        config,
+        new JsonIdIndex({ workspaceRoot: workspaceA })
+      );
+      const managerB = new WaymarkIdManager(
+        config,
+        new JsonIdIndex({ workspaceRoot: workspaceB })
+      );
+
+      const idA = await managerA.reserveId(metadata);
+      const idB = await managerB.reserveId(metadata);
+
+      expect(idA).toBeDefined();
+      expect(idB).toBeDefined();
+      expect(idA).toBe(idB);
+    } finally {
+      await cleanupWorkspace(workspaceA);
+      await cleanupWorkspace(workspaceB);
+    }
+  });
+
+  it("respects configured length and bracket format", async () => {
+    const workspace = await createWorkspace();
+
+    try {
+      const metadata = buildMetadata();
+      const config = { ...DEFAULT_CONFIG.ids, mode: "auto", length: 9 };
+      const manager = new WaymarkIdManager(
+        config,
+        new JsonIdIndex({ workspaceRoot: workspace })
+      );
+
+      const id = await manager.reserveId(metadata);
+
+      expect(id).toBeDefined();
+      if (!id) {
+        throw new Error("Expected generated ID");
+      }
+      expect(id.startsWith("[[")).toBe(true);
+      expect(id.endsWith("]]")).toBe(true);
+      expect(id.slice(2, -2)).toHaveLength(config.length);
+    } finally {
+      await cleanupWorkspace(workspace);
+    }
+  });
+});

--- a/packages/core/src/__tests__/contracts/relations.test.ts
+++ b/packages/core/src/__tests__/contracts/relations.test.ts
@@ -1,0 +1,28 @@
+// tldr ::: contract coverage for relation extraction and normalization
+
+import { describe, expect, it } from "bun:test";
+import { parse } from "@waymarks/grammar";
+
+import { normalizeRelations } from "../../normalize.ts";
+
+describe("relation contracts", () => {
+  it("normalizes relation kinds and tokens consistently", () => {
+    const source =
+      "// todo ::: validate relations see:Alpha docs:Spec from:Source replaces:Legacy";
+    const records = parse(source, { file: "src/contracts.ts" });
+
+    expect(records).toHaveLength(1);
+    const record = records[0];
+    if (!record) {
+      throw new Error("Expected parsed waymark record");
+    }
+
+    const normalized = normalizeRelations(record.relations);
+    expect(normalized).toEqual([
+      { kind: "docs", token: "#spec" },
+      { kind: "from", token: "#source" },
+      { kind: "replaces", token: "#legacy" },
+      { kind: "see", token: "#alpha" },
+    ]);
+  });
+});

--- a/packages/grammar/src/__tests__/roundtrip.test.ts
+++ b/packages/grammar/src/__tests__/roundtrip.test.ts
@@ -1,0 +1,41 @@
+// tldr ::: parse/format roundtrip contract for waymark grammar
+
+import { describe, expect, it } from "bun:test";
+import { parse, type WaymarkRecord } from "@waymarks/grammar";
+import { formatText } from "../../../core/src/format.ts";
+
+const SOURCE = [
+  "// TODO  ::: Review docs see:Alpha priority:high #perf @alice",
+  "//       ::: follow up with docs:Spec",
+].join("\n");
+
+function pickRecord(record: WaymarkRecord) {
+  return {
+    type: record.type,
+    contentText: record.contentText,
+    properties: record.properties,
+    relations: record.relations,
+    canonicals: record.canonicals,
+    mentions: record.mentions,
+    tags: record.tags,
+    signals: record.signals,
+    commentLeader: record.commentLeader,
+  };
+}
+
+describe("parse/format roundtrip", () => {
+  it("preserves record semantics after formatting", () => {
+    const options = { file: "src/roundtrip.ts" };
+    const original = parse(SOURCE, options).map(pickRecord);
+    const { formattedText } = formatText(SOURCE, options);
+    const formatted = parse(formattedText, options).map(pickRecord);
+
+    expect(formatted).toEqual(original);
+
+    const { formattedText: formattedAgain } = formatText(
+      formattedText,
+      options
+    );
+    expect(formattedAgain).toBe(formattedText);
+  });
+});

--- a/schemas/doctor-report.schema.json
+++ b/schemas/doctor-report.schema.json
@@ -1,0 +1,113 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://outfitter.dev/schemas/doctor-report.schema.json",
+  "title": "WaymarkDoctorReport",
+  "description": "Health check report from the waymark CLI",
+  "type": "object",
+  "required": ["healthy", "timestamp", "checks", "issues", "summary"],
+  "$defs": {
+    "diagnosticIssue": {
+      "type": "object",
+      "required": ["severity", "category", "message"],
+      "properties": {
+        "severity": {
+          "type": "string",
+          "enum": ["error", "warning", "info"],
+          "description": "Severity of the issue"
+        },
+        "category": {
+          "type": "string",
+          "description": "Issue category"
+        },
+        "message": {
+          "type": "string",
+          "description": "Human-readable issue description"
+        },
+        "file": {
+          "type": "string",
+          "description": "File path associated with the issue"
+        },
+        "line": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Line number associated with the issue"
+        },
+        "suggestion": {
+          "type": "string",
+          "description": "Suggested remediation"
+        }
+      },
+      "additionalProperties": false
+    },
+    "checkResult": {
+      "type": "object",
+      "required": ["category", "name", "passed", "issues"],
+      "properties": {
+        "category": {
+          "type": "string",
+          "description": "Check category"
+        },
+        "name": {
+          "type": "string",
+          "description": "Check name"
+        },
+        "passed": {
+          "type": "boolean",
+          "description": "Whether the check passed"
+        },
+        "issues": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/diagnosticIssue" }
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "properties": {
+    "healthy": {
+      "type": "boolean",
+      "description": "Overall health status"
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Timestamp when the report was generated"
+    },
+    "checks": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/checkResult" }
+    },
+    "issues": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/diagnosticIssue" }
+    },
+    "summary": {
+      "type": "object",
+      "required": ["total", "errors", "warnings", "infos"],
+      "properties": {
+        "total": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Total number of issues"
+        },
+        "errors": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Total number of error issues"
+        },
+        "warnings": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Total number of warning issues"
+        },
+        "infos": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Total number of info issues"
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/lint-report.schema.json
+++ b/schemas/lint-report.schema.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://outfitter.dev/schemas/lint-report.schema.json",
+  "title": "WaymarkLintReport",
+  "description": "Lint report from the waymark CLI",
+  "type": "object",
+  "required": ["issues"],
+  "properties": {
+    "issues": {
+      "type": "array",
+      "description": "Lint issues found in the scanned files",
+      "items": {
+        "type": "object",
+        "required": ["file", "line", "rule", "severity", "message"],
+        "properties": {
+          "file": {
+            "type": "string",
+            "description": "File path where the issue was found"
+          },
+          "line": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Line number where the issue was found"
+          },
+          "rule": {
+            "type": "string",
+            "description": "Lint rule identifier"
+          },
+          "severity": {
+            "type": "string",
+            "enum": ["warn", "error"],
+            "description": "Severity of the lint issue"
+          },
+          "message": {
+            "type": "string",
+            "description": "Human-readable description of the issue"
+          },
+          "type": {
+            "type": "string",
+            "description": "Waymark marker type associated with the issue"
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/scan-result.schema.json
+++ b/schemas/scan-result.schema.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://outfitter.dev/schemas/scan-result.schema.json",
+  "$ref": "waymark-scan-result.schema.json"
+}

--- a/schemas/waymark-scan-result.schema.json
+++ b/schemas/waymark-scan-result.schema.json
@@ -2,76 +2,9 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://outfitter.dev/schemas/waymark-scan-result.schema.json",
   "title": "WaymarkScanResult",
-  "description": "Result of scanning files for waymarks",
-  "type": "object",
-  "required": ["records", "stats"],
-  "properties": {
-    "records": {
-      "type": "array",
-      "description": "All waymark records found",
-      "items": {
-        "$ref": "waymark-record.schema.json"
-      }
-    },
-    "stats": {
-      "type": "object",
-      "description": "Statistics about the scan",
-      "required": ["filesScanned", "totalWaymarks", "markerCounts"],
-      "properties": {
-        "filesScanned": {
-          "type": "integer",
-          "minimum": 0,
-          "description": "Number of files scanned"
-        },
-        "totalWaymarks": {
-          "type": "integer",
-          "minimum": 0,
-          "description": "Total number of waymarks found"
-        },
-        "markerCounts": {
-          "type": "object",
-          "description": "Count of waymarks by marker type",
-          "additionalProperties": {
-            "type": "integer",
-            "minimum": 0
-          }
-        },
-        "scanTimeMs": {
-          "type": "number",
-          "minimum": 0,
-          "description": "Time taken to scan in milliseconds"
-        }
-      },
-      "additionalProperties": false
-    },
-    "errors": {
-      "type": "array",
-      "description": "Errors encountered during scanning",
-      "items": {
-        "type": "object",
-        "required": ["file", "message"],
-        "properties": {
-          "file": {
-            "type": "string",
-            "description": "File where error occurred"
-          },
-          "line": {
-            "type": "integer",
-            "minimum": 1,
-            "description": "Line number where error occurred"
-          },
-          "message": {
-            "type": "string",
-            "description": "Error message"
-          },
-          "code": {
-            "type": "string",
-            "description": "Error code (e.g., 'WM001')"
-          }
-        },
-        "additionalProperties": false
-      }
-    }
-  },
-  "additionalProperties": false
+  "description": "JSON array of waymark records from a scan",
+  "type": "array",
+  "items": {
+    "$ref": "waymark-record.schema.json"
+  }
 }

--- a/scripts/check-spec-alignment.ts
+++ b/scripts/check-spec-alignment.ts
@@ -82,9 +82,7 @@ const schemaRelationKinds = readEnum(schema, [
   "kind",
   "enum",
 ]);
-if (!schemaRelationKinds) {
-  errors.push("Missing relation kind enum in waymark-record.schema.json.");
-} else {
+if (schemaRelationKinds) {
   const runtimeKinds = normalize(Object.values(RELATION_KIND_MAP));
   const schemaKinds = normalize(schemaRelationKinds);
   if (!arraysEqual(schemaKinds, runtimeKinds)) {
@@ -94,6 +92,8 @@ if (!schemaRelationKinds) {
       )}] runtime=[${runtimeKinds.join(", ")}].`
     );
   }
+} else {
+  errors.push("Missing relation kind enum in waymark-record.schema.json.");
 }
 
 const schemaMentionPattern = readString(schema, [


### PR DESCRIPTION
## Summary
- Validate JSON outputs against schemas and standardize exit codes/no-input handling.
- Improve TTY output/help behavior and harden update command overrides.
- Add contract tests and document exit behavior expectations.

## Testing
- bun check:all


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added `--no-input` flag to control interactive prompts and ensure CLI works in non-interactive environments.
  * Introduced schema validation for CLI JSON outputs (scan, lint, and doctor reports).

* **Bug Fixes**
  * Fixed output sanitization to remove control characters from displayed content.
  * Improved color handling in unified command to persist original state.
  * Enhanced prompt behavior to prevent interruptions in non-TTY terminals.
  * Removed deprecated signal field from JSON output.

* **Tests**
  * Added schema validation tests for all JSON outputs.
  * Extended test coverage for grammar roundtrip and relation normalization.

* **Documentation**
  * Updated RC specification with error handling and exit code policies.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->