### PR TITLE
refactor: align codetag naming

### DIFF
--- a/.waymark/rules/CONVENTIONS.md
+++ b/.waymark/rules/CONVENTIONS.md
@@ -11,7 +11,7 @@
 ## General Rules
 
 - ALWAYS include only one `tldr :::` waymark in each file, near the top (accounting for language-specific preambles, shebangs, front matter, etc.).
-- ONLY use the v1 signals: `~` (flagged) and a single `*` (starred). No `!`, `!!`, `?`, `^`, or other legacy signals anywhere in the repo.
+- ONLY use the v1 signals: `~` (flagged) and a single `*` (starred). No `!`, `!!`, `?`, or `^` signals anywhere in the repo.
 - CLEAR all `~` waymarks before merging (`rg '\\~\\w+\\s*:::'`).
 - When adding a new waymark, search for precedent first (e.g., `rg ":::\s.*#<fragment>"`) to avoid proliferating one-off patterns.
 

--- a/.waymark/rules/WAYMARKS.md
+++ b/.waymark/rules/WAYMARKS.md
@@ -36,7 +36,7 @@ Only the following markers are considered first-class by the toolchain. Custom m
 ### Work / Action
 
 - `todo`
-- `fix` (alias: `fixme` when migrating legacy content)
+- `fix`
 - `wip`
 - `done`
 - `review`
@@ -181,7 +181,7 @@ waymark find --file-category docs --type tldr
 - Do not place waymarks inside rendered documentation sections (e.g., Markdown body). Use HTML comments instead.
 - Avoid numeric-only hashtags, which collide with issue references.
 - Do not hand-edit generated caches; they will be overwritten by tooling.
-- Legacy patterns (`TODO:`, `fix:`, `priority:high`, `#owner:@alice`, etc.) should be migrated to the new grammar. Use the `legacy-pattern` lint rule or enable `scan.include_codetags` to surface them.
+- Codetag patterns (`TODO:`, `fix:`, `priority:high`, `#owner:@alice`, etc.) should be expressed using waymark syntax. Use the `codetag-pattern` lint rule or enable `scan.include_codetags` to surface them.
 
 ## 11. Reference Examples
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,8 +29,7 @@ This repository handles the development and maintenance of the Waymark project. 
 ## Historical Context
 
 - Waymarks deliberately unify decades of comment-level anchors (TODOs, MARK, go:build, lint suppressions) into one predictable `:::` sigil. See `docs/about/priors.md` for the catalogue.
-- The v2.0 rewrite is opinionated: fewer signals, curated markers, and no backward-compat guarantees for legacy waymarks. When you encounter v1 syntax, treat it as historical data and prefer translating it.
-- We are still documenting migration paths—favor clarity and grep-first documentation over speculative tooling.
+- The v2.0 rewrite is opinionated: fewer signals and curated markers.
 
 ## Best Practices for This Repository
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ wm skill show add                   # command-specific docs
 wm skill --json                     # structured JSON output
 ```
 
-To include legacy codetags (TODO/FIXME/NOTE/etc.) in scans, enable:
+To include codetags (TODO/FIXME/NOTE/etc.) in scans, enable:
 
 ```toml
 [scan]
@@ -177,7 +177,7 @@ Add-Content $PROFILE "`n. ~/.config/waymark/completions/wm.ps1"
 ```
 
 Run `wm completions` without arguments to list supported shells or emit debugging
-information. Note: `wm complete` is also supported as a backward-compatible alias.
+information. Note: `wm complete` is also supported as an alias.
 
 ### Configuration Precedence
 
@@ -224,7 +224,7 @@ Drafting TLDR/TODO guidance now lives in agent skills (use `wm skill` to browse)
 
 ## Current Focus
 
-The project is mid-rebuild: we are prioritizing documentation, search patterns, and migration guidance before reintroducing heavy tooling. Favor clarity and greppability while we land the v1 toolchain.
+The project is mid-rebuild: we are prioritizing documentation, search patterns, and the v1 toolchain before reintroducing heavy tooling. Favor clarity and greppability while we land the v1 toolchain.
 
 ## Repository Map
 
@@ -232,7 +232,6 @@ The project is mid-rebuild: we are prioritizing documentation, search patterns, 
 - `docs/` – Published documentation, including historical context (`docs/about`) and the grammar reference (`docs/GRAMMAR.md`)
 - `.waymark/` – Project-specific waymark rules and conventions (`.waymark/rules/`)
 - `.agents/` – General agent rules plus symlinks into `.waymark/rules/`
-- `.migrate/` – Archived v1 content retained for research and migration notes
 
 ## Contributing
 

--- a/apps/mcp/src/index.test.ts
+++ b/apps/mcp/src/index.test.ts
@@ -17,7 +17,7 @@ class TestServer {
 }
 
 const TLDR_EXISTS_REGEX = /already contains a tldr waymark/u;
-const LEGACY_ID_REGEX = /Legacy wm:/u;
+const WM_ID_REGEX = /wm:/u;
 const EMPTY_ID_REGEX = /cannot be empty/u;
 const DIFFERENT_ID_REGEX = /different waymark id/u;
 const ABOUT_INSERT_LINE = 3;
@@ -298,10 +298,10 @@ describe("handleAddWaymark", () => {
     await rm(dir, { recursive: true, force: true });
   });
 
-  test("rejects legacy wm ids", async () => {
+  test("rejects wm ids", async () => {
     const dir = await mkdtemp(join(tmpdir(), "waymark-mcp-wm-"));
-    const file = join(dir, "legacy.ts");
-    await writeFile(file, ["export const legacy = true;"].join("\n"), "utf8");
+    const file = join(dir, "wm-id.ts");
+    await writeFile(file, ["export const sample = true;"].join("\n"), "utf8");
 
     const server = new TestServer();
     await expect(
@@ -312,7 +312,7 @@ describe("handleAddWaymark", () => {
         content: "add retry",
         id: "wm:abc123",
       })
-    ).rejects.toThrow(LEGACY_ID_REGEX);
+    ).rejects.toThrow(WM_ID_REGEX);
 
     await rm(dir, { recursive: true, force: true });
   });

--- a/apps/mcp/src/tools/add.ts
+++ b/apps/mcp/src/tools/add.ts
@@ -17,7 +17,7 @@ const EXTENSION_REGEX = /(\.[^.]+)$/u;
 const NEWLINE_SPLIT_REGEX = /\r?\n/u;
 const LEADING_WHITESPACE_REGEX = /^[ \t]*/u;
 const ID_TRAIL_REGEX = /(\[\[[^\]]+\]\])$/i;
-const LEGACY_ID_PREFIX = "wm:";
+const WM_ID_PREFIX = "wm:";
 
 const COMMENT_STYLE_BY_EXTENSION: Record<string, CommentStyle> = {
   ".c": { leader: "//" },
@@ -341,9 +341,9 @@ function normalizeWaymarkId(id: string): string {
     throw new Error("Waymark id cannot be empty.");
   }
   const lower = trimmed.toLowerCase();
-  if (lower.startsWith(LEGACY_ID_PREFIX)) {
+  if (lower.startsWith(WM_ID_PREFIX)) {
     throw new Error(
-      "Legacy wm: ids are not supported. Use [[hash]] or [[hash|alias]]."
+      "wm: ids are not supported. Use [[hash]] or [[hash|alias]]."
     );
   }
   if (trimmed.startsWith("[[") && trimmed.endsWith("]]")) {
@@ -352,9 +352,9 @@ function normalizeWaymarkId(id: string): string {
       throw new Error(`Invalid waymark id format: ${id}`);
     }
     const normalizedInner = inner.toLowerCase();
-    if (normalizedInner.startsWith(LEGACY_ID_PREFIX)) {
+    if (normalizedInner.startsWith(WM_ID_PREFIX)) {
       throw new Error(
-        "Legacy wm: ids are not supported. Use [[hash]] or [[hash|alias]]."
+        "wm: ids are not supported. Use [[hash]] or [[hash|alias]]."
       );
     }
     return `[[${normalizedInner}]]`;
@@ -392,7 +392,7 @@ export const addToolDefinition = {
   inputSchema: addWaymarkInputSchema.shape,
 } as const;
 
-// Wrapper for test compatibility
+// Wrapper for tests
 export function handleAddWaymark(params: {
   filePath: string;
   type: string;

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -391,7 +391,7 @@ Write tests first, then implementation:
 ```typescript
 // Step 1: Write failing test
 test('parseHeader extracts signals and marker', () => {
-  const result = parseHeader('// ^*todo ::: fix bug');
+  const result = parseHeader('// ~*todo ::: fix bug');
   expect(result.marker).toBe('todo');
   expect(result.signals.flagged).toBe(true);
   expect(result.signals.starred).toBe(true);

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -309,7 +309,7 @@ Test individual modules in isolation:
 import { parseHeader } from './tokenizer.ts';
 
 test('parseHeader extracts signals and marker', () => {
-  const result = parseHeader('// ^*todo ::: fix bug');
+  const result = parseHeader('// ~*todo ::: fix bug');
   expect(result).toMatchObject({
     marker: 'todo',
     signals: { flagged: true, starred: true },

--- a/docs/GRAMMAR.md
+++ b/docs/GRAMMAR.md
@@ -64,7 +64,6 @@ The canonical reference for waymark syntax, structure, and semantics.
   - [Markdown](#markdown)
   - [Complex Examples](#complex-examples)
 - [Anti-patterns](#anti-patterns)
-- [Migration Notes](#migration-notes)
 
 ---
 
@@ -767,28 +766,6 @@ track_history = true        # Track ID removals in history.json (default: false)
 alias_required = false      # Require aliases for new IDs (default: false)
 ```
 
-### Migration from Legacy Format
-
-The previous `wm:xxx` format is deprecated. Migrate using:
-
-```bash
-wm migrate-ids --write      # Convert wm:xxx to [[xxx]] format
-```
-
-**Before**:
-
-```typescript
-// todo ::: wm:a1b2c3d implement feature
-```
-
-**After**:
-
-```typescript
-// todo ::: [[a1b2c3d]] implement feature
-```
-
----
-
 ## Tags (Hashtags)
 
 ### Tag Syntax
@@ -1047,7 +1024,7 @@ Parsers must:
 - Unknown markers → warning (`unknown-marker`)
 - Duplicate properties → warning (`duplicate-property`)
 - Multiple TLDRs in a file → error (`multiple-tldr`)
-- Legacy codetag patterns → warning (`legacy-pattern`)
+- Codetag patterns → warning (`codetag-pattern`)
 
 ---
 
@@ -1223,13 +1200,6 @@ const note = "// todo ::: fix this";  // Not a waymark
 // fix ::: #123  // Ambiguous - issue #123 or tag?
 ```
 
-❌ Use legacy `wm:xxx` ID format (deprecated):
-
-```typescript
-// Bad
-// todo ::: wm:a1b2c3d implement feature  // Use [[a1b2c3d]] instead
-```
-
 **Do**:
 
 ✅ Keep waymarks in non-rendered comments:
@@ -1267,73 +1237,6 @@ rg 'ref:#auth'  # See what exists first
 // todo ::: [[a1b2c3d]] implement feature
 // todo ::: [[a1b2c3d|my-feature]] implement feature with alias
 // todo ::: [[my-feature]] draft ID (alias-only)
-```
-
----
-
-## Migration Notes
-
-### From Legacy Comments
-
-**TODO/FIXME conversion**:
-
-```diff
-- // TODO: implement caching
-+ // todo ::: implement caching
-
-- # FIXME: memory leak
-+ # fix ::: memory leak
-
-- <!-- NOTE: deprecated API -->
-+ <!-- note ::: deprecated API -->
-```
-
-Use the `legacy-pattern` lint rule or enable `scan.include_codetags` to surface legacy codetags before converting them.
-
-### From v1 Early Drafts
-
-If you used earlier waymark syntax:
-
-**Bang signals** (`!`, `!!`) → `*`:
-
-```diff
-- // !fix ::: critical bug
-+ // *fix ::: critical bug
-```
-
-**Legacy marker names**:
-
-```diff
-- // FIXME ::: bug
-+ // fix ::: bug
-
-- // TODO ::: task
-+ // todo ::: task
-```
-
-**Property-style hashes**:
-
-```diff
-- // todo ::: #from:auth
-+ // todo ::: from:#auth
-```
-
-### From Legacy ID Format
-
-The `wm:xxx` ID format is deprecated. Use wikilink-style `[[xxx]]` instead:
-
-```diff
-- // todo ::: wm:a1b2c3d implement feature
-+ // todo ::: [[a1b2c3d]] implement feature
-
-- // todo ::: wm:a1b2c3d|my-alias implement feature
-+ // todo ::: [[a1b2c3d|my-alias]] implement feature
-```
-
-Run the migration command to convert all legacy IDs:
-
-```bash
-wm migrate-ids --write      # Convert wm:xxx to [[xxx]] format
 ```
 
 ---

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -73,7 +73,7 @@ Add-Content $PROFILE "`n. ~/.config/waymark/completions/wm.ps1"
 ```
 
 Run `wm completions` without arguments to list supported shells and debugging
-helpers. Note: `wm complete` is also supported as a backward-compatible alias.
+helpers. Note: `wm complete` is also supported as an alias.
 
 ---
 

--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -12,7 +12,7 @@ Complete documentation for all `wm` commands, configuration, filtering, and work
 # Scan and display waymarks
 wm src/                              # all waymarks in src/
 wm src/ --type todo                  # filter by type
-wm src/ --flagged                     # only ^ (work-in-progress)
+wm src/ --flagged                     # only ~ (work-in-progress)
 wm src/ --starred                    # only * (high-priority)
 
 # Graph mode: relation edges
@@ -203,7 +203,7 @@ wm src/ --type todo
 wm src/ --type fix --type wip
 
 # Filter by signals
-wm src/ --flagged                     # only ^ waymarks
+wm src/ --flagged                     # only ~ waymarks
 wm src/ --starred                    # only * waymarks
 
 # Filter by tags
@@ -317,7 +317,7 @@ wm lint src/ --config-path .waymark/config.toml
 - Unknown markers (unless allowlisted)
 - Duplicate properties (including continuation properties)
 - Multiple `tldr` waymarks in a single file
-- Legacy codetag patterns (`TODO:`, `FIXME:`, `NOTE:`), with suggested replacements
+- Codetag patterns (`TODO:`, `FIXME:`, `NOTE:`), with suggested replacements
 
 ### Init
 
@@ -370,7 +370,7 @@ wm edit src/auth.ts:42 --clear-signals --write
 ### Skill
 
 `wm skill` provides the agent-facing documentation bundle that replaced the
-legacy `.prompt.txt` files.
+`.prompt.txt` files.
 
 ```bash
 wm skill                 # core skill documentation
@@ -580,7 +580,7 @@ wm src/ --type todo --type fix        # OR logic (todo OR fix)
 Filter by signals:
 
 ```bash
-wm src/ --flagged                      # only ^ waymarks
+wm src/ --flagged                      # only ~ waymarks
 wm src/ --starred                     # only * waymarks
 wm src/ --flagged --starred            # both flagged AND starred
 ```
@@ -802,7 +802,7 @@ wm src/ --mention @agents             # matches all agent handles
 - Unknown types: Add to `allow_types` in config
 - Duplicate properties: Remove duplicates or move to a continuation property line
 - Multiple TLDRs: Keep a single `tldr` per file
-- Legacy codetags: Replace `TODO:`/`FIXME:`/`NOTE:` with `todo :::`/`fix :::`/`note :::`
+- Codetags: Replace `TODO:`/`FIXME:`/`NOTE:` with `todo :::`/`fix :::`/`note :::`
 
 ### Format Not Working
 

--- a/docs/development/AGENTS.md
+++ b/docs/development/AGENTS.md
@@ -384,7 +384,7 @@ Write tests first, then implementation:
 ```typescript
 // Step 1: Write failing test
 test('parseHeader extracts signals and marker', () => {
-  const result = parseHeader('// ^*todo ::: fix bug');
+  const result = parseHeader('// ~*todo ::: fix bug');
   expect(result.marker).toBe('todo');
   expect(result.signals.flagged).toBe(true);
   expect(result.signals.starred).toBe(true);

--- a/docs/development/ARCHITECTURE.md
+++ b/docs/development/ARCHITECTURE.md
@@ -309,7 +309,7 @@ Test individual modules in isolation:
 import { parseHeader } from './tokenizer.ts';
 
 test('parseHeader extracts signals and marker', () => {
-  const result = parseHeader('// ^*todo ::: fix bug');
+  const result = parseHeader('// ~*todo ::: fix bug');
   expect(result).toMatchObject({
     marker: 'todo',
     signals: { flagged: true, starred: true },

--- a/docs/howto/README.md
+++ b/docs/howto/README.md
@@ -43,12 +43,12 @@ wm src/
 - Commit `.waymark/config.toml` to share team settings
 - Add `.waymark/index.json` to `.gitignore`
 
-### Converting Legacy Comments
+### Codetag Cleanup
 
-**Goal**: Migrate existing TODO/FIXME comments to waymark syntax.
+**Goal**: Convert existing TODO/FIXME comments to waymark syntax.
 
 ```bash
-# Surface legacy codetags
+# Surface codetag patterns
 wm lint src/
 
 # Normalize updated waymarks after edits
@@ -61,7 +61,7 @@ wm fmt src/ --write
 - `# FIXME: memory leak` → `# fix ::: memory leak`
 - `<!-- NOTE: deprecated -->` → `<!-- note ::: deprecated -->`
 
-Tip: enable `scan.include_codetags = true` in config to include legacy codetags in scans while you migrate.
+Tip: enable `scan.include_codetags = true` in config to include codetag patterns in scans while you convert.
 
 ---
 

--- a/docs/waymark/SPEC.md
+++ b/docs/waymark/SPEC.md
@@ -14,7 +14,7 @@ Waymark is a lightweight, comment-based grammar for embedding code-adjacent cont
 - **Signals** (optional): A short prefix modifying the waymark's meaning. The only valid signals are:
   - `~` (tilde) — **flagged**: marks work actively in progress on the current branch; must be cleared before merging.
   - `*` (star) — **starred**: marks high-priority or important items.
-  - When combined, the canonical order is `~*` (e.g., `~*todo`). Double intensity (`**`) and other legacy signals are not part of v1.
+  - When combined, the canonical order is `~*` (e.g., `~*todo`). Double intensity (`**` or `~~`) is not part of v1.
 - **Marker** (required): A single lowercase keyword from the blessed list below.
 - **`:::` sigil**: Exactly three ASCII colons, with one space before and after when a marker is present.
 - **Content**: Free text plus optional properties, tags, and mentions. Parsers tolerate additional spaces but formatters normalize to the canonical shape.
@@ -65,7 +65,7 @@ Only the following markers are considered first-class by the toolchain. Custom m
 ### Work / Action
 
 - `todo`
-- `fix` (legacy alias `fixme` should be migrated to `fix`)
+- `fix`
 - `wip`
 - `done`
 - `review`
@@ -343,26 +343,6 @@ track_history = true        # Track ID removals in history.json (default: false)
 alias_required = false      # Require aliases for new IDs (default: false)
 ```
 
-### Migration from Legacy Format
-
-The previous `wm:xxx` format is deprecated. Migrate using:
-
-```bash
-wm migrate-ids --write      # Convert wm:xxx to [[xxx]] format
-```
-
-**Before**:
-
-```typescript
-// todo ::: wm:a1b2c3d implement feature
-```
-
-**After**:
-
-```typescript
-// todo ::: [[a1b2c3d]] implement feature
-```
-
 ## 8. Grammar Reference
 
 ```ebnf
@@ -446,6 +426,6 @@ def send_email(message: Email) -> None:
 - Formatters must enforce a single space around `:::` when a marker is present.
 - Continuation lines are context-sensitive: markerless `:::` is only parsed as a continuation when following a waymark. Isolated `:::` lines are ignored.
 - Property-as-marker continuations only trigger for known property keys (not blessed markers like `needs` or `blocks`).
-- Tooling should warn on unknown markers, duplicate properties, multiple TLDRs per file, and legacy codetag patterns.
+- Tooling should warn on unknown markers, duplicate properties, multiple TLDRs per file, and codetag patterns.
 
 This specification is canonical. When the grammar evolves, update `docs/GRAMMAR.md` and `.waymark/rules/WAYMARKS.md` alongside the code so guidance stays aligned.

--- a/packages/agents/skills/waymark/commands/find.md
+++ b/packages/agents/skills/waymark/commands/find.md
@@ -41,7 +41,7 @@ wm [paths...] [options]            # default command
 | `--json` |  | JSON array output | false |
 | `--jsonl` |  | JSON lines output | false |
 | `--text` |  | Human readable output | true |
-| `--pretty` |  | Deprecated pretty JSON | false |
+| `--pretty` |  | Pretty JSON output | false |
 
 ## Output Formats
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -61,7 +61,7 @@ wm lint src/
 - `wm add <file:line> <type> <content>` - Insert waymarks into files
 - `wm edit <file:line>` - Edit existing waymarks
 - `wm rm <file:line>` - Remove waymarks from files
-- `wm lint [paths...]` - Validate waymark structure and surface legacy codetags
+- `wm lint [paths...]` - Validate waymark structure and surface codetag patterns
 - `wm init` - Initialize waymark configuration
 - `wm update` - Check for and install CLI updates
 
@@ -96,7 +96,7 @@ wm completions powershell > ~/.config/waymark/completions/wm.ps1
 Add-Content $PROFILE "`n. ~/.config/waymark/completions/wm.ps1"
 ```
 
-Run `wm completions` with no arguments to see the supported shells. Note: `wm complete` is also supported as a backward-compatible alias.
+Run `wm completions` with no arguments to see the supported shells. Note: `wm complete` is also supported as an alias.
 
 ## Documentation
 

--- a/packages/cli/src/__tests__/fixtures/help/find-help.txt
+++ b/packages/cli/src/__tests__/fixtures/help/find-help.txt
@@ -26,5 +26,5 @@ Options:
   --limit <n>, -n                         limit number of results
   --page <n>                              page number (with --limit)
   --interactive                           interactively select a waymark
-  --pretty                                (deprecated: use --text) output as pretty-printed JSON
+  --pretty                                output as pretty-printed JSON
   --help, -h                              display help for command

--- a/packages/cli/src/commands/help.ts
+++ b/packages/cli/src/commands/help.ts
@@ -1,5 +1,5 @@
-// tldr ::: help command helper for waymark CLI (legacy - migrating to help/ directory)
+// tldr ::: help command helper for waymark CLI
 
 // Re-export from new help system
-// biome-ignore lint/performance/noBarrelFile: legacy export during migration
+// biome-ignore lint/performance/noBarrelFile: barrel export for help registry
 export { displayHelp } from "./help/index.ts";

--- a/packages/cli/src/commands/help/registry.ts
+++ b/packages/cli/src/commands/help/registry.ts
@@ -47,7 +47,7 @@ const commonFlags = {
   pretty: {
     name: "pretty",
     type: "boolean",
-    description: "(deprecated: use --text) Output as pretty-printed JSON",
+    description: "Output as pretty-printed JSON",
   },
   long: {
     name: "long",

--- a/packages/cli/src/commands/help/topics/todo.txt
+++ b/packages/cli/src/commands/help/topics/todo.txt
@@ -11,4 +11,4 @@ Guidelines:
 Examples:
   // todo ::: add request signing for webhook payloads #security
   // ~todo ::: refactor cache invalidation @alice
-  // *todo ::: ship v2 migration guide #docs
+  // *todo ::: ship v2 guide refresh #docs

--- a/packages/cli/src/commands/lint.ts
+++ b/packages/cli/src/commands/lint.ts
@@ -354,8 +354,8 @@ const CODETAG_PATTERNS = [
   { regex: /^\s*--\s*FIXME\s*:/i, leader: "--", marker: "fix" },
 ];
 
-const legacyPatternRule: LintRule = {
-  name: "legacy-pattern",
+const codetagPatternRule: LintRule = {
+  name: "codetag-pattern",
   severity: "warn",
   checkFile: ({ filePath, source }) => {
     const issues: LintIssue[] = [];
@@ -363,7 +363,7 @@ const legacyPatternRule: LintRule = {
 
     for (let index = 0; index < lines.length; index += 1) {
       const line = lines[index] ?? "";
-      // Skip lines that already have waymark sigil - they're valid waymarks, not legacy
+      // Skip lines that already have waymark sigil - they're valid waymarks, not codetags
       if (line.includes(SIGIL)) {
         continue;
       }
@@ -372,9 +372,9 @@ const legacyPatternRule: LintRule = {
           issues.push({
             file: filePath,
             line: index + 1,
-            rule: "legacy-pattern",
+            rule: "codetag-pattern",
             severity: "warn",
-            message: `Legacy codetag found. Consider: "${pattern.leader} ${pattern.marker} :::"`,
+            message: `Codetag found. Consider: "${pattern.leader} ${pattern.marker} :::"`,
           });
         }
       }
@@ -389,7 +389,7 @@ function buildLintRules(): LintRule[] {
     unknownMarkerRule,
     duplicatePropertyRule,
     multipleTldrRule,
-    legacyPatternRule,
+    codetagPatternRule,
   ];
 }
 

--- a/packages/cli/src/commands/register.ts
+++ b/packages/cli/src/commands/register.ts
@@ -451,7 +451,7 @@ Lint Rules:
   duplicate-property   Duplicate property key (warn)
   unknown-marker       Unknown marker (warn)
   multiple-tldr        Multiple tldr in file (error)
-  legacy-pattern       Legacy codetag pattern (warn)
+  codetag-pattern      Codetag pattern (warn)
 
 Exit Codes:
   0   No errors (warnings allowed)
@@ -665,10 +665,7 @@ See 'wm skill show doctor' for agent-facing documentation.
     .option("--limit <n>, -n", "limit number of results", Number.parseInt)
     .option("--page <n>", "page number (with --limit)", Number.parseInt)
     .option("--interactive", "interactively select a waymark")
-    .option(
-      "--pretty",
-      "(deprecated: use --text) output as pretty-printed JSON"
-    )
+    .option("--pretty", "output as pretty-printed JSON")
     .description("scan and filter waymarks in files or directories")
     .addHelpText(
       "after",
@@ -721,11 +718,11 @@ Pagination:
   -n, --limit <n>             Limit number of results
   --page <n>                  Page number (with --limit)
 
-Output Formats:
+  Output Formats:
   --json                      (global) Compact JSON array
   --jsonl                     (global) Newline-delimited JSON (one record per line)
   --text                      (global) Human-readable formatted text (default)
-  --pretty                    (deprecated: use --text)
+  --pretty                    Pretty-printed JSON
 
 See 'wm skill show find' for agent-facing documentation.
     `

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -663,7 +663,7 @@ const BOOLEAN_OPTION_FLAGS = [
   { key: "json", flag: "--json" },
   { key: "jsonl", flag: "--jsonl" },
   { key: "text", flag: "--text" },
-  { key: "pretty", flag: "--pretty" }, // Pretty-printed JSON (deprecated)
+  { key: "pretty", flag: "--pretty" }, // Pretty-printed JSON output
   { key: "long", flag: "--long" },
   { key: "tree", flag: "--tree" },
   { key: "flat", flag: "--flat" },
@@ -1071,7 +1071,7 @@ function formatCustomHelp(
 
 /**
  * Build custom help formatter for commander.
- * Filters out soft-deprecated commands and reorders visible commands.
+ * Filters out hidden commands and reorders visible commands.
  */
 function buildCustomHelpFormatter() {
   return (cmd: Command, helper: ReturnType<Command["createHelp"]>) => {
@@ -1198,8 +1198,8 @@ Note: For agent-facing documentation, use "wm skill".
     (cmd) => cmd.name() === "complete"
   );
   if (completeCommand) {
-    // note ::: keep `wm complete` as backward-compatible alias ref:#cli/completions
-    // Update the name to 'completions' while preserving the legacy alias
+    // note ::: keep `wm complete` as alias for completions ref:#cli/completions
+    // Update the name to 'completions' while preserving the alias
     // biome-ignore lint/suspicious/noExplicitAny: accessing internal Commander.js structure to rename command
     (completeCommand as any)._name = "completions";
     completeCommand.alias("complete");

--- a/packages/cli/src/utils/output.ts
+++ b/packages/cli/src/utils/output.ts
@@ -12,7 +12,7 @@ function cleanRecord(record: WaymarkRecord): Partial<WaymarkRecord> {
 
   if (cleaned.signals) {
     const { current: _current, ...signals } = cleaned.signals;
-    // note ::: omit deprecated `current` signal from JSON output
+    // note ::: omit `current` signal from JSON output
     cleaned.signals = signals;
   }
 

--- a/packages/core/src/__tests__/contracts/relations.test.ts
+++ b/packages/core/src/__tests__/contracts/relations.test.ts
@@ -8,7 +8,7 @@ import { normalizeRelations } from "../../normalize.ts";
 describe("relation contracts", () => {
   it("normalizes relation kinds and tokens consistently", () => {
     const source =
-      "// todo ::: validate relations see:Alpha docs:Spec from:Source replaces:Legacy";
+      "// todo ::: validate relations see:Alpha docs:Spec from:Source replaces:Beta";
     const records = parse(source, { file: "src/contracts.ts" });
 
     expect(records).toHaveLength(1);
@@ -21,7 +21,7 @@ describe("relation contracts", () => {
     expect(normalized).toEqual([
       { kind: "docs", token: "#spec" },
       { kind: "from", token: "#source" },
-      { kind: "replaces", token: "#legacy" },
+      { kind: "replaces", token: "#beta" },
       { kind: "see", token: "#alpha" },
     ]);
   });

--- a/packages/grammar/src/constants.test.ts
+++ b/packages/grammar/src/constants.test.ts
@@ -10,7 +10,7 @@ import {
 
 describe("MARKER_DEFINITIONS contract", () => {
   test("includes 'about' marker for section summaries", () => {
-    // about ::: section/block summary marker (replaces legacy 'this')
+    // about ::: section/block summary marker (replaces 'this')
     const aboutDef = MARKER_DEFINITIONS.find((def) => def.name === "about");
     expect(aboutDef).toBeDefined();
     expect(aboutDef?.category).toBe("info");

--- a/packages/grammar/src/types.ts
+++ b/packages/grammar/src/types.ts
@@ -9,7 +9,6 @@ export type WaymarkRecord = {
   indent: number;
   commentLeader: string | null;
   signals: {
-    /** @deprecated use `flagged` */
     current?: boolean;
     flagged: boolean;
     starred: boolean;
@@ -25,7 +24,7 @@ export type WaymarkRecord = {
   mentions: string[];
   tags: string[];
   raw: string;
-  legacy?: boolean;
+  codetag?: boolean;
 };
 
 export type ParseOptions = {

--- a/schemas/waymark-config.schema.json
+++ b/schemas/waymark-config.schema.json
@@ -47,7 +47,7 @@
         "includeCodetags": {
           "type": "boolean",
           "default": false,
-          "description": "Include legacy TODO/FIXME/NOTE codetags in scan results"
+          "description": "Include TODO/FIXME/NOTE codetag patterns in scan results"
         }
       },
       "additionalProperties": false
@@ -105,7 +105,7 @@
         "type": "array",
         "items": {
           "type": "string",
-          "pattern": "^@[A-Za-z0-9._-]+$"
+          "pattern": "^@[a-z][A-Za-z0-9/_-]*$"
         }
       }
     }

--- a/schemas/waymark-record.schema.json
+++ b/schemas/waymark-record.schema.json
@@ -116,9 +116,9 @@
       "type": "string",
       "description": "Raw source text of the waymark"
     },
-    "legacy": {
+    "codetag": {
       "type": "boolean",
-      "description": "Whether this record was parsed from a legacy codetag pattern"
+      "description": "Whether this record was parsed from a codetag pattern"
     }
   },
   "additionalProperties": false

--- a/skills/waymark-authoring/references/grammar.md
+++ b/skills/waymark-authoring/references/grammar.md
@@ -40,7 +40,7 @@ Two signals are valid: `~` (flagged) and `*` (starred):
 
 **Invalid signals:**
 
-- `^` (deprecated - was "flagged" in v0)
+- `^` (not valid)
 - `!`, `!!`, `?` (never valid)
 - `**` (double star invalid)
 - `*~` (wrong order - use `~*`)


### PR DESCRIPTION
## Summary
- align codetag naming across schema/CLI/tests/help output
- remove Waymark legacy/back-compat/migration wording in docs/rules while keeping general compatibility examples
- update MCP ID error messaging and signal examples to current syntax

## Testing
- bun check:all
