### PR TITLE
feat(cli/grammar): add scan cache metrics + block comment continuations

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,10 +134,10 @@ The CLI relies on the core formatter and parser helpers exported from `@waymarks
 
 ### Cache Usage
 
-The SQLite cache infrastructure exists but CLI scans do not populate it yet. Cache
-integration is planned for a future release. For now, the cache is available
-programmatically via `@waymarks/core` (see `WaymarkCache`), and `wm doctor` reports
-cache directory health.
+The CLI can populate and reuse the SQLite cache for faster repeated scans by
+passing the global `--cache` flag (disabled by default). The cache is also
+available programmatically via `@waymarks/core` (see `WaymarkCache`), and
+`wm doctor` reports cache directory health.
 
 ### Exit Codes
 

--- a/bun.lock
+++ b/bun.lock
@@ -58,6 +58,7 @@
         "commander": "14.0.1",
         "ignore": "7.0.5",
         "inquirer": "12.9.6",
+        "ora": "9.0.0",
         "pino": "9.12.0",
         "pino-pretty": "13.1.1",
         "simple-update-notifier": "2.0.0",
@@ -314,7 +315,7 @@
 
     "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
 
-    "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+    "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
     "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
@@ -353,6 +354,10 @@
     "check-error": ["check-error@2.1.1", "", {}, "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw=="],
 
     "citty": ["citty@0.1.6", "", { "dependencies": { "consola": "^3.2.3" } }, "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ=="],
+
+    "cli-cursor": ["cli-cursor@5.0.0", "", { "dependencies": { "restore-cursor": "^5.0.0" } }, "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw=="],
+
+    "cli-spinners": ["cli-spinners@3.3.0", "", {}, "sha512-/+40ljC3ONVnYIttjMWrlL51nItDAbBrq2upN8BPyvGU/2n5Oxw3tbNwORCaNuNqLJnxGqOfjUuhsv7l5Q4IsQ=="],
 
     "cli-width": ["cli-width@4.1.0", "", {}, "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ=="],
 
@@ -466,6 +471,8 @@
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
+    "get-east-asian-width": ["get-east-asian-width@1.4.0", "", {}, "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q=="],
+
     "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
 
     "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
@@ -508,9 +515,13 @@
 
     "is-hexadecimal": ["is-hexadecimal@2.0.1", "", {}, "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg=="],
 
+    "is-interactive": ["is-interactive@2.0.0", "", {}, "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ=="],
+
     "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
 
     "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
+
+    "is-unicode-supported": ["is-unicode-supported@2.1.0", "", {}, "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ=="],
 
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
@@ -549,6 +560,8 @@
     "lefthook-windows-x64": ["lefthook-windows-x64@1.13.4", "", { "os": "win32", "cpu": "x64" }, "sha512-p2YfWuj/43gUT0nHJ6j0pTRpLLwX9n2bio60POuXOrr3RVxdv5MEaQchdRhqYG5uWj7Zsm86K9FWkNuxPG81IA=="],
 
     "linkify-it": ["linkify-it@5.0.0", "", { "dependencies": { "uc.micro": "^2.0.0" } }, "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ=="],
+
+    "log-symbols": ["log-symbols@7.0.1", "", { "dependencies": { "is-unicode-supported": "^2.0.0", "yoctocolors": "^2.1.1" } }, "sha512-ja1E3yCr9i/0hmBVaM0bfwDjnGy8I/s6PP4DFp+yP+a+mrHO4Rm7DtmnqROTUkHIkqffC84YY7AeqX6oFk0WFg=="],
 
     "loupe": ["loupe@3.2.1", "", {}, "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ=="],
 
@@ -628,6 +641,8 @@
 
     "mime-types": ["mime-types@3.0.1", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA=="],
 
+    "mimic-function": ["mimic-function@5.0.1", "", {}, "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA=="],
+
     "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
@@ -649,6 +664,10 @@
     "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
 
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
+
+    "onetime": ["onetime@7.0.0", "", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
+
+    "ora": ["ora@9.0.0", "", { "dependencies": { "chalk": "^5.6.2", "cli-cursor": "^5.0.0", "cli-spinners": "^3.2.0", "is-interactive": "^2.0.0", "is-unicode-supported": "^2.1.0", "log-symbols": "^7.0.1", "stdin-discarder": "^0.2.2", "string-width": "^8.1.0", "strip-ansi": "^7.1.2" } }, "sha512-m0pg2zscbYgWbqRR6ABga5c3sZdEon7bSgjnlXC64kxtxLOyjRcbbUkLj7HFyy/FTD+P2xdBWu8snGhYI0jc4A=="],
 
     "parse-entities": ["parse-entities@4.0.2", "", { "dependencies": { "@types/unist": "^2.0.0", "character-entities-legacy": "^3.0.0", "character-reference-invalid": "^2.0.0", "decode-named-character-reference": "^1.0.0", "is-alphanumerical": "^2.0.0", "is-decimal": "^2.0.0", "is-hexadecimal": "^2.0.0" } }, "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw=="],
 
@@ -709,6 +728,8 @@
     "regexp-tree": ["regexp-tree@0.1.27", "", { "bin": { "regexp-tree": "bin/regexp-tree" } }, "sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA=="],
 
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
+    "restore-cursor": ["restore-cursor@5.1.0", "", { "dependencies": { "onetime": "^7.0.0", "signal-exit": "^4.1.0" } }, "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA=="],
 
     "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
 
@@ -776,9 +797,11 @@
 
     "std-env": ["std-env@3.9.0", "", {}, "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw=="],
 
-    "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+    "stdin-discarder": ["stdin-discarder@0.2.2", "", {}, "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ=="],
 
-    "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+    "string-width": ["string-width@8.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.0", "strip-ansi": "^7.1.0" } }, "sha512-Kxl3KJGb/gxkaUMOjRsQ8IrXiGW75O4E3RPjFIINOVH8AMl2SQ/yWdTzWwF3FevIX9LcMAjJW+GRwAlAbTSXdg=="],
+
+    "strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
 
     "strip-json-comments": ["strip-json-comments@5.0.3", "", {}, "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw=="],
 
@@ -860,6 +883,8 @@
 
     "yaml": ["yaml@2.8.1", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw=="],
 
+    "yoctocolors": ["yoctocolors@2.1.2", "", {}, "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug=="],
+
     "yoctocolors-cjs": ["yoctocolors-cjs@2.1.3", "", {}, "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw=="],
 
     "zod": ["zod@4.1.12", "", {}, "sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ=="],
@@ -890,8 +915,14 @@
 
     "vitest/tinyexec": ["tinyexec@0.3.2", "", {}, "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA=="],
 
+    "wrap-ansi/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "wrap-ansi/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
     "zod-to-json-schema/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "@modelcontextprotocol/sdk/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
+
+    "wrap-ansi/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -26,6 +26,7 @@
     "commander": "14.0.1",
     "ignore": "7.0.5",
     "inquirer": "12.9.6",
+    "ora": "9.0.0",
     "pino": "9.12.0",
     "pino-pretty": "13.1.1",
     "simple-update-notifier": "2.0.0",

--- a/packages/cli/src/commands/find.ts
+++ b/packages/cli/src/commands/find.ts
@@ -8,7 +8,7 @@ import { handleMentionFlag } from "../utils/flags/mention";
 import { handleTagFlag } from "../utils/flags/tag";
 import { handleTldrFlag } from "../utils/flags/tldr";
 import { handleTypeFlag } from "../utils/flags/type";
-import { scanRecords } from "./scan";
+import { type ScanRuntimeOptions, scanRecords } from "./scan";
 
 export type FindCommandOptions = {
   filePath: string;
@@ -17,6 +17,7 @@ export type FindCommandOptions = {
   mentions?: string[];
   outputFormat?: "json" | "jsonl";
   config: WaymarkConfig;
+  scanOptions?: ScanRuntimeOptions;
 };
 
 /**
@@ -25,8 +26,8 @@ export type FindCommandOptions = {
 export async function findRecords(
   options: FindCommandOptions
 ): Promise<WaymarkRecord[]> {
-  const { filePath, types, tags, mentions, config } = options;
-  const records = await scanRecords([filePath], config);
+  const { filePath, types, tags, mentions, config, scanOptions } = options;
+  const records = await scanRecords([filePath], config, scanOptions);
 
   const query: Parameters<typeof searchRecords>[1] = {};
   if (types && types.length > 0) {

--- a/packages/cli/src/commands/graph.ts
+++ b/packages/cli/src/commands/graph.ts
@@ -6,15 +6,23 @@ import {
   type WaymarkRecord,
 } from "@waymarks/core";
 
-import { scanRecords } from "./scan";
+import { type ScanRuntimeOptions, scanRecords } from "./scan";
 
 export type ParsedGraphArgs = {
   filePaths: string[];
   json: boolean;
 };
 
-export async function graphRecords(filePaths: string[], config: WaymarkConfig) {
-  const records: WaymarkRecord[] = await scanRecords(filePaths, config);
+export async function graphRecords(
+  filePaths: string[],
+  config: WaymarkConfig,
+  scanOptions?: ScanRuntimeOptions
+) {
+  const records: WaymarkRecord[] = await scanRecords(
+    filePaths,
+    config,
+    scanOptions
+  );
   return buildRelationGraph(records).edges;
 }
 

--- a/packages/cli/src/commands/scan.ts
+++ b/packages/cli/src/commands/scan.ts
@@ -5,9 +5,9 @@ import { performance } from "node:perf_hooks";
 
 import {
   parse,
+  WaymarkCache,
   type WaymarkConfig,
   type WaymarkRecord,
-  WaymarkCache,
 } from "@waymarks/core";
 
 import { expandInputPaths } from "../utils/fs";

--- a/packages/cli/src/commands/unified/index.ts
+++ b/packages/cli/src/commands/unified/index.ts
@@ -36,7 +36,9 @@ export async function runUnifiedCommand(
 
   // Graph mode: extract relation edges
   if (isGraphMode) {
-    const edges = await graphRecords(filePaths, context.config);
+    const edges = await graphRecords(filePaths, context.config, {
+      cache: context.globalOptions.cache,
+    });
     if (outputFormat === "json") {
       return { output: JSON.stringify(edges) };
     }
@@ -55,7 +57,9 @@ export async function runUnifiedCommand(
   }
 
   // Scan + filter mode (find behavior)
-  const records = await scanRecords(filePaths, context.config);
+  const records = await scanRecords(filePaths, context.config, {
+    cache: context.globalOptions.cache,
+  });
   const filtered = applyFilters(records, options);
 
   // If JSON output requested, use renderRecords

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -11,7 +11,7 @@ import { expandFormatPaths, formatFile } from "./commands/fmt";
 import { graphRecords } from "./commands/graph";
 import { lintFiles } from "./commands/lint";
 import type { ModifyPayload } from "./commands/modify";
-import { parseScanArgs, scanRecords, type ScanMetrics } from "./commands/scan";
+import { parseScanArgs, type ScanMetrics, scanRecords } from "./commands/scan";
 import {
   runUnifiedCommand,
   type UnifiedCommandResult,

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -9,6 +9,7 @@ export type GlobalOptions = {
   configPath?: string;
   scope?: CliScopeOption;
   logLevel?: LogLevel;
+  cache?: boolean;
 };
 
 export type CommandContext = {

--- a/packages/cli/src/utils/spinner.ts
+++ b/packages/cli/src/utils/spinner.ts
@@ -1,0 +1,45 @@
+// tldr ::: helper to create optional CLI spinners
+
+import ora from "ora";
+
+import { shouldUseColor } from "./terminal.ts";
+
+export type SpinnerHandle = {
+  isEnabled: boolean;
+  start: () => void;
+  stop: () => void;
+  succeed: (text?: string) => void;
+  fail: (text?: string) => void;
+};
+
+export type SpinnerOptions = {
+  enabled: boolean;
+  text: string;
+  noColor?: boolean;
+};
+
+const noop = (..._args: unknown[]): void => {
+  return;
+};
+
+const noopSpinner: SpinnerHandle = {
+  isEnabled: false,
+  start: noop,
+  stop: noop,
+  succeed: noop,
+  fail: noop,
+};
+
+export function createSpinner(options: SpinnerOptions): SpinnerHandle {
+  if (!options.enabled) {
+    return noopSpinner;
+  }
+
+  const spinner = ora({
+    text: options.text,
+    color: shouldUseColor(options.noColor) ? "cyan" : undefined,
+    stream: process.stderr,
+  });
+
+  return spinner as SpinnerHandle;
+}

--- a/packages/core/src/__tests__/contracts/roundtrip.test.ts
+++ b/packages/core/src/__tests__/contracts/roundtrip.test.ts
@@ -2,7 +2,7 @@
 
 import { describe, expect, it } from "bun:test";
 import { parse, type WaymarkRecord } from "@waymarks/grammar";
-import { formatText } from "../../../core/src/format.ts";
+import { formatText } from "../../format.ts";
 
 const SOURCE = [
   "// TODO  ::: Review docs see:Alpha priority:high #perf @alice",

--- a/packages/grammar/src/content.ts
+++ b/packages/grammar/src/content.ts
@@ -64,7 +64,11 @@ export function processContentSegment(
   const closingIndex = working.lastIndexOf(SIGIL);
   if (closingIndex >= 0) {
     const afterSigil = working.slice(closingIndex + SIGIL.length).trim();
-    if (afterSigil.length === 0 || afterSigil === "-->" || afterSigil === "*/") {
+    if (
+      afterSigil.length === 0 ||
+      afterSigil === "-->" ||
+      afterSigil === "*/"
+    ) {
       closes = true;
       working = working.slice(0, closingIndex);
     }

--- a/packages/grammar/src/content.ts
+++ b/packages/grammar/src/content.ts
@@ -10,6 +10,7 @@ import type { WaymarkRecord } from "./types";
 
 const LEADING_SPACES_REGEX = /^\s+/;
 const HTML_COMMENT_CLOSE_REGEX = /\s*-->\s*$/;
+const BLOCK_COMMENT_CLOSE_REGEX = /\s*\*\/\s*$/;
 
 export type ContentSegment = {
   text: string;
@@ -33,6 +34,23 @@ export function stripHtmlCommentClosure(
   return content;
 }
 
+export function stripBlockCommentClosure(
+  content: string,
+  commentLeader: string
+): string {
+  if (commentLeader === "/*") {
+    return content.replace(BLOCK_COMMENT_CLOSE_REGEX, "");
+  }
+  return content;
+}
+
+function stripCommentClosure(content: string, commentLeader: string): string {
+  return stripBlockCommentClosure(
+    stripHtmlCommentClosure(content, commentLeader),
+    commentLeader
+  );
+}
+
 export function processContentSegment(
   segment: string,
   commentLeader: string
@@ -40,19 +58,19 @@ export function processContentSegment(
   let working = segment;
 
   working = working.replace(LEADING_SPACES_REGEX, "");
-  working = stripHtmlCommentClosure(working, commentLeader);
+  working = stripCommentClosure(working, commentLeader);
 
   let closes = false;
   const closingIndex = working.lastIndexOf(SIGIL);
   if (closingIndex >= 0) {
     const afterSigil = working.slice(closingIndex + SIGIL.length).trim();
-    if (afterSigil.length === 0 || afterSigil === "-->") {
+    if (afterSigil.length === 0 || afterSigil === "-->" || afterSigil === "*/") {
       closes = true;
       working = working.slice(0, closingIndex);
     }
   }
 
-  working = stripHtmlCommentClosure(working, commentLeader);
+  working = stripCommentClosure(working, commentLeader);
 
   return {
     text: working.trim(),
@@ -66,11 +84,12 @@ export function parseContinuation(
   inWaymarkContext: boolean
 ): ContinuationResult | null {
   const trimmed = line.trimStart();
-  if (!trimmed.startsWith(commentLeader)) {
+  const continuationLeader = resolveContinuationLeader(trimmed, commentLeader);
+  if (!continuationLeader) {
     return null;
   }
 
-  const afterLeader = trimmed.slice(commentLeader.length);
+  const afterLeader = trimmed.slice(continuationLeader.length);
 
   // Check if this line contains ::: (the sigil)
   const sigilIndex = afterLeader.indexOf(SIGIL);
@@ -101,7 +120,7 @@ export function parseContinuation(
     // Check if it's a known property key
     if (PROPERTY_KEYS.has(lowerKey)) {
       // This is a property continuation
-      const strippedValue = stripHtmlCommentClosure(afterSigil, commentLeader);
+      const strippedValue = stripCommentClosure(afterSigil, commentLeader);
       const propertyValue = strippedValue.trim();
       return {
         type: "property",
@@ -121,6 +140,26 @@ export function parseContinuation(
   }
 
   // Otherwise, this line has a marker and shouldn't be treated as a continuation
+  return null;
+}
+
+function resolveContinuationLeader(
+  trimmed: string,
+  commentLeader: string
+): string | null {
+  if (trimmed.startsWith(commentLeader)) {
+    return commentLeader;
+  }
+
+  if (commentLeader === "/*") {
+    if (trimmed.startsWith("*/")) {
+      return null;
+    }
+    if (trimmed.startsWith("*")) {
+      return "*";
+    }
+  }
+
   return null;
 }
 

--- a/packages/grammar/src/parser.test.ts
+++ b/packages/grammar/src/parser.test.ts
@@ -218,6 +218,35 @@ describe("parse", () => {
     );
   });
 
+  test("parses multi-line block comment continuations", () => {
+    const source = [
+      "/* todo ::: document block comment support",
+      " * ::: keeps continuation lines aligned",
+      " * ::: trims closer */",
+      "const noop = true;",
+    ].join("\n");
+
+    const records = parse(source, { file: "src/styles.css" });
+    expect(records).toHaveLength(1);
+    const record = records[0];
+
+    expect(record).toBeDefined();
+    if (!record) {
+      throw new Error("expected waymark record for block comment");
+    }
+
+    expect(record.commentLeader).toBe("/*");
+    expect(record.startLine).toBe(LINE_ONE);
+    expect(record.endLine).toBe(LINE_THREE);
+    expect(record.contentText).toBe(
+      [
+        "document block comment support",
+        "keeps continuation lines aligned",
+        "trims closer",
+      ].join("\n")
+    );
+  });
+
   test("parses property-as-marker in continuation context", () => {
     const source = [
       "// tldr  ::: payment processor entry point",


### PR DESCRIPTION
## Summary
- Add scan cache toggle/metrics and progress spinners for long operations.
- Support block comment continuations in the grammar and move roundtrip tests to core.
- Update README and CLI tests to reflect new scan behavior.

## Testing
- bun check:all
