### PR TITLE
chore: consolidate test cache to .waymark-test/

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -12,3 +12,5 @@ pre-push:
   commands:
     quality-gates:
       run: bun run lint && bun run typecheck && bun run test
+    cleanup:
+      run: rm -rf .waymark-test

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -116,7 +116,7 @@ describe("CLI handlers", () => {
   test("scan command caches results when enabled", async () => {
     const source = "// todo ::: cached";
     const { file, cleanup } = await withTempFile(source);
-    const cacheRoot = join(process.cwd(), "test-cache");
+    const cacheRoot = join(process.cwd(), ".waymark-test");
     await mkdir(cacheRoot, { recursive: true });
     const cacheDir = await mkdtemp(join(cacheRoot, "scan-cache-"));
     const cachePath = join(cacheDir, "waymark-cache.db");

--- a/packages/core/src/cache/index.test.ts
+++ b/packages/core/src/cache/index.test.ts
@@ -324,7 +324,7 @@ describe("WaymarkCache", () => {
   });
 
   test("WaymarkCache allows workspace-local cache paths", () => {
-    const workspacePath = join(process.cwd(), "test-cache", "waymark.db");
+    const workspacePath = join(process.cwd(), ".waymark-test", "waymark.db");
 
     expect(() => {
       const cache = new WaymarkCache({ dbPath: workspacePath });
@@ -334,7 +334,9 @@ describe("WaymarkCache", () => {
 
   test("WaymarkCache allows relative workspace paths", () => {
     expect(() => {
-      const cache = new WaymarkCache({ dbPath: "./fixtures/test-cache.db" });
+      const cache = new WaymarkCache({
+        dbPath: "./.waymark-test/test-cache.db",
+      });
       cache[Symbol.dispose]();
     }).not.toThrow();
   });


### PR DESCRIPTION
- Replace fixtures/, test-cache/ with single .waymark-test/ directory
- Update .gitignore to use simplified .waymark-test/ pattern
- Update test paths in cache and CLI tests
- Add cleanup step to pre-push hook (rm -rf .waymark-test)

All tests pass with new consolidated cache location.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated test cache location to use a workspace-local hidden folder for improved isolation and organization.

* **Chores**
  * Added a cleanup step to pre-push hooks to automatically remove local test artifacts before pushing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->