### PR TITLE
feat(cli/docs): add config print command + agent skill docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,45 @@
+<!-- tldr ::: contributor workflow for the Waymark repository -->
+
+# Contributing
+
+Thanks for helping improve Waymark! This guide covers the local setup,
+development workflow, and expectations for pull requests.
+
+## Prerequisites
+
+- **Bun 1.2.22** (matches the `packageManager` version in `package.json`)
+- Git + Graphite (`gt`) when working in Graphite-synced repos
+
+## Setup
+
+1. Install dependencies: `bun install`
+2. Run the CLI locally: `bun dev:cli`
+3. Run the core package in watch mode: `bun dev:core`
+
+## Development Workflow
+
+- Use conventional commits.
+- Work on short-lived branches off `main`.
+- Prefer Graphite stacks (`gt log`, `gt create`, `gt submit`) when configured.
+- Keep PRs small and focused; feature-flag incomplete work.
+
+## Testing & Checks
+
+Run the checks that CI will enforce:
+
+- `bun test` — run tests
+- `bun check:all` — lint, typecheck, tests, and spec alignment
+- `bun ci:local` — full CI simulation (recommended before pushing)
+- `bun ci:validate` — tests/types/build (quick pre-push validation)
+
+## Docs & Waymarks
+
+- Add `<!-- tldr ::: ... -->` at the top of new Markdown files.
+- Use the `:::` sigil for new waymarks and keep them greppable.
+- Verify patterns with `rg ':::'` before committing.
+
+## Pull Requests
+
+- Keep branches up to date with `main` (rebase preferred).
+- Squash-merge after checks pass.
+- If you address `@coderabbitai` feedback, reply on the PR with a summary.

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ wm fmt src/ --write               # format waymarks in a directory
 wm lint src/ --json                  # validate waymark types
 wm rm src/auth.ts:42 --write     # remove a waymark
 wm edit src/auth.ts:42 --flagged --write # adjust an existing waymark
+wm config --print                  # print merged configuration
 ```
 
 To include legacy codetags (TODO/FIXME/NOTE/etc.) in scans, enable:
@@ -156,6 +157,18 @@ Add-Content $PROFILE "`n. ~/.config/waymark/completions/wm.ps1"
 Run `wm completions` without arguments to list supported shells or emit debugging
 information. Note: `wm complete` is also supported as a backward-compatible alias.
 
+### Configuration Precedence
+
+Waymark loads configuration with the following precedence (highest wins):
+
+1. `--config <path>` explicit config file
+2. `WAYMARK_CONFIG_PATH` environment variable
+3. Project config: `.waymark/config.(toml|jsonc|yaml|yml)` (walks up from cwd)
+4. User config: `~/.config/waymark/config.(toml|jsonc|yaml|yml)` (or `$XDG_CONFIG_HOME`)
+
+Use `--scope project|user|default` to limit search, and `wm config --print` to
+inspect the merged configuration.
+
 ### MCP Server
 
 Waymark also ships a Model Context Protocol server so agents can consume the same tooling over stdio:
@@ -175,10 +188,17 @@ Drafting TLDR/TODO guidance now lives in agent skills; MCP prompts were removed.
 
 ### Code Structure
 
-- `packages/cli/src/index.ts` is a thin dispatcher that parses global flags and routes commands.
+- `packages/cli/src/index.ts` wires Commander, help formatting, and command routing.
 - Each command lives in `packages/cli/src/commands/<name>.ts` with its own argument parser and executor.
 - Shared utilities reside in `packages/cli/src/utils/` (filesystem expansion, record rendering) and shared CLI types in `packages/cli/src/types.ts`.
 - Tests primarily target the modules directly, while `packages/cli/src/index.test.ts` keeps a lightweight smoke suite.
+
+## Development Quickstart
+
+1. Install Bun **1.2.22** (matches `packageManager` in `package.json`).
+2. Install dependencies: `bun install`
+3. Run tests: `bun test` (or `bun check:all` for lint/typecheck/tests/spec)
+4. Start CLI dev loop: `bun dev:cli`
 
 ## Current Focus
 
@@ -195,6 +215,12 @@ The project is mid-rebuild: we are prioritizing documentation, search patterns, 
 ## Contributing
 
 We follow conventional commits, short-lived branches, and Graphite-managed stacks. Review `.agents/rules/CORE.md` plus the waymark-specific guidance in `.waymark/rules/WAYMARKS.md` and `.waymark/rules/CONVENTIONS.md` before sending patches. When adding docs, include a `<!-- tldr ::: ... -->` preamble and verify new waymarks with `rg ':::'`.
+
+## Troubleshooting
+
+- **Bun/npm registry errors:** verify your registry in `~/.npmrc` and network access. If needed, set `NPM_CONFIG_REGISTRY` or `BUN_CONFIG_REGISTRY`.
+- **`wm` not found after install:** run `bun install` and `bun install:bin` (or `bun dev:cli` for local dev).
+- **Config parse failures:** run `wm config --print` to validate merged config, or `wm doctor` for diagnostics.
 
 ## Questions?
 

--- a/packages/agents/skills/waymark/SKILL.md
+++ b/packages/agents/skills/waymark/SKILL.md
@@ -1,0 +1,87 @@
+<!-- tldr ::: core skill documentation for waymark CLI agents -->
+
+# Waymark CLI Skill
+
+Waymarks are structured comments that capture intent, ownership, and constraints
+in code. The `wm` CLI scans, adds, edits, removes, and validates these
+annotations across a codebase.
+
+## When to Use This Skill
+
+- Find existing waymarks and summarize project status.
+- Add new TODOs, TLDRs, or notes while implementing changes.
+- Edit signals (flagged/starred) or content in place.
+- Remove completed waymarks with audit history.
+- Format or lint waymarks for consistency in CI.
+
+## Syntax Quick Reference
+
+```text
+[signal][marker] ::: [content] [properties] [#tags] [@mentions]
+```
+
+Signals:
+
+- `~` flagged (in-progress; must clear before merge)
+- `*` starred (high priority)
+
+Markers (examples):
+
+- Work: todo, fix, wip, done, review, test, check
+- Info: note, context, tldr, about, example, idea, comment
+- Caution: warn, alert, deprecated, temp
+- Workflow: blocked, needs
+- Inquiry: ask
+
+## Command Overview
+
+| Command | Purpose | Example |
+| --- | --- | --- |
+| find | Scan and filter | `wm find src/ --type todo --json` |
+| add | Insert waymarks | `wm add src/auth.ts:42 todo "add retry"` |
+| edit | Modify waymarks | `wm edit src/auth.ts:42 --flagged` |
+| rm | Remove waymarks | `wm rm src/auth.ts:42 --write` |
+| fmt | Format waymarks | `wm fmt src/ --write` |
+| lint | Validate structure | `wm lint src/ --json` |
+| init | Write config | `wm init --format toml` |
+| doctor | Diagnose config | `wm doctor --json` |
+
+## Quick Start Patterns
+
+- Find open work:
+  `wm find src/ --type todo --json`
+- Add a tldr for a new file:
+  `wm add src/new.ts:1 tldr "summary"`
+- Flag a waymark during a refactor:
+  `wm edit src/auth.ts:42 --flagged --write`
+- Remove completed work safely:
+  `wm rm src/auth.ts:42 --write`
+
+## Output Formats
+
+- Default: human-readable text
+- `--json`: JSON array (best for parsing)
+- `--jsonl`: JSON lines (streaming)
+
+## Safety Model
+
+- Most commands preview by default.
+- Use `--write` to apply changes.
+- `--no-input` fails fast in CI if prompts are required.
+
+## Exit Codes
+
+| Code | Meaning |
+| --- | --- |
+| 0 | Success |
+| 1 | Waymark error |
+| 2 | Usage error |
+| 3 | Configuration error |
+| 4 | I/O error |
+
+## Getting More Help
+
+- Command docs: `wm skill show <command>`
+- References: `wm skill show schemas` or `wm skill show exit-codes`
+- Examples: `wm skill show workflows`
+- CLI help: `wm <command> --help`

--- a/packages/agents/skills/waymark/commands/add.md
+++ b/packages/agents/skills/waymark/commands/add.md
@@ -1,0 +1,96 @@
+<!-- tldr ::: command guide for wm add -->
+
+# wm add
+
+## Synopsis
+
+Insert waymarks into files with optional JSON input and automatic formatting.
+
+## Syntax
+
+```text
+wm add <file:line> <type> <content> [options]
+wm add --from <json-file>
+```
+
+## Arguments
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<file:line>` | Yes* | Target location (required unless `--from`) |
+| `<type>` | Yes* | Waymark type (todo, fix, note, tldr, etc.) |
+| `<content>` | Yes* | Content text (use `-` to read stdin) |
+
+## Options
+
+| Option | Short | Description | Default |
+| --- | --- | --- | --- |
+| `--from <file>` |  | Read JSON/JSONL input (use `-` for stdin) | none |
+| `--mention <actor>` |  | Add mention(s) | none |
+| `--tag <tag>` |  | Add tag(s) | none |
+| `--property <kv>` |  | Add property key:value | none |
+| `--ref <token>` |  | Set canonical reference | none |
+| `--source <token>` |  | Add dependency relation | none |
+| `--see <token>` |  | Add reference relation | none |
+| `--replaces <token>` |  | Add replaces relation | none |
+| `--signal <~\|*>` |  | Add flagged/starred signals | none |
+| `--write` | `-w` | Apply changes (default preview) | false |
+| `--json` |  | JSON array output | false |
+| `--jsonl` |  | JSON lines output | false |
+
+## Input Modes
+
+- Inline arguments: `wm add src/a.ts:10 todo "add tests"`
+- JSON file: `wm add --from waymarks.json`
+- JSONL stdin: `cat waymarks.jsonl | wm add --from -`
+
+## Output Formats
+
+| Flag | Format | Use Case |
+| --- | --- | --- |
+| default | Human text | Terminal viewing |
+| `--json` | JSON array | Programmatic parsing |
+| `--jsonl` | JSON lines | Streaming |
+
+## Examples
+
+```bash
+wm add src/auth.ts:42 todo "implement OAuth" --mention @agent --tag "#sec"
+wm add src/db.ts:1 tldr "database helpers" --write
+cat waymarks.jsonl | wm add --from - --json
+```
+
+## Configuration
+
+```toml
+[ids]
+mode = "auto"
+length = 7
+
+[format]
+normalizeCase = true
+alignContinuations = true
+```
+
+## Exit Codes
+
+| Code | Meaning |
+| --- | --- |
+| 0 | Success |
+| 1 | Errors occurred |
+| 2 | Usage error |
+| 3 | Config error |
+| 4 | I/O error |
+
+## Common Errors
+
+| Error | Cause | Fix |
+| --- | --- | --- |
+| Invalid JSON | Malformed input | Validate JSON before piping |
+| Unknown type | Marker not allowed | Update `allowTypes` config |
+| File not found | Bad path | Check file path |
+
+## See Also
+
+- `wm find` - verify inserted waymarks
+- `wm skill show schemas`

--- a/packages/agents/skills/waymark/commands/doctor.md
+++ b/packages/agents/skills/waymark/commands/doctor.md
@@ -1,0 +1,44 @@
+<!-- tldr ::: command guide for wm doctor -->
+
+# wm doctor
+
+## Synopsis
+
+Run diagnostics on configuration, cache, and waymark integrity.
+
+## Syntax
+
+```text
+wm doctor [paths...] [options]
+```
+
+## Options
+
+| Option | Short | Description | Default |
+| --- | --- | --- | --- |
+| `--strict` |  | Treat warnings as failures | false |
+| `--fix` |  | Attempt safe repairs | false |
+| `--json` |  | JSON report output | false |
+
+## Examples
+
+```bash
+wm doctor
+wm doctor src/ --strict
+wm doctor --json
+```
+
+## Exit Codes
+
+| Code | Meaning |
+| --- | --- |
+| 0 | Healthy (or warnings without --strict) |
+| 1 | Issues found |
+| 2 | Usage error |
+| 3 | Config error |
+| 4 | I/O error |
+
+## See Also
+
+- `wm lint` - lint waymarks
+- `wm config --print` - view config

--- a/packages/agents/skills/waymark/commands/edit.md
+++ b/packages/agents/skills/waymark/commands/edit.md
@@ -1,0 +1,63 @@
+<!-- tldr ::: command guide for wm edit -->
+
+# wm edit
+
+## Synopsis
+
+Edit an existing waymark by location or ID. Preview by default; apply with `--write`.
+
+## Syntax
+
+```text
+wm edit [target] [options]
+```
+
+## Arguments
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `target` | No | Waymark location `file:line` (or use `--id`) |
+
+## Options
+
+| Option | Short | Description | Default |
+| --- | --- | --- | --- |
+| `--id <id>` |  | Target by ID (`[[abc123]]`) | none |
+| `--type <marker>` |  | Change marker type | none |
+| `--content <text>` |  | Replace content (`-` reads stdin) | none |
+| `--flagged` | `-F` | Add flagged signal | false |
+| `--starred` |  | Add starred signal | false |
+| `--clear-signals` |  | Remove all signals | false |
+| `--write` | `-w` | Apply changes | false |
+| `--no-interactive` |  | Skip prompts when no target | false |
+| `--json` |  | JSON array output | false |
+| `--jsonl` |  | JSON lines output | false |
+
+## Examples
+
+```bash
+wm edit src/auth.ts:42 --type fix
+wm edit --id [[a3k9m2p]] --clear-signals --write
+printf "validate JWT" | wm edit src/auth.ts:42 --content - --write
+wm edit --no-interactive
+```
+
+## Notes
+
+- Provide either `file:line` or `--id`.
+- When no target is provided, interactive mode runs unless `--no-interactive`.
+
+## Exit Codes
+
+| Code | Meaning |
+| --- | --- |
+| 0 | Success |
+| 1 | Errors occurred |
+| 2 | Usage error |
+| 3 | Config error |
+| 4 | I/O error |
+
+## See Also
+
+- `wm find` - locate waymarks
+- `wm rm` - remove waymarks

--- a/packages/agents/skills/waymark/commands/find.md
+++ b/packages/agents/skills/waymark/commands/find.md
@@ -1,0 +1,93 @@
+<!-- tldr ::: command guide for wm find -->
+
+# wm find
+
+## Synopsis
+
+Scan and filter waymarks across files or directories.
+
+## Syntax
+
+```text
+wm find [paths...] [options]
+wm [paths...] [options]            # default command
+```
+
+## Arguments
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `paths...` | No | Files or directories to scan (defaults to cwd) |
+
+## Options
+
+| Option | Short | Description | Default |
+| --- | --- | --- | --- |
+| `--type <types...>` | `-t` | Filter by marker type(s) | all |
+| `--tag <tags...>` |  | Filter by tags | all |
+| `--mention <mentions...>` |  | Filter by mentions | all |
+| `--flagged` | `-F` | Only flagged waymarks | false |
+| `--starred` | `-S` | Only starred waymarks | false |
+| `--graph` |  | Output relation graph | false |
+| `--long` |  | Detailed record output | false |
+| `--tree` |  | Group output by directory | false |
+| `--flat` |  | Flat output list | true |
+| `--compact` |  | Compact output | false |
+| `--context <n>` | `-C` | Show N context lines | 0 |
+| `--after <n>` | `-A` | Show N lines after | 0 |
+| `--before <n>` | `-B` | Show N lines before | 0 |
+| `--limit <n>` | `-n` | Limit results | none |
+| `--page <n>` |  | Page results | 1 |
+| `--json` |  | JSON array output | false |
+| `--jsonl` |  | JSON lines output | false |
+| `--text` |  | Human readable output | true |
+| `--pretty` |  | Deprecated pretty JSON | false |
+
+## Output Formats
+
+| Flag | Format | Use Case |
+| --- | --- | --- |
+| default | Human text | Terminal viewing |
+| `--json` | JSON array | Programmatic parsing |
+| `--jsonl` | JSON lines | Streaming |
+| `--graph` | Graph edges | Dependency analysis |
+
+## Examples
+
+```bash
+wm find src/ --type todo --json
+wm find --graph --json > graph.json
+wm --flagged --mention @agent
+```
+
+## Configuration
+
+Scan behavior respects `.waymark/config.*`:
+
+```toml
+[scan]
+include_codetags = true
+```
+
+## Exit Codes
+
+| Code | Meaning |
+| --- | --- |
+| 0 | Success |
+| 1 | Errors occurred |
+| 2 | Usage error |
+| 3 | Config error |
+| 4 | I/O error |
+
+## Common Errors
+
+| Error | Cause | Fix |
+| --- | --- | --- |
+| Unknown flag | Invalid option | Check `--help` |
+| Config parse error | Invalid config | Fix `.waymark/config.*` |
+
+## See Also
+
+- `wm lint` - validate waymarks
+- `wm fmt` - normalize formatting
+- `wm skill show schemas`

--- a/packages/agents/skills/waymark/commands/fmt.md
+++ b/packages/agents/skills/waymark/commands/fmt.md
@@ -1,0 +1,53 @@
+<!-- tldr ::: command guide for wm fmt -->
+
+# wm fmt
+
+## Synopsis
+
+Format waymarks in files to match configured style rules.
+
+## Syntax
+
+```text
+wm fmt <paths...> [options]
+```
+
+## Arguments
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `paths...` | Yes | Files or directories to format |
+
+## Options
+
+| Option | Short | Description | Default |
+| --- | --- | --- | --- |
+| `--write` | `-w` | Apply changes to files | false |
+
+## Examples
+
+```bash
+wm fmt src/                 # Preview formatted output
+wm fmt src/ --write          # Apply formatting
+wm fmt src/file.ts -w        # Short form
+```
+
+## Notes
+
+- `wm fmt` only touches files containing `:::` waymarks.
+- When `--write` is set, the CLI prompts before writing.
+
+## Exit Codes
+
+| Code | Meaning |
+| --- | --- |
+| 0 | Success |
+| 1 | Errors occurred |
+| 2 | Usage error |
+| 3 | Config error |
+| 4 | I/O error |
+
+## See Also
+
+- `wm lint` - validate structure
+- `wm find` - scan for waymarks

--- a/packages/agents/skills/waymark/commands/init.md
+++ b/packages/agents/skills/waymark/commands/init.md
@@ -1,0 +1,45 @@
+<!-- tldr ::: command guide for wm init -->
+
+# wm init
+
+## Synopsis
+
+Create a waymark configuration file interactively or via flags.
+
+## Syntax
+
+```text
+wm init [options]
+```
+
+## Options
+
+| Option | Short | Description | Default |
+| --- | --- | --- | --- |
+| `--format <format>` | `-f` | Config format (toml\|jsonc\|yaml\|yml) | toml |
+| `--preset <preset>` | `-p` | Preset (full\|minimal) | full |
+| `--scope <scope>` | `-s` | Scope (project\|user) | project |
+| `--force` |  | Overwrite existing config | false |
+
+## Examples
+
+```bash
+wm init
+wm init --format toml --scope project
+wm init --preset minimal --force
+```
+
+## Exit Codes
+
+| Code | Meaning |
+| --- | --- |
+| 0 | Success |
+| 1 | Errors occurred |
+| 2 | Usage error |
+| 3 | Config error |
+| 4 | I/O error |
+
+## See Also
+
+- `wm config --print` - inspect merged config
+- `wm doctor` - validate config

--- a/packages/agents/skills/waymark/commands/lint.md
+++ b/packages/agents/skills/waymark/commands/lint.md
@@ -1,0 +1,54 @@
+<!-- tldr ::: command guide for wm lint -->
+
+# wm lint
+
+## Synopsis
+
+Validate waymark structure and marker rules.
+
+## Syntax
+
+```text
+wm lint <paths...> [options]
+```
+
+## Arguments
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `paths...` | Yes | Files or directories to lint |
+
+## Options
+
+| Option | Short | Description | Default |
+| --- | --- | --- | --- |
+| `--json` |  | JSON array output | false |
+
+## Examples
+
+```bash
+wm lint src/ --json
+wm lint src/auth.ts
+```
+
+## Exit Codes
+
+| Code | Meaning |
+| --- | --- |
+| 0 | No lint errors |
+| 1 | Lint errors found |
+| 2 | Usage error |
+| 3 | Config error |
+| 4 | I/O error |
+
+## Common Errors
+
+| Error | Cause | Fix |
+| --- | --- | --- |
+| Unknown marker | Not in blessed list | Add to config allowTypes |
+| Duplicate property | Same key repeated | Remove duplicates |
+
+## See Also
+
+- `wm fmt` - normalize formatting
+- `wm find` - scan and filter

--- a/packages/agents/skills/waymark/commands/rm.md
+++ b/packages/agents/skills/waymark/commands/rm.md
@@ -1,0 +1,74 @@
+<!-- tldr ::: command guide for wm rm -->
+
+# wm rm
+
+## Synopsis
+
+Remove waymarks by location, ID, or filter criteria. Preview by default.
+
+## Syntax
+
+```text
+wm rm <file:line> [options]
+wm rm --id <id> [options]
+wm rm --from <json-file> [options]
+wm rm [filters] <paths...> [options]
+```
+
+## Options
+
+| Option | Short | Description | Default |
+| --- | --- | --- | --- |
+| `--id <id>` |  | Remove by ID | none |
+| `--from <file>` |  | Read JSON input (use `-` for stdin) | none |
+| `--criteria <query>` |  | Filter query string | none |
+| `--type <type>` |  | Filter by type | none |
+| `--mention <mention>` |  | Filter by mention | none |
+| `--tag <tag>` |  | Filter by tag | none |
+| `--flagged` |  | Filter flagged | false |
+| `--starred` |  | Filter starred | false |
+| `--contains <text>` |  | Filter by content | none |
+| `--reason <text>` |  | Record removal reason | none |
+| `--write` | `-w` | Apply removal | false |
+| `--yes` | `-y` | Skip confirmation prompt | false |
+| `--confirm` |  | Always prompt | false |
+| `--json` |  | JSON array output | false |
+| `--jsonl` |  | JSON lines output | false |
+
+## Examples
+
+```bash
+wm rm src/auth.ts:42
+wm rm src/auth.ts:42 --write --reason "cleanup"
+wm rm --id [[a3k9m2p]] --write
+wm rm --type done . --write
+cat removals.json | wm rm --from - --write --json
+```
+
+## Safety Model
+
+- Preview by default; add `--write` to apply.
+- Removals update `.waymark/history.json` when tracking is enabled.
+
+## Exit Codes
+
+| Code | Meaning |
+| --- | --- |
+| 0 | Success |
+| 1 | Errors occurred |
+| 2 | Usage error |
+| 3 | Config error |
+| 4 | I/O error |
+
+## Common Errors
+
+| Error | Cause | Fix |
+| --- | --- | --- |
+| No matches | Filter too narrow | Broaden filters |
+| Unknown ID | Not in index | Verify ID exists |
+| File not found | Bad path | Check file path |
+
+## See Also
+
+- `wm find` - locate targets
+- `wm edit` - adjust waymarks without removing

--- a/packages/agents/skills/waymark/examples/agent-tasks.md
+++ b/packages/agents/skills/waymark/examples/agent-tasks.md
@@ -1,0 +1,21 @@
+<!-- tldr ::: common agent task patterns using waymarks -->
+
+# Agent Tasks
+
+## Add TLDRs for New Files
+
+```bash
+wm add src/new.ts:1 tldr "summary of file" --write
+```
+
+## Mark In-Progress Work
+
+```bash
+wm edit src/auth.ts:42 --flagged --write
+```
+
+## Annotate Performance Hotspots
+
+```bash
+wm add src/query.ts:120 note "perf hotspot" --tag "#perf" --write
+```

--- a/packages/agents/skills/waymark/examples/batch-operations.md
+++ b/packages/agents/skills/waymark/examples/batch-operations.md
@@ -1,0 +1,21 @@
+<!-- tldr ::: batch insert/remove workflows for waymark CLI -->
+
+# Batch Operations
+
+## Batch Insert from JSONL
+
+```bash
+cat waymarks.jsonl | wm add --from - --json
+```
+
+## Batch Remove from JSON
+
+```bash
+cat removals.json | wm rm --from - --write --json
+```
+
+## Generate and Insert Waymarks
+
+```bash
+python scripts/generate_waymarks.py | wm add --from - --json
+```

--- a/packages/agents/skills/waymark/examples/integration.md
+++ b/packages/agents/skills/waymark/examples/integration.md
@@ -1,0 +1,25 @@
+<!-- tldr ::: integration examples for MCP and CI -->
+
+# Integration
+
+## MCP Server
+
+```bash
+waymark-mcp
+```
+
+## CI Gate for Flagged Waymarks
+
+```bash
+count=$(wm find --flagged --json | jq 'length')
+if [ "$count" -gt 0 ]; then
+  echo "Flagged waymarks must be cleared before merge"
+  exit 1
+fi
+```
+
+## Lint in CI
+
+```bash
+wm lint src/ --json > lint.json
+```

--- a/packages/agents/skills/waymark/examples/workflows.md
+++ b/packages/agents/skills/waymark/examples/workflows.md
@@ -1,0 +1,25 @@
+<!-- tldr ::: multi-command workflows for waymark CLI -->
+
+# Workflows
+
+## Find and Resolve TODOs
+
+```bash
+wm find src/ --type todo --json | jq 'length'
+wm find src/ --type todo
+```
+
+## Remove Completed Work
+
+```bash
+wm find src/ --type done --json \
+  | jq -r '.[] | "\(.file):\(.startLine)"' \
+  | xargs -I {} wm rm {} --write
+```
+
+## Format Then Lint
+
+```bash
+wm fmt src/ --write
+wm lint src/ --json
+```

--- a/packages/agents/skills/waymark/index.json
+++ b/packages/agents/skills/waymark/index.json
@@ -1,0 +1,33 @@
+{
+  "name": "waymark",
+  "version": "1.0.0-beta.1",
+  "description": "Structured code annotations using the ::: sigil",
+  "entry": "SKILL.md",
+  "commands": {
+    "find": "commands/find.md",
+    "add": "commands/add.md",
+    "edit": "commands/edit.md",
+    "rm": "commands/rm.md",
+    "fmt": "commands/fmt.md",
+    "lint": "commands/lint.md",
+    "init": "commands/init.md",
+    "doctor": "commands/doctor.md"
+  },
+  "references": {
+    "schemas": "references/schemas.md",
+    "exit-codes": "references/exit-codes.md",
+    "errors": "references/errors.md",
+    "workflows": "examples/workflows.md",
+    "agent-tasks": "examples/agent-tasks.md",
+    "batch-operations": "examples/batch-operations.md",
+    "integration": "examples/integration.md"
+  },
+  "triggers": [
+    "waymark",
+    "wm",
+    "code annotations",
+    ":::",
+    "todo markers",
+    "tldr"
+  ]
+}

--- a/packages/agents/skills/waymark/references/errors.md
+++ b/packages/agents/skills/waymark/references/errors.md
@@ -1,0 +1,23 @@
+<!-- tldr ::: error handling patterns and recovery guidance -->
+
+# Error Handling
+
+Waymark errors follow a What/Why/How pattern. Use the exit code to determine
+whether the issue is usage, config, or I/O related.
+
+## Common Error Types
+
+- Usage errors: invalid flags, missing arguments
+- Config errors: bad TOML/JSON/YAML, missing config file
+- I/O errors: file not found, permission denied
+
+## Recovery Steps
+
+1. Re-run with `--help` for usage errors.
+2. Validate config with `wm config --print` or `wm doctor`.
+3. Check file paths and permissions for I/O issues.
+
+## Tips
+
+- Use `--json` for programmatic workflows.
+- In CI, prefer `--no-input` to fail fast.

--- a/packages/agents/skills/waymark/references/exit-codes.md
+++ b/packages/agents/skills/waymark/references/exit-codes.md
@@ -1,0 +1,23 @@
+<!-- tldr ::: exit code taxonomy for the wm CLI -->
+
+# Exit Codes
+
+Waymark commands return consistent exit codes for scripting and CI.
+
+| Code | Name | Meaning |
+| --- | --- | --- |
+| 0 | success | Operation completed successfully |
+| 1 | failure | Waymark-level error (lint errors, operation failures) |
+| 2 | usage error | Invalid flags or arguments |
+| 3 | config error | Invalid configuration or missing config |
+| 4 | I/O error | File system failure (missing files, permissions) |
+
+## CI Patterns
+
+- Fail build on `!= 0`.
+- Distinguish usage/config errors for developer feedback.
+
+## Signal Codes
+
+- SIGINT exits with 130
+- SIGTERM exits with 143

--- a/packages/agents/skills/waymark/references/schemas.md
+++ b/packages/agents/skills/waymark/references/schemas.md
@@ -1,0 +1,51 @@
+<!-- tldr ::: schema references for waymark JSON inputs and outputs -->
+
+# Schema Reference
+
+Waymark JSON payloads are validated against schema files in `schemas/`.
+Use these schemas when producing or consuming structured output.
+
+## Core Schemas
+
+- `schemas/waymark-record.schema.json` - Waymark record output
+- `schemas/scan-result.schema.json` - Scan output
+- `schemas/lint-report.schema.json` - Lint output
+- `schemas/doctor-report.schema.json` - Doctor output
+
+## Add Input
+
+Insertions accept either a single object or an array. Fields:
+
+```json
+{
+  "file": "src/auth.ts",
+  "line": 42,
+  "type": "todo",
+  "content": "implement OAuth",
+  "mentions": ["@agent"],
+  "tags": ["#sec"],
+  "properties": { "owner": "@alice" }
+}
+```
+
+## Remove Input
+
+Removal accepts `file`/`line` or `id`:
+
+```json
+{ "file": "src/auth.ts", "line": 42 }
+{ "id": "[[a3k9m2p]]" }
+```
+
+## Graph Output
+
+Graph mode emits edges:
+
+```json
+{ "source": "src/a.ts", "target": "#auth", "relation": "see" }
+```
+
+## Notes
+
+- Use `--json` for arrays and `--jsonl` for streaming output.
+- Always validate generated JSON against the schema for CI.

--- a/packages/cli/src/__tests__/fixtures/help/config-help.txt
+++ b/packages/cli/src/__tests__/fixtures/help/config-help.txt
@@ -1,0 +1,7 @@
+wm config [options]
+print resolved configuration
+
+Options:
+  --print     print merged configuration (default: false)
+  --json      output compact JSON (default: false)
+  --help, -h  display help for command

--- a/packages/cli/src/__tests__/fixtures/help/find-help.txt
+++ b/packages/cli/src/__tests__/fixtures/help/find-help.txt
@@ -1,0 +1,31 @@
+wm find [options] [paths...]
+scan and filter waymarks in files or directories
+
+Arguments:
+  paths                                   files or directories to scan
+
+
+Options:
+  --type <types...>, -t                   filter by waymark type(s)
+  --tag <tags...>                         filter by tag(s)
+  --mention <mentions...>                 filter by mention(s)
+  --flagged, -F                           filter for flagged (~) waymarks
+  --starred, -S                           filter for starred (*) waymarks
+  --tldr                                  shorthand for --type tldr
+  --graph                                 show dependency graph
+  --long                                  show detailed record information
+  --tree                                  group output by directory structure
+  --flat                                  show flat list (default)
+  --compact                               compact output format
+  --no-wrap                               disable line wrapping
+  --group <by>                            group by: file, dir, type
+  --sort <by>                             sort by: file, line, type, modified
+  --context <n>, -C                       show N lines of context
+  --after <n>, -A, --after-context <n>    show N lines after match
+  --before <n>, -B, --before-context <n>  show N lines before match
+  --limit <n>, -n                         limit number of results
+  --page <n>                              page number (with --limit)
+  --interactive                           interactively select a waymark
+  --pretty                                (deprecated: use --text) output as pretty-printed JSON
+  --prompt                                show agent-facing prompt instead of help
+  --help, -h                              display help for command

--- a/packages/cli/src/__tests__/fixtures/help/root-help.txt
+++ b/packages/cli/src/__tests__/fixtures/help/root-help.txt
@@ -1,0 +1,51 @@
+wm [options] [command] [paths...]
+Waymark CLI - scan, filter, format, and manage waymarks
+
+Quick Start:
+  wm [paths...]             Scan and filter waymarks (default: current directory)
+  wm find --graph           Show dependency graph
+  wm fmt <file> --write     Format waymarks in file
+  wm rm <file:line> --write Remove waymark from file
+  wm init                   Initialize waymark configuration
+
+Global Options:
+  --version, -v                 output the current version
+  --prompt                      show agent-facing documentation
+  --no-input                    fail if interactive input required
+  --scope <scope>, -s           config scope (default|project|user) (choices: "default", "project", "user", default: "default")
+  --config <path>               load additional config file (JSON/YAML/TOML)
+
+
+Logging:
+  --verbose                     enable verbose logging (info level)
+  --debug                       enable debug logging
+  --quiet, -q                   only show errors
+
+
+Output Formats:
+  --json                        Output as JSON array
+  --jsonl                       Output as JSON Lines (newline-delimited)
+  --text                        Output as human-readable formatted text
+
+
+Color:
+  --no-color                    disable ANSI colors
+
+
+Commands:
+  find                          scan and filter waymarks in files or directories
+  add                           add waymarks into files
+  edit                          edit existing waymarks
+  rm                            remove waymarks from files
+  fmt                           format and normalize waymark syntax in files
+  lint                          validate waymark structure and enforce quality rules
+  init                          initialize waymark configuration
+  config                        print resolved configuration
+  doctor                        run health checks and diagnostics
+  completions|complete          Generate shell completion scripts
+  update                        check for and install CLI updates (npm global installs)
+  help                          display help for command
+
+
+Topics:
+  Run 'wm help <topic>' for syntax guides (syntax, tldr, todo, signals, tags)

--- a/packages/cli/src/commands/config.test.ts
+++ b/packages/cli/src/commands/config.test.ts
@@ -1,0 +1,33 @@
+// tldr ::: tests for config command output [[cli/config-test]]
+
+import { describe, expect, test } from "bun:test";
+import { resolveConfig, type WaymarkConfig } from "@waymarks/core";
+import type { CommandContext } from "../types.ts";
+import { runConfigCommand } from "./config.ts";
+
+const context: CommandContext = {
+  config: resolveConfig(),
+  globalOptions: {},
+  workspaceRoot: process.cwd(),
+};
+
+describe("config command", () => {
+  test("prints merged configuration when --print is set", async () => {
+    const result = await runConfigCommand(context, { print: true });
+
+    expect(result.exitCode).toBe(0);
+    const parsed = JSON.parse(result.output) as WaymarkConfig;
+    expect(parsed).toEqual(context.config);
+  });
+
+  test("prints compact JSON when --json is set", async () => {
+    const result = await runConfigCommand(context, { print: true, json: true });
+    expect(result.output.includes("\n")).toBe(false);
+  });
+
+  test("requires --print flag", async () => {
+    await expect(runConfigCommand(context)).rejects.toThrow(
+      "Config command requires --print."
+    );
+  });
+});

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -1,0 +1,45 @@
+// tldr ::: config command helpers for printing resolved settings [[cli/config-print]]
+
+import type { WaymarkConfig } from "@waymarks/core";
+
+import { createUsageError } from "../errors.ts";
+import { ExitCode } from "../exit-codes.ts";
+import type { CommandContext } from "../types.ts";
+
+export type ConfigCommandOptions = {
+  print?: boolean;
+  json?: boolean;
+};
+
+export type ConfigCommandResult = {
+  output: string;
+  exitCode: number;
+};
+
+const PRETTY_JSON_INDENT = 2;
+
+function serializeConfig(
+  config: WaymarkConfig,
+  options: { compact?: boolean }
+): string {
+  const indent = options.compact ? undefined : PRETTY_JSON_INDENT;
+  return JSON.stringify(config, null, indent);
+}
+
+export function runConfigCommand(
+  context: CommandContext,
+  options: ConfigCommandOptions = {}
+): Promise<ConfigCommandResult> {
+  if (!options.print) {
+    throw createUsageError("Config command requires --print.");
+  }
+
+  const output = serializeConfig(context.config, {
+    compact: Boolean(options.json),
+  });
+
+  return {
+    output,
+    exitCode: ExitCode.success,
+  };
+}

--- a/packages/cli/src/commands/help/registry.ts
+++ b/packages/cli/src/commands/help/registry.ts
@@ -515,6 +515,33 @@ export const commands: HelpRegistry = {
       "wm init --preset minimal --force      # Overwrite with minimal config",
     ],
   },
+  config: {
+    name: "config",
+    usage: "wm config --print [options]",
+    description:
+      "Print resolved configuration (defaults merged with project/user or explicit config).",
+    flags: [
+      {
+        name: "print",
+        type: "boolean",
+        description: "Print merged configuration",
+      },
+      {
+        name: "json",
+        type: "boolean",
+        description: "Output compact JSON",
+      },
+      commonFlags.config,
+      commonFlags.scope,
+      commonFlags.help,
+    ],
+    examples: [
+      "wm config --print                     # Show merged configuration",
+      "wm --scope user config --print        # Show user config",
+      "wm --config ./custom.toml config --print",
+      "wm config --print --json              # Output compact JSON",
+    ],
+  },
   update: {
     name: "update",
     usage: "wm update [options]",

--- a/packages/cli/src/help-snapshots.test.ts
+++ b/packages/cli/src/help-snapshots.test.ts
@@ -1,0 +1,48 @@
+// tldr ::: snapshot checks for CLI help output [[cli/help-snapshots]]
+
+import { beforeAll, describe, expect, test } from "bun:test";
+import { readFile } from "node:fs/promises";
+import type { Command } from "commander";
+
+let program: Command;
+
+async function loadSnapshot(name: string): Promise<string> {
+  const baseUrl = new URL("./__tests__/fixtures/help/", import.meta.url);
+  return await readFile(new URL(`${name}-help.txt`, baseUrl), "utf8");
+}
+
+function normalizeHelp(output: string): string {
+  return `${output.trimEnd()}\n`;
+}
+
+function requireCommand(target: string): Command {
+  const command = program.commands.find((cmd) => cmd.name() === target);
+  if (!command) {
+    throw new Error(`Missing command: ${target}`);
+  }
+  return command;
+}
+
+beforeAll(async () => {
+  const module = await import("./index.ts");
+  program = await module.createProgram();
+});
+
+describe("help snapshots", () => {
+  test("root help output is stable", async () => {
+    const snapshot = await loadSnapshot("root");
+    expect(normalizeHelp(program.helpInformation())).toBe(snapshot);
+  });
+
+  test("find help output is stable", async () => {
+    const snapshot = await loadSnapshot("find");
+    const findHelp = requireCommand("find").helpInformation();
+    expect(normalizeHelp(findHelp)).toBe(snapshot);
+  });
+
+  test("config help output is stable", async () => {
+    const snapshot = await loadSnapshot("config");
+    const configHelp = requireCommand("config").helpInformation();
+    expect(normalizeHelp(configHelp)).toBe(snapshot);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `config --print` and CLI help snapshot coverage.
- Document config precedence in README and add CONTRIBUTING guidance.
- Add agent skill docs and command references for the waymark skill.

## Testing
- bun check:all
