### PR TITLE
docs(core): add TSDoc for public exports

### DIFF
--- a/packages/core/src/cache/files.ts
+++ b/packages/core/src/cache/files.ts
@@ -2,6 +2,14 @@
 
 import type { Database } from "bun:sqlite";
 
+/**
+ * Check whether cached file metadata is stale.
+ * @param db - SQLite database handle.
+ * @param filePath - File path to check.
+ * @param mtime - Modified time in milliseconds.
+ * @param size - File size in bytes.
+ * @returns True if cached metadata is missing or out of date.
+ */
 export function isFileStale(
   db: Database,
   filePath: string,
@@ -20,14 +28,21 @@ export function isFileStale(
   return cached.mtime !== mtime || cached.size !== size;
 }
 
-// biome-ignore lint/nursery/useMaxParams: straightforward file metadata params
+/**
+ * Upsert cached file metadata.
+ * @param db - SQLite database handle.
+ * @param info - File metadata to persist.
+ */
 export function updateFileInfo(
   db: Database,
-  filePath: string,
-  mtime: number,
-  size: number,
-  hash?: string | null
+  info: {
+    filePath: string;
+    mtime: number;
+    size: number;
+    hash?: string | null;
+  }
 ): void {
+  const { filePath, mtime, size, hash } = info;
   const stmt = db.prepare(`
     INSERT OR REPLACE INTO files (path, mtime, size, hash)
     VALUES (?, ?, ?, ?)

--- a/packages/core/src/cache/index.ts
+++ b/packages/core/src/cache/index.ts
@@ -97,7 +97,9 @@ export class WaymarkCache {
     hash?: string | null
   ): void {
     const info =
-      hash === undefined ? { filePath, mtime, size } : { filePath, mtime, size, hash };
+      hash === undefined
+        ? { filePath, mtime, size }
+        : { filePath, mtime, size, hash };
     updateFileInfo(this.db, info);
   }
 

--- a/packages/core/src/cache/index.ts
+++ b/packages/core/src/cache/index.ts
@@ -96,7 +96,9 @@ export class WaymarkCache {
     size: number,
     hash?: string | null
   ): void {
-    updateFileInfo(this.db, { filePath, mtime, size, hash });
+    const info =
+      hash === undefined ? { filePath, mtime, size } : { filePath, mtime, size, hash };
+    updateFileInfo(this.db, info);
   }
 
   /**

--- a/packages/core/src/cache/index.ts
+++ b/packages/core/src/cache/index.ts
@@ -72,12 +72,24 @@ export class WaymarkCache {
     }
   }
 
-  /** Check whether cached file metadata is stale versus current stats. */
+  /**
+   * Check whether cached file metadata is stale versus current stats.
+   * @param filePath - File path to check.
+   * @param mtime - Modified time in milliseconds.
+   * @param size - File size in bytes.
+   * @returns True when cached metadata is stale or missing.
+   */
   isFileStale(filePath: string, mtime: number, size: number): boolean {
     return isFileStale(this.db, filePath, mtime, size);
   }
 
-  /** Persist file metadata in the cache index. */
+  /**
+   * Persist file metadata in the cache index.
+   * @param filePath - File path to update.
+   * @param mtime - Modified time in milliseconds.
+   * @param size - File size in bytes.
+   * @param hash - Optional content hash.
+   */
   updateFileInfo(
     filePath: string,
     mtime: number,
@@ -87,17 +99,26 @@ export class WaymarkCache {
     updateFileInfo(this.db, filePath, mtime, size, hash);
   }
 
-  /** Insert records into the cache. */
+  /**
+   * Insert records into the cache.
+   * @param records - Waymark records to insert.
+   */
   insertWaymarks(records: WaymarkRecord[]): void {
     insertWaymarks(this.db, records);
   }
 
-  /** Insert records in a batched transaction grouped by file. */
+  /**
+   * Insert records in a batched transaction grouped by file.
+   * @param recordsByFile - Map of file paths to waymark records.
+   */
   insertWaymarksBatch(recordsByFile: Map<string, WaymarkRecord[]>): void {
     insertWaymarksBatch(this.db, recordsByFile);
   }
 
-  /** Replace cached records for a single file. */
+  /**
+   * Replace cached records for a single file.
+   * @param args - File metadata and records to replace in the cache.
+   */
   replaceFileWaymarks(args: {
     filePath: string;
     mtime: number;
@@ -108,37 +129,64 @@ export class WaymarkCache {
     replaceFileWaymarks(this.db, args);
   }
 
-  /** Remove cached records for the given file path. */
+  /**
+   * Remove cached records for the given file path.
+   * @param filePath - File path to remove.
+   */
   deleteFile(filePath: string): void {
     deleteFile(this.db, filePath);
   }
 
-  /** Retrieve cached records for a specific file. */
+  /**
+   * Retrieve cached records for a specific file.
+   * @param filePath - File path to look up.
+   * @returns Cached waymark records for the file.
+   */
   findByFile(filePath: string): WaymarkRecord[] {
     return findByFile(this.db, filePath);
   }
 
-  /** Retrieve cached records filtered by marker type. */
+  /**
+   * Retrieve cached records filtered by marker type.
+   * @param marker - Marker type to filter by.
+   * @returns Cached records matching the marker.
+   */
   findByType(marker: string): WaymarkRecord[] {
     return findByType(this.db, marker);
   }
 
-  /** Retrieve cached records that include the given tag. */
+  /**
+   * Retrieve cached records that include the given tag.
+   * @param tag - Tag to filter by.
+   * @returns Cached records containing the tag.
+   */
   findByTag(tag: string): WaymarkRecord[] {
     return findByTag(this.db, tag);
   }
 
-  /** Retrieve cached records that include the given mention. */
+  /**
+   * Retrieve cached records that include the given mention.
+   * @param mention - Mention to filter by.
+   * @returns Cached records containing the mention.
+   */
   findByMention(mention: string): WaymarkRecord[] {
     return findByMention(this.db, mention);
   }
 
-  /** Retrieve cached records that reference a canonical token. */
+  /**
+   * Retrieve cached records that reference a canonical token.
+   * @param canonical - Canonical token to match.
+   * @returns Cached records referencing the canonical token.
+   */
   findByCanonical(canonical: string): WaymarkRecord[] {
     return findByCanonical(this.db, canonical);
   }
 
-  /** Search cached records by content text. */
+  /**
+   * Search cached records by content text.
+   * @param query - Search query text.
+   * @returns Cached records matching the query.
+   */
   searchContent(query: string): WaymarkRecord[] {
     return searchContent(this.db, query);
   }

--- a/packages/core/src/cache/index.ts
+++ b/packages/core/src/cache/index.ts
@@ -96,7 +96,7 @@ export class WaymarkCache {
     size: number,
     hash?: string | null
   ): void {
-    updateFileInfo(this.db, filePath, mtime, size, hash);
+    updateFileInfo(this.db, { filePath, mtime, size, hash });
   }
 
   /**

--- a/packages/core/src/cache/index.ts
+++ b/packages/core/src/cache/index.ts
@@ -23,10 +23,12 @@ import {
   replaceFileWaymarks,
 } from "./writes.ts";
 
+/** Options for configuring the on-disk waymark cache. */
 export type WaymarkCacheOptions = {
   dbPath?: string;
 };
 
+/** SQLite-backed cache for storing waymark records and query indexes. */
 export class WaymarkCache {
   private readonly db: Database;
   private readonly dbPath: string;

--- a/packages/core/src/cache/index.ts
+++ b/packages/core/src/cache/index.ts
@@ -72,10 +72,12 @@ export class WaymarkCache {
     }
   }
 
+  /** Check whether cached file metadata is stale versus current stats. */
   isFileStale(filePath: string, mtime: number, size: number): boolean {
     return isFileStale(this.db, filePath, mtime, size);
   }
 
+  /** Persist file metadata in the cache index. */
   updateFileInfo(
     filePath: string,
     mtime: number,
@@ -85,14 +87,17 @@ export class WaymarkCache {
     updateFileInfo(this.db, filePath, mtime, size, hash);
   }
 
+  /** Insert records into the cache. */
   insertWaymarks(records: WaymarkRecord[]): void {
     insertWaymarks(this.db, records);
   }
 
+  /** Insert records in a batched transaction grouped by file. */
   insertWaymarksBatch(recordsByFile: Map<string, WaymarkRecord[]>): void {
     insertWaymarksBatch(this.db, recordsByFile);
   }
 
+  /** Replace cached records for a single file. */
   replaceFileWaymarks(args: {
     filePath: string;
     mtime: number;
@@ -103,34 +108,42 @@ export class WaymarkCache {
     replaceFileWaymarks(this.db, args);
   }
 
+  /** Remove cached records for the given file path. */
   deleteFile(filePath: string): void {
     deleteFile(this.db, filePath);
   }
 
+  /** Retrieve cached records for a specific file. */
   findByFile(filePath: string): WaymarkRecord[] {
     return findByFile(this.db, filePath);
   }
 
+  /** Retrieve cached records filtered by marker type. */
   findByType(marker: string): WaymarkRecord[] {
     return findByType(this.db, marker);
   }
 
+  /** Retrieve cached records that include the given tag. */
   findByTag(tag: string): WaymarkRecord[] {
     return findByTag(this.db, tag);
   }
 
+  /** Retrieve cached records that include the given mention. */
   findByMention(mention: string): WaymarkRecord[] {
     return findByMention(this.db, mention);
   }
 
+  /** Retrieve cached records that reference a canonical token. */
   findByCanonical(canonical: string): WaymarkRecord[] {
     return findByCanonical(this.db, canonical);
   }
 
+  /** Search cached records by content text. */
   searchContent(query: string): WaymarkRecord[] {
     return searchContent(this.db, query);
   }
 
+  /** Flush and close the underlying SQLite connection. */
   close(): void {
     // Run optimization before closing
     this.db.exec("PRAGMA optimize");
@@ -142,6 +155,7 @@ export class WaymarkCache {
   }
 
   // Implement disposable pattern for automatic cleanup
+  /** Dispose the cache by closing the database connection. */
   [Symbol.dispose](): void {
     this.close();
   }

--- a/packages/core/src/cache/queries.ts
+++ b/packages/core/src/cache/queries.ts
@@ -4,6 +4,12 @@ import type { Database } from "bun:sqlite";
 import type { WaymarkRecord } from "@waymarks/grammar";
 import { deserializeRecord, type WaymarkRow } from "./serialization.ts";
 
+/**
+ * Fetch cached records for a specific file.
+ * @param db - SQLite database handle.
+ * @param filePath - File path to filter by.
+ * @returns Waymark records for the file.
+ */
 export function findByFile(db: Database, filePath: string): WaymarkRecord[] {
   const stmt = db.prepare(`
     SELECT * FROM waymarkRecords
@@ -15,6 +21,12 @@ export function findByFile(db: Database, filePath: string): WaymarkRecord[] {
   );
 }
 
+/**
+ * Fetch cached records for a specific marker type.
+ * @param db - SQLite database handle.
+ * @param type - Marker type to filter by.
+ * @returns Waymark records matching the type.
+ */
 export function findByType(db: Database, type: string): WaymarkRecord[] {
   const stmt = db.prepare(`
     SELECT * FROM waymarkRecords
@@ -24,6 +36,12 @@ export function findByType(db: Database, type: string): WaymarkRecord[] {
   return (stmt.all(type) as WaymarkRow[]).map((row) => deserializeRecord(row));
 }
 
+/**
+ * Fetch cached records containing a specific tag.
+ * @param db - SQLite database handle.
+ * @param tag - Tag to filter by.
+ * @returns Waymark records containing the tag.
+ */
 export function findByTag(db: Database, tag: string): WaymarkRecord[] {
   const stmt = db.prepare(`
     SELECT * FROM waymarkRecords
@@ -35,6 +53,12 @@ export function findByTag(db: Database, tag: string): WaymarkRecord[] {
   );
 }
 
+/**
+ * Fetch cached records containing a specific mention.
+ * @param db - SQLite database handle.
+ * @param mention - Mention to filter by.
+ * @returns Waymark records containing the mention.
+ */
 export function findByMention(db: Database, mention: string): WaymarkRecord[] {
   const stmt = db.prepare(`
     SELECT * FROM waymarkRecords
@@ -46,6 +70,12 @@ export function findByMention(db: Database, mention: string): WaymarkRecord[] {
   );
 }
 
+/**
+ * Fetch cached records containing a canonical token.
+ * @param db - SQLite database handle.
+ * @param canonical - Canonical token to filter by.
+ * @returns Waymark records containing the canonical token.
+ */
 export function findByCanonical(
   db: Database,
   canonical: string
@@ -60,6 +90,12 @@ export function findByCanonical(
   );
 }
 
+/**
+ * Search cached records by content text.
+ * @param db - SQLite database handle.
+ * @param query - Query text to match.
+ * @returns Waymark records with matching content.
+ */
 export function searchContent(db: Database, query: string): WaymarkRecord[] {
   const stmt = db.prepare(`
     SELECT * FROM waymarkRecords

--- a/packages/core/src/cache/schema.ts
+++ b/packages/core/src/cache/schema.ts
@@ -2,11 +2,16 @@
 
 import type { Database } from "bun:sqlite";
 
-// Schema version for cache database
-// Increment when making breaking schema changes (e.g., column renames, type changes)
-// On version mismatch, cache is invalidated and recreated
+/**
+ * Schema version for the cache database.
+ * Increment when making breaking schema changes (e.g., column renames, type changes).
+ */
 export const CACHE_SCHEMA_VERSION = 2;
 
+/**
+ * Apply performance-oriented PRAGMA settings for the cache database.
+ * @param db - SQLite database handle.
+ */
 export function configureForPerformance(db: Database): void {
   db.exec("PRAGMA foreign_keys = ON");
   // Enable WAL mode for better concurrency
@@ -21,6 +26,11 @@ export function configureForPerformance(db: Database): void {
   db.exec("PRAGMA auto_vacuum = INCREMENTAL");
 }
 
+/**
+ * Read the schema version from the cache metadata table.
+ * @param db - SQLite database handle.
+ * @returns Current schema version (0 when unset).
+ */
 export function getSchemaVersion(db: Database): number {
   // Create metadata table if it doesn't exist
   db.exec(`
@@ -37,6 +47,11 @@ export function getSchemaVersion(db: Database): number {
   return row?.value ?? 0;
 }
 
+/**
+ * Persist the schema version in the cache metadata table.
+ * @param db - SQLite database handle.
+ * @param version - Schema version to store.
+ */
 export function setSchemaVersion(db: Database, version: number): void {
   db.exec(`
     INSERT OR REPLACE INTO cache_metadata (key, value)
@@ -44,6 +59,10 @@ export function setSchemaVersion(db: Database, version: number): void {
   `);
 }
 
+/**
+ * Drop all cache tables to force reinitialization.
+ * @param db - SQLite database handle.
+ */
 export function invalidateCache(db: Database): void {
   // Drop all existing tables
   db.exec("DROP TABLE IF EXISTS dependencies");
@@ -52,6 +71,10 @@ export function invalidateCache(db: Database): void {
   db.exec("DROP TABLE IF EXISTS cache_metadata");
 }
 
+/**
+ * Create the cache schema, applying migrations as needed.
+ * @param db - SQLite database handle.
+ */
 export function createSchema(db: Database): void {
   // Check schema version and invalidate if mismatch
   const currentVersion = getSchemaVersion(db);
@@ -151,6 +174,10 @@ export function createSchema(db: Database): void {
   `);
 }
 
+/**
+ * Ensure new columns exist on the waymarkRecords table.
+ * @param db - SQLite database handle.
+ */
 export function ensureWaymarkRecordColumns(db: Database): void {
   const existingColumns = new Set<string>();
   const pragma = db.prepare("PRAGMA table_info(waymarkRecords)");

--- a/packages/core/src/cache/serialization.ts
+++ b/packages/core/src/cache/serialization.ts
@@ -21,6 +21,11 @@ export type WaymarkRow = {
   tags?: string | null;
 };
 
+/**
+ * Convert a serialized cache row into a waymark record.
+ * @param row - Serialized row from the cache database.
+ * @returns Deserialized waymark record.
+ */
 export function deserializeRecord(row: WaymarkRow): WaymarkRecord {
   return {
     file: row.filePath,

--- a/packages/core/src/cache/writes.ts
+++ b/packages/core/src/cache/writes.ts
@@ -4,6 +4,11 @@ import type { Database } from "bun:sqlite";
 import type { WaymarkRecord } from "@waymarks/grammar";
 import { updateFileInfo } from "./files.ts";
 
+/**
+ * Insert waymark records into the cache.
+ * @param db - SQLite database handle.
+ * @param records - Records to insert.
+ */
 export function insertWaymarks(db: Database, records: WaymarkRecord[]): void {
   if (records.length === 0) {
     return;
@@ -16,6 +21,11 @@ export function insertWaymarks(db: Database, records: WaymarkRecord[]): void {
   transaction(records);
 }
 
+/**
+ * Insert waymark records grouped by file in a single transaction.
+ * @param db - SQLite database handle.
+ * @param recordsByFile - Map of file paths to records.
+ */
 export function insertWaymarksBatch(
   db: Database,
   recordsByFile: Map<string, WaymarkRecord[]>
@@ -36,6 +46,11 @@ export function insertWaymarksBatch(
   transaction();
 }
 
+/**
+ * Replace cached records for a single file.
+ * @param db - SQLite database handle.
+ * @param args - File metadata and records to store.
+ */
 export function replaceFileWaymarks(
   db: Database,
   args: {
@@ -49,7 +64,7 @@ export function replaceFileWaymarks(
   const { filePath, mtime, size, hash, records } = args;
   const transaction = db.transaction(() => {
     deleteFileInternal(db, filePath);
-    updateFileInfo(db, filePath, mtime, size, hash);
+    updateFileInfo(db, { filePath, mtime, size, hash });
     if (records.length > 0) {
       insertWaymarksUnsafe(db, records);
     }
@@ -58,6 +73,11 @@ export function replaceFileWaymarks(
   transaction();
 }
 
+/**
+ * Delete cached records and file metadata for a given file.
+ * @param db - SQLite database handle.
+ * @param filePath - File path to delete.
+ */
 export function deleteFile(db: Database, filePath: string): void {
   const transaction = db.transaction(() => {
     deleteFileInternal(db, filePath);

--- a/packages/core/src/cache/writes.ts
+++ b/packages/core/src/cache/writes.ts
@@ -64,7 +64,9 @@ export function replaceFileWaymarks(
   const { filePath, mtime, size, hash, records } = args;
   const transaction = db.transaction(() => {
     deleteFileInternal(db, filePath);
-    updateFileInfo(db, { filePath, mtime, size, hash });
+    const info =
+      hash === undefined ? { filePath, mtime, size } : { filePath, mtime, size, hash };
+    updateFileInfo(db, info);
     if (records.length > 0) {
       insertWaymarksUnsafe(db, records);
     }

--- a/packages/core/src/cache/writes.ts
+++ b/packages/core/src/cache/writes.ts
@@ -65,7 +65,9 @@ export function replaceFileWaymarks(
   const transaction = db.transaction(() => {
     deleteFileInternal(db, filePath);
     const info =
-      hash === undefined ? { filePath, mtime, size } : { filePath, mtime, size, hash };
+      hash === undefined
+        ? { filePath, mtime, size }
+        : { filePath, mtime, size, hash };
     updateFileInfo(db, info);
     if (records.length > 0) {
       insertWaymarksUnsafe(db, records);

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -16,6 +16,7 @@ import type {
   WaymarkLintConfig,
 } from "./types";
 
+/** Default configuration values for waymark operations. */
 export const DEFAULT_CONFIG: WaymarkConfig = {
   typeCase: "lowercase",
   idScope: "repo",
@@ -61,12 +62,15 @@ export const DEFAULT_CONFIG: WaymarkConfig = {
   },
 } as const satisfies WaymarkConfig;
 
+/** Options for resolving a full config from partial overrides. */
 export type ResolveConfigOptions = {
   overrides?: PartialWaymarkConfig;
 };
 
+/** Indicates which configuration scope should be loaded. */
 export type ConfigScope = "default" | "project" | "user";
 
+/** Inputs for loading configuration from disk. */
 export type LoadConfigOptions = {
   cwd?: string;
   scope?: ConfigScope;
@@ -125,6 +129,7 @@ function deepMerge(
   return result;
 }
 
+/** Merge overrides into the default configuration. */
 export function resolveConfig(overrides?: PartialWaymarkConfig): WaymarkConfig {
   if (!overrides) {
     return cloneConfig(DEFAULT_CONFIG);
@@ -133,10 +138,12 @@ export function resolveConfig(overrides?: PartialWaymarkConfig): WaymarkConfig {
   return deepMerge(DEFAULT_CONFIG, overrides);
 }
 
+/** Clone a config object to avoid mutation side effects. */
 export function cloneConfig(config: WaymarkConfig): WaymarkConfig {
   return structuredClone(config);
 }
 
+/** Load configuration from explicit path, env path, or scoped defaults. */
 export async function loadConfigFromDisk(
   options: LoadConfigOptions = {}
 ): Promise<WaymarkConfig> {

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -129,7 +129,11 @@ function deepMerge(
   return result;
 }
 
-/** Merge overrides into the default configuration. */
+/**
+ * Merge overrides into the default configuration.
+ * @param overrides - Partial configuration overrides.
+ * @returns Resolved configuration with defaults applied.
+ */
 export function resolveConfig(overrides?: PartialWaymarkConfig): WaymarkConfig {
   if (!overrides) {
     return cloneConfig(DEFAULT_CONFIG);
@@ -138,12 +142,20 @@ export function resolveConfig(overrides?: PartialWaymarkConfig): WaymarkConfig {
   return deepMerge(DEFAULT_CONFIG, overrides);
 }
 
-/** Clone a config object to avoid mutation side effects. */
+/**
+ * Clone a config object to avoid mutation side effects.
+ * @param config - Configuration to clone.
+ * @returns Deep-cloned configuration.
+ */
 export function cloneConfig(config: WaymarkConfig): WaymarkConfig {
   return structuredClone(config);
 }
 
-/** Load configuration from explicit path, env path, or scoped defaults. */
+/**
+ * Load configuration from explicit path, env path, or scoped defaults.
+ * @param options - Options controlling where config is loaded from.
+ * @returns Resolved configuration loaded from disk.
+ */
 export async function loadConfigFromDisk(
   options: LoadConfigOptions = {}
 ): Promise<WaymarkConfig> {

--- a/packages/core/src/edit.ts
+++ b/packages/core/src/edit.ts
@@ -100,7 +100,12 @@ type ResolvedTarget = {
   id?: string;
 };
 
-/** Edit a waymark in place, optionally writing changes to disk. */
+/**
+ * Edit a waymark in place, optionally writing changes to disk.
+ * @param options - Edit request options and optional ID manager/logger.
+ * @param config - Optional configuration overrides for formatting.
+ * @returns Result describing the applied edit.
+ */
 export async function editWaymark(
   options: EditOptions,
   config?: WaymarkConfig

--- a/packages/core/src/edit.ts
+++ b/packages/core/src/edit.ts
@@ -21,6 +21,7 @@ const HTML_COMMENT_CLOSE_REGEX = /\s*--!?>\s*$/;
 const CONTEXT_BEFORE_LINES = 2;
 const CONTEXT_AFTER_LINES = 3;
 
+/** Zod schema for validating edit inputs. */
 export const EditSpecSchema = z
   .object({
     file: z.string().min(1).optional(),
@@ -68,13 +69,16 @@ export const EditSpecSchema = z
     }
   );
 
+/** Validated edit specification for a waymark record. */
 export type EditSpec = z.infer<typeof EditSpecSchema>;
 
+/** Options for editing a waymark, including optional ID management. */
 export type EditOptions = EditSpec & {
   idManager?: WaymarkIdManager;
   logger?: CoreLogger;
 };
 
+/** Result of applying edits to a waymark in a file. */
 export type EditResult = {
   file: string;
   before: WaymarkRecord;
@@ -96,6 +100,7 @@ type ResolvedTarget = {
   id?: string;
 };
 
+/** Edit a waymark in place, optionally writing changes to disk. */
 export async function editWaymark(
   options: EditOptions,
   config?: WaymarkConfig

--- a/packages/core/src/format.ts
+++ b/packages/core/src/format.ts
@@ -6,10 +6,12 @@ import { PROPERTY_KEYS, parse, SIGIL } from "@waymarks/grammar";
 import { resolveConfig } from "./config";
 import type { PartialWaymarkConfig, WaymarkConfig } from "./types";
 
+/** Options for formatting waymark comments in source text. */
 export type FormatOptions = ParseOptions & {
   config?: PartialWaymarkConfig;
 };
 
+/** Describes a single formatting change in the source text. */
 export type FormatEdit = {
   startLine: number;
   endLine: number;
@@ -18,6 +20,7 @@ export type FormatEdit = {
   reason: string;
 };
 
+/** Output from formatting, including the rewritten text and edits. */
 export type FormatResult = {
   formattedText: string;
   edits: FormatEdit[];
@@ -28,6 +31,7 @@ const SINGLE_SPACE = " ";
 const NEWLINE = "\n";
 const LINE_SPLIT_REGEX = /\r?\n/;
 
+/** Normalize waymark formatting within the provided source text. */
 export function formatText(
   source: string,
   options: FormatOptions = {}

--- a/packages/core/src/format.ts
+++ b/packages/core/src/format.ts
@@ -31,7 +31,12 @@ const SINGLE_SPACE = " ";
 const NEWLINE = "\n";
 const LINE_SPLIT_REGEX = /\r?\n/;
 
-/** Normalize waymark formatting within the provided source text. */
+/**
+ * Normalize waymark formatting within the provided source text.
+ * @param source - Source text to format.
+ * @param options - Formatting and parse options.
+ * @returns Formatted text and a list of edits.
+ */
 export function formatText(
   source: string,
   options: FormatOptions = {}

--- a/packages/core/src/graph.ts
+++ b/packages/core/src/graph.ts
@@ -2,17 +2,20 @@
 
 import type { WaymarkRecord } from "@waymarks/grammar";
 
+/** Directed relation edge between waymark records. */
 export type GraphEdge = {
   from: WaymarkRecord;
   toCanonical: string;
   relation: WaymarkRecord["relations"][number]["kind"];
 };
 
+/** Graph structure derived from canonical and relation fields. */
 export type WaymarkGraph = {
   canonicals: Map<string, WaymarkRecord[]>;
   edges: GraphEdge[];
 };
 
+/** Build a relation graph from a list of waymark records. */
 export function buildRelationGraph(records: WaymarkRecord[]): WaymarkGraph {
   const canonicals = new Map<string, WaymarkRecord[]>();
   const edges: GraphEdge[] = [];

--- a/packages/core/src/graph.ts
+++ b/packages/core/src/graph.ts
@@ -15,7 +15,11 @@ export type WaymarkGraph = {
   edges: GraphEdge[];
 };
 
-/** Build a relation graph from a list of waymark records. */
+/**
+ * Build a relation graph from a list of waymark records.
+ * @param records - Waymark records to analyze.
+ * @returns Graph of canonicals and relation edges.
+ */
 export function buildRelationGraph(records: WaymarkRecord[]): WaymarkGraph {
   const canonicals = new Map<string, WaymarkRecord[]>();
   const edges: GraphEdge[] = [];

--- a/packages/core/src/id-index.ts
+++ b/packages/core/src/id-index.ts
@@ -78,7 +78,10 @@ export class JsonIdIndex {
     this.trackHistory = options.trackHistory ?? false;
   }
 
-  /** Load index and history from disk once per instance. */
+  /**
+   * Load index and history from disk once per instance.
+   * @returns Promise that resolves when the index is initialized.
+   */
   async init(): Promise<void> {
     if (this.loaded) {
       return;
@@ -91,26 +94,43 @@ export class JsonIdIndex {
     this.loaded = true;
   }
 
-  /** Check whether a waymark ID exists in the index. */
+  /**
+   * Check whether a waymark ID exists in the index.
+   * @param id - Waymark ID to check.
+   * @returns True if the ID exists.
+   */
   async has(id: string): Promise<boolean> {
     await this.init();
     return Boolean(this.data.ids[id]);
   }
 
-  /** Fetch a waymark ID entry, if present. */
+  /**
+   * Fetch a waymark ID entry, if present.
+   * @param id - Waymark ID to fetch.
+   * @returns Matching entry or null.
+   */
   async get(id: string): Promise<IdIndexEntry | null> {
     await this.init();
     return this.data.ids[id] ?? null;
   }
 
-  /** Insert or replace a waymark ID entry. */
+  /**
+   * Insert or replace a waymark ID entry.
+   * @param entry - Entry to persist.
+   * @returns Promise that resolves when saved.
+   */
   async set(entry: IdIndexEntry): Promise<void> {
     await this.init();
     this.data.ids[entry.id] = entry;
     await this.save();
   }
 
-  /** Update an existing entry via an updater function. */
+  /**
+   * Update an existing entry via an updater function.
+   * @param id - Waymark ID to update.
+   * @param updater - Function to transform the existing entry.
+   * @returns Promise that resolves when saved.
+   */
   async update(
     id: string,
     updater: (entry: IdIndexEntry) => IdIndexEntry
@@ -124,7 +144,12 @@ export class JsonIdIndex {
     await this.save();
   }
 
-  /** Remove an entry and optionally record it in history. */
+  /**
+   * Remove an entry and optionally record it in history.
+   * @param id - Waymark ID to remove.
+   * @param history - Optional history fields to record with removal.
+   * @returns Promise that resolves when saved.
+   */
   async delete(
     id: string,
     history?: Partial<Omit<HistoryEntry, "removedAt">>
@@ -147,7 +172,12 @@ export class JsonIdIndex {
     await this.save();
   }
 
-  /** Record a file hash and last-seen timestamp. */
+  /**
+   * Record a file hash and last-seen timestamp.
+   * @param filePath - File path to update.
+   * @param hash - Optional content hash.
+   * @returns Promise that resolves when saved.
+   */
   async touchFile(filePath: string, hash?: string | null): Promise<void> {
     await this.init();
     this.data.files[filePath] = {
@@ -157,28 +187,43 @@ export class JsonIdIndex {
     await this.save();
   }
 
-  /** Remove file metadata from the index. */
+  /**
+   * Remove file metadata from the index.
+   * @param filePath - File path to remove.
+   * @returns Promise that resolves when saved.
+   */
   async removeFile(filePath: string): Promise<void> {
     await this.init();
     delete this.data.files[filePath];
     await this.save();
   }
 
-  /** Set the last refresh timestamp for the index metadata. */
+  /**
+   * Set the last refresh timestamp for the index metadata.
+   * @param date - Date to record as last refresh.
+   * @returns Promise that resolves when saved.
+   */
   async setLastRefreshed(date: Date): Promise<void> {
     await this.init();
     this.data.metadata.lastRefreshed = date.toISOString();
     await this.save();
   }
 
-  /** Retrieve the last refresh timestamp, if recorded. */
+  /**
+   * Retrieve the last refresh timestamp, if recorded.
+   * @returns Date of last refresh or null.
+   */
   async getLastRefreshed(): Promise<Date | null> {
     await this.init();
     const value = this.data.metadata.lastRefreshed;
     return value ? new Date(value) : null;
   }
 
-  /** Find the first entry where either content or context hash matches. */
+  /**
+   * Find the first entry where either content or context hash matches.
+   * @param fingerprint - Content or context hashes to match.
+   * @returns Matching entry or null.
+   */
   async findByFingerprint(fingerprint: {
     contentHash?: string;
     contextHash?: string;
@@ -200,7 +245,10 @@ export class JsonIdIndex {
     return null;
   }
 
-  /** List all stored ID entries. */
+  /**
+   * List all stored ID entries.
+   * @returns All entries in the index.
+   */
   async listIds(): Promise<IdIndexEntry[]> {
     await this.init();
     return Object.values(this.data.ids);

--- a/packages/core/src/id-index.ts
+++ b/packages/core/src/id-index.ts
@@ -178,7 +178,7 @@ export class JsonIdIndex {
     return value ? new Date(value) : null;
   }
 
-  /** Find an entry that matches content or context hashes. */
+  /** Find the first entry where either content or context hash matches. */
   async findByFingerprint(fingerprint: {
     contentHash?: string;
     contextHash?: string;

--- a/packages/core/src/id-index.ts
+++ b/packages/core/src/id-index.ts
@@ -78,6 +78,7 @@ export class JsonIdIndex {
     this.trackHistory = options.trackHistory ?? false;
   }
 
+  /** Load index and history from disk once per instance. */
   async init(): Promise<void> {
     if (this.loaded) {
       return;
@@ -90,22 +91,26 @@ export class JsonIdIndex {
     this.loaded = true;
   }
 
+  /** Check whether a waymark ID exists in the index. */
   async has(id: string): Promise<boolean> {
     await this.init();
     return Boolean(this.data.ids[id]);
   }
 
+  /** Fetch a waymark ID entry, if present. */
   async get(id: string): Promise<IdIndexEntry | null> {
     await this.init();
     return this.data.ids[id] ?? null;
   }
 
+  /** Insert or replace a waymark ID entry. */
   async set(entry: IdIndexEntry): Promise<void> {
     await this.init();
     this.data.ids[entry.id] = entry;
     await this.save();
   }
 
+  /** Update an existing entry via an updater function. */
   async update(
     id: string,
     updater: (entry: IdIndexEntry) => IdIndexEntry
@@ -119,6 +124,7 @@ export class JsonIdIndex {
     await this.save();
   }
 
+  /** Remove an entry and optionally record it in history. */
   async delete(
     id: string,
     history?: Partial<Omit<HistoryEntry, "removedAt">>
@@ -141,6 +147,7 @@ export class JsonIdIndex {
     await this.save();
   }
 
+  /** Record a file hash and last-seen timestamp. */
   async touchFile(filePath: string, hash?: string | null): Promise<void> {
     await this.init();
     this.data.files[filePath] = {
@@ -150,24 +157,28 @@ export class JsonIdIndex {
     await this.save();
   }
 
+  /** Remove file metadata from the index. */
   async removeFile(filePath: string): Promise<void> {
     await this.init();
     delete this.data.files[filePath];
     await this.save();
   }
 
+  /** Set the last refresh timestamp for the index metadata. */
   async setLastRefreshed(date: Date): Promise<void> {
     await this.init();
     this.data.metadata.lastRefreshed = date.toISOString();
     await this.save();
   }
 
+  /** Retrieve the last refresh timestamp, if recorded. */
   async getLastRefreshed(): Promise<Date | null> {
     await this.init();
     const value = this.data.metadata.lastRefreshed;
     return value ? new Date(value) : null;
   }
 
+  /** Find an entry that matches content or context hashes. */
   async findByFingerprint(fingerprint: {
     contentHash?: string;
     contextHash?: string;
@@ -189,6 +200,7 @@ export class JsonIdIndex {
     return null;
   }
 
+  /** List all stored ID entries. */
   async listIds(): Promise<IdIndexEntry[]> {
     await this.init();
     return Object.values(this.data.ids);

--- a/packages/core/src/id-index.ts
+++ b/packages/core/src/id-index.ts
@@ -4,8 +4,10 @@ import { existsSync } from "node:fs";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 
+/** Source categories for IDs tracked in the index. */
 export type WaymarkIdSourceType = "cli" | "mcp" | "api" | "manual";
 
+/** Stored metadata for a single waymark ID. */
 export type IdIndexEntry = {
   id: string;
   file: string;
@@ -19,11 +21,13 @@ export type IdIndexEntry = {
   updatedAt: number;
 };
 
+/** Stored metadata for a scanned file. */
 export type FileIndexEntry = {
   hash?: string | null;
   lastSeen: string;
 };
 
+/** Serialized index payload stored on disk. */
 export type IdIndexData = {
   version: number;
   ids: Record<string, IdIndexEntry>;
@@ -40,17 +44,20 @@ const DEFAULT_INDEX: IdIndexData = {
   metadata: {},
 };
 
+/** Options for configuring the JSON index location and history. */
 export type JsonIdIndexOptions = {
   workspaceRoot: string;
   trackHistory?: boolean;
 };
 
+/** Historic entry recorded when an ID is removed. */
 export interface HistoryEntry extends IdIndexEntry {
   removedAt: string;
   removedBy?: string;
   reason?: string;
 }
 
+/** JSON-backed index for waymark IDs and file metadata. */
 export class JsonIdIndex {
   private readonly indexPath: string;
   private readonly historyPath: string;

--- a/packages/core/src/ids.ts
+++ b/packages/core/src/ids.ts
@@ -85,6 +85,7 @@ export class WaymarkIdManager {
     this.reserved.delete(normalized);
   }
 
+  /** Update the stored location metadata for an existing ID. */
   async updateLocation(id: string, metadata: WaymarkIdMetadata): Promise<void> {
     const normalized = this.normalizeId(id);
     await this.index.update(normalized, () =>
@@ -92,6 +93,7 @@ export class WaymarkIdManager {
     );
   }
 
+  /** Remove an ID from the index and optionally record a removal reason. */
   async remove(
     id: string,
     options?: { reason?: string; removedBy?: string }
@@ -100,11 +102,13 @@ export class WaymarkIdManager {
     await this.index.delete(normalized, options);
   }
 
+  /** Fetch a stored ID entry by ID. */
   get(id: string): Promise<IdIndexEntry | null> {
     const normalized = this.normalizeId(id);
     return this.index.get(normalized);
   }
 
+  /** Lookup an ID entry by content or context hash. */
   lookupByFingerprint(fingerprint: {
     contentHash?: string;
     contextHash?: string;

--- a/packages/core/src/ids.ts
+++ b/packages/core/src/ids.ts
@@ -11,6 +11,7 @@ const BASE36_RADIX = 36;
 import type { IdIndexEntry, JsonIdIndex } from "./id-index.ts";
 import type { WaymarkIdConfig } from "./types.ts";
 
+/** Metadata used to generate and persist waymark IDs. */
 export type WaymarkIdMetadata = {
   file: string;
   line: number;
@@ -22,6 +23,7 @@ export type WaymarkIdMetadata = {
   sourceType?: IdIndexEntry["sourceType"];
 };
 
+/** Manages waymark ID generation and persistence using the JSON index. */
 export class WaymarkIdManager {
   private readonly config: WaymarkIdConfig;
   private readonly index: JsonIdIndex;
@@ -196,10 +198,12 @@ export class WaymarkIdManager {
   }
 }
 
+/** Hash normalized waymark content for ID matching. */
 export function fingerprintContent(content: string): string {
   return createHash("sha256").update(content.trim()).digest("hex");
 }
 
+/** Hash surrounding context for ID matching. */
 export function fingerprintContext(context: string): string {
   return createHash("sha256").update(context).digest("hex");
 }

--- a/packages/core/src/ids.ts
+++ b/packages/core/src/ids.ts
@@ -37,6 +37,9 @@ export class WaymarkIdManager {
   /**
    * Reserve an ID for the provided metadata without immediately writing to disk.
    * Call {@link commitReservedId} after the file write succeeds to persist the mapping.
+   * @param metadata - Metadata used to generate or validate the ID.
+   * @param requestedId - Optional explicit ID to reserve.
+   * @returns Reserved ID or undefined when no ID should be assigned.
    */
   async reserveId(
     metadata: WaymarkIdMetadata,
@@ -72,6 +75,9 @@ export class WaymarkIdManager {
 
   /**
    * Persist a previously reserved ID to the on-disk index.
+   * @param id - Reserved ID to persist.
+   * @param metadata - Metadata associated with the ID.
+   * @returns Promise that resolves when saved.
    */
   async commitReservedId(
     id: string,
@@ -85,7 +91,12 @@ export class WaymarkIdManager {
     this.reserved.delete(normalized);
   }
 
-  /** Update the stored location metadata for an existing ID. */
+  /**
+   * Update the stored location metadata for an existing ID.
+   * @param id - Waymark ID to update.
+   * @param metadata - Updated metadata for the ID.
+   * @returns Promise that resolves when saved.
+   */
   async updateLocation(id: string, metadata: WaymarkIdMetadata): Promise<void> {
     const normalized = this.normalizeId(id);
     await this.index.update(normalized, () =>
@@ -93,7 +104,12 @@ export class WaymarkIdManager {
     );
   }
 
-  /** Remove an ID from the index and optionally record a removal reason. */
+  /**
+   * Remove an ID from the index and optionally record a removal reason.
+   * @param id - Waymark ID to remove.
+   * @param options - Optional removal metadata.
+   * @returns Promise that resolves when saved.
+   */
   async remove(
     id: string,
     options?: { reason?: string; removedBy?: string }
@@ -102,13 +118,21 @@ export class WaymarkIdManager {
     await this.index.delete(normalized, options);
   }
 
-  /** Fetch a stored ID entry by ID. */
+  /**
+   * Fetch a stored ID entry by ID.
+   * @param id - Waymark ID to fetch.
+   * @returns Entry if found, otherwise null.
+   */
   get(id: string): Promise<IdIndexEntry | null> {
     const normalized = this.normalizeId(id);
     return this.index.get(normalized);
   }
 
-  /** Lookup an ID entry by content or context hash. */
+  /**
+   * Lookup an ID entry by content or context hash.
+   * @param fingerprint - Content/context hashes to search for.
+   * @returns Matching entry or null.
+   */
   lookupByFingerprint(fingerprint: {
     contentHash?: string;
     contextHash?: string;
@@ -202,12 +226,20 @@ export class WaymarkIdManager {
   }
 }
 
-/** Hash normalized waymark content for ID matching. */
+/**
+ * Hash normalized waymark content for ID matching.
+ * @param content - Waymark content to hash.
+ * @returns SHA-256 content hash.
+ */
 export function fingerprintContent(content: string): string {
   return createHash("sha256").update(content.trim()).digest("hex");
 }
 
-/** Hash surrounding context for ID matching. */
+/**
+ * Hash surrounding context for ID matching.
+ * @param context - Surrounding text to hash.
+ * @returns SHA-256 context hash.
+ */
 export function fingerprintContext(context: string): string {
   return createHash("sha256").update(context).digest("hex");
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,6 @@
 // tldr ::: core waymark utilities with caching and scanning
 
+/** Current version of the core package. */
 export const version = "1.0.0-beta.1";
 
 export type { ParseOptions, WaymarkRecord } from "@waymarks/grammar";

--- a/packages/core/src/insert.ts
+++ b/packages/core/src/insert.ts
@@ -68,7 +68,12 @@ export type InsertOptions = {
   logger?: CoreLogger;
 };
 
-/** Insert waymarks into files, optionally writing changes to disk. */
+/**
+ * Insert waymarks into files, optionally writing changes to disk.
+ * @param specs - Insertion specs describing what to insert.
+ * @param options - Options controlling formatting, writing, and ID management.
+ * @returns Results for each insertion attempt.
+ */
 export async function insertWaymarks(
   specs: InsertionSpec[],
   options: InsertOptions = {}

--- a/packages/core/src/insert.ts
+++ b/packages/core/src/insert.ts
@@ -18,7 +18,7 @@ const CONTEXT_BEFORE_LINES = 2;
 const CONTEXT_AFTER_LINES = 3;
 const DEFAULT_EOL = "\n";
 
-// Define the Zod schema for InsertionSpec
+/** Zod schema describing a waymark insertion request. */
 export const InsertionSpecSchema = z.object({
   file: z.string().min(1, "File path is required"),
   line: z.number().int().positive("Line must be a positive integer"),
@@ -40,9 +40,10 @@ export const InsertionSpecSchema = z.object({
   id: z.string().optional(),
 });
 
-// Infer the type from the schema for consistency
+/** Parsed insertion spec derived from {@link InsertionSpecSchema}. */
 export type InsertionSpec = z.infer<typeof InsertionSpecSchema>;
 
+/** Result for a single insertion attempt. */
 export type InsertionResult = {
   file: string;
   requested: {
@@ -58,6 +59,7 @@ export type InsertionResult = {
   error?: string;
 };
 
+/** Options that control how insertions are applied and written. */
 export type InsertOptions = {
   write?: boolean;
   format?: boolean;
@@ -66,6 +68,7 @@ export type InsertOptions = {
   logger?: CoreLogger;
 };
 
+/** Insert waymarks into files, optionally writing changes to disk. */
 export async function insertWaymarks(
   specs: InsertionSpec[],
   options: InsertOptions = {}

--- a/packages/core/src/normalize.ts
+++ b/packages/core/src/normalize.ts
@@ -12,7 +12,12 @@ export type NormalizeRecordOptions = {
   type?: NormalizeTypeOptions;
 };
 
-/** Normalize a waymark type string. */
+/**
+ * Normalize a waymark type string.
+ * @param type - Marker type to normalize.
+ * @param options - Normalization options.
+ * @returns Normalized type string.
+ */
 export function normalizeType(
   type: string,
   options: NormalizeTypeOptions = {}
@@ -29,7 +34,11 @@ export function normalizeType(
   return trimmed;
 }
 
-/** Normalize waymark properties by sorting keys. */
+/**
+ * Normalize waymark properties by sorting keys.
+ * @param properties - Properties map to normalize.
+ * @returns Properties with sorted keys.
+ */
 export function normalizeProperties(
   properties: WaymarkRecord["properties"]
 ): WaymarkRecord["properties"] {
@@ -41,7 +50,11 @@ export function normalizeProperties(
   return Object.fromEntries(entries.sort(([a], [b]) => a.localeCompare(b)));
 }
 
-/** Normalize relation tokens and ordering. */
+/**
+ * Normalize relation tokens and ordering.
+ * @param relations - Relations to normalize.
+ * @returns Normalized relations list.
+ */
 export function normalizeRelations(
   relations: WaymarkRecord["relations"]
 ): WaymarkRecord["relations"] {
@@ -63,7 +76,11 @@ export function normalizeRelations(
     });
 }
 
-/** Normalize tags by trimming, lowercasing, and sorting. */
+/**
+ * Normalize tags by trimming, lowercasing, and sorting.
+ * @param tags - Tags to normalize.
+ * @returns Normalized tag list.
+ */
 export function normalizeTags(tags: WaymarkRecord["tags"]): string[] {
   if (tags.length === 0) {
     return [];
@@ -77,7 +94,11 @@ export function normalizeTags(tags: WaymarkRecord["tags"]): string[] {
   );
 }
 
-/** Normalize canonical references by formatting and sorting. */
+/**
+ * Normalize canonical references by formatting and sorting.
+ * @param canonicals - Canonical tokens to normalize.
+ * @returns Normalized canonical tokens.
+ */
 export function normalizeCanonicals(
   canonicals: WaymarkRecord["canonicals"]
 ): string[] {
@@ -88,7 +109,11 @@ export function normalizeCanonicals(
   return sortUnique(canonicals.map(normalizeCanonicalToken));
 }
 
-/** Normalize mentions by trimming and sorting. */
+/**
+ * Normalize mentions by trimming and sorting.
+ * @param mentions - Mentions to normalize.
+ * @returns Normalized mention list.
+ */
 export function normalizeMentions(
   mentions: WaymarkRecord["mentions"]
 ): string[] {
@@ -103,7 +128,12 @@ export function normalizeMentions(
   );
 }
 
-/** Normalize a full waymark record for stable comparisons. */
+/**
+ * Normalize a full waymark record for stable comparisons.
+ * @param record - Waymark record to normalize.
+ * @param options - Normalization options.
+ * @returns Normalized waymark record.
+ */
 export function normalizeRecord(
   record: WaymarkRecord,
   options: NormalizeRecordOptions = {}

--- a/packages/core/src/normalize.ts
+++ b/packages/core/src/normalize.ts
@@ -2,14 +2,17 @@
 
 import type { WaymarkRecord } from "@waymarks/grammar";
 
+/** Options for normalizing waymark types. */
 export type NormalizeTypeOptions = {
   normalizeCase?: boolean;
 };
 
+/** Options for normalizing entire waymark records. */
 export type NormalizeRecordOptions = {
   type?: NormalizeTypeOptions;
 };
 
+/** Normalize a waymark type string. */
 export function normalizeType(
   type: string,
   options: NormalizeTypeOptions = {}
@@ -26,6 +29,7 @@ export function normalizeType(
   return trimmed;
 }
 
+/** Normalize waymark properties by sorting keys. */
 export function normalizeProperties(
   properties: WaymarkRecord["properties"]
 ): WaymarkRecord["properties"] {
@@ -37,6 +41,7 @@ export function normalizeProperties(
   return Object.fromEntries(entries.sort(([a], [b]) => a.localeCompare(b)));
 }
 
+/** Normalize relation tokens and ordering. */
 export function normalizeRelations(
   relations: WaymarkRecord["relations"]
 ): WaymarkRecord["relations"] {
@@ -58,6 +63,7 @@ export function normalizeRelations(
     });
 }
 
+/** Normalize tags by trimming, lowercasing, and sorting. */
 export function normalizeTags(tags: WaymarkRecord["tags"]): string[] {
   if (tags.length === 0) {
     return [];
@@ -71,6 +77,7 @@ export function normalizeTags(tags: WaymarkRecord["tags"]): string[] {
   );
 }
 
+/** Normalize canonical references by formatting and sorting. */
 export function normalizeCanonicals(
   canonicals: WaymarkRecord["canonicals"]
 ): string[] {
@@ -81,6 +88,7 @@ export function normalizeCanonicals(
   return sortUnique(canonicals.map(normalizeCanonicalToken));
 }
 
+/** Normalize mentions by trimming and sorting. */
 export function normalizeMentions(
   mentions: WaymarkRecord["mentions"]
 ): string[] {
@@ -95,6 +103,7 @@ export function normalizeMentions(
   );
 }
 
+/** Normalize a full waymark record for stable comparisons. */
 export function normalizeRecord(
   record: WaymarkRecord,
   options: NormalizeRecordOptions = {}

--- a/packages/core/src/remove.ts
+++ b/packages/core/src/remove.ts
@@ -134,7 +134,12 @@ type RemovalState = {
   dryRun: boolean;
 };
 
-/** Remove waymarks matching specs, optionally writing changes to disk. */
+/**
+ * Remove waymarks matching specs, optionally writing changes to disk.
+ * @param specs - Removal specs describing what to remove.
+ * @param options - Options controlling formatting, writing, and ID management.
+ * @returns Results for each removal attempt.
+ */
 export async function removeWaymarks(
   specs: RemovalSpec[],
   options: RemoveOptions = {}

--- a/packages/core/src/remove.ts
+++ b/packages/core/src/remove.ts
@@ -20,9 +20,10 @@ const RemovalSignalsSchema = z
   })
   .strict();
 
+/** Signal filters used when selecting waymarks to remove. */
 export type RemovalSignals = z.infer<typeof RemovalSignalsSchema>;
 
-// Define the Zod schema for RemovalCriteria
+/** Zod schema describing removal criteria filters. */
 export const RemovalCriteriaSchema = z
   .object({
     type: z.string().optional(),
@@ -49,10 +50,10 @@ export const RemovalCriteriaSchema = z
     { message: "At least one criteria field must be provided" }
   );
 
-// Infer the type from the schema for consistency
+/** Parsed criteria used to match waymarks for removal. */
 export type RemovalCriteria = z.infer<typeof RemovalCriteriaSchema>;
 
-// Define the Zod schema for RemovalSpec
+/** Zod schema describing a removal request. */
 export const RemovalSpecSchema = z
   .object({
     file: z.string().optional(),
@@ -78,9 +79,10 @@ export const RemovalSpecSchema = z
     }
   );
 
-// Infer the type from the schema for consistency
+/** Parsed removal request for one or more waymarks. */
 export type RemovalSpec = z.infer<typeof RemovalSpecSchema>;
 
+/** Result for a single removal attempt. */
 export type RemovalResult = {
   file: string;
   line: number;
@@ -89,6 +91,7 @@ export type RemovalResult = {
   error?: string;
 };
 
+/** Options that control how removals are applied and written. */
 export type RemoveOptions = {
   write?: boolean;
   config?: WaymarkConfig;
@@ -131,6 +134,7 @@ type RemovalState = {
   dryRun: boolean;
 };
 
+/** Remove waymarks matching specs, optionally writing changes to disk. */
 export async function removeWaymarks(
   specs: RemovalSpec[],
   options: RemoveOptions = {}

--- a/packages/core/src/search.ts
+++ b/packages/core/src/search.ts
@@ -12,7 +12,12 @@ export type SearchQuery = {
   predicate?: (record: WaymarkRecord) => boolean;
 };
 
-/** Filter waymark records using marker, tag, mention, and text criteria. */
+/**
+ * Filter waymark records using marker, tag, mention, and text criteria.
+ * @param records - Records to filter.
+ * @param query - Query criteria to apply.
+ * @returns Filtered records.
+ */
 export function searchRecords(
   records: WaymarkRecord[],
   query: SearchQuery = {}

--- a/packages/core/src/search.ts
+++ b/packages/core/src/search.ts
@@ -2,6 +2,7 @@
 
 import type { WaymarkRecord } from "@waymarks/grammar";
 
+/** Query options for filtering waymark records. */
 export type SearchQuery = {
   markers?: string[];
   tags?: string[];
@@ -11,6 +12,7 @@ export type SearchQuery = {
   predicate?: (record: WaymarkRecord) => boolean;
 };
 
+/** Filter waymark records using marker, tag, mention, and text criteria. */
 export function searchRecords(
   records: WaymarkRecord[],
   query: SearchQuery = {}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -3,6 +3,7 @@
 // Re-export grammar types for convenience
 export type { ParseOptions, WaymarkRecord } from "@waymarks/grammar";
 
+/** Formatting controls for rendered waymark comments. */
 export type WaymarkFormatConfig = {
   spaceAroundSigil: boolean;
   normalizeCase: boolean;
@@ -11,6 +12,7 @@ export type WaymarkFormatConfig = {
   wrapWidth?: number;
 };
 
+/** Lint severity configuration for waymark validation. */
 export type WaymarkLintConfig = {
   duplicateProperty: "warn" | "error" | "ignore";
   unknownMarker: "warn" | "error" | "ignore";
@@ -18,10 +20,12 @@ export type WaymarkLintConfig = {
   duplicateCanonical: "warn" | "error" | "ignore";
 };
 
+/** Scan-time toggles for including additional markers. */
 export type WaymarkScanConfig = {
   includeCodetags: boolean;
 };
 
+/** Full configuration shape for waymark operations. */
 export type WaymarkConfig = {
   typeCase: "lowercase" | "uppercase";
   idScope: "repo" | "file";
@@ -36,7 +40,7 @@ export type WaymarkConfig = {
   index: WaymarkIndexConfig;
 };
 
-// Manually defined partial config to work with exactOptionalPropertyTypes
+/** Partial configuration shape for overrides. */
 export type PartialWaymarkConfig = {
   typeCase?: "lowercase" | "uppercase";
   idScope?: "repo" | "file";
@@ -51,12 +55,14 @@ export type PartialWaymarkConfig = {
   index?: Partial<WaymarkIndexConfig>;
 };
 
+/** Options that control scanning and filtering waymarks. */
 export type ScanOptions = {
   cache?: boolean;
   filter?: (record: import("@waymarks/grammar").WaymarkRecord) => boolean;
   config?: Partial<WaymarkConfig>;
 };
 
+/** Configuration for waymark ID assignment. */
 export type WaymarkIdConfig = {
   mode: "auto" | "prompt" | "off" | "manual";
   length: number;
@@ -65,11 +71,13 @@ export type WaymarkIdConfig = {
   assignOnRefresh: boolean;
 };
 
+/** Configuration for the on-disk ID index refresh behavior. */
 export type WaymarkIndexConfig = {
   refreshTriggers: string[];
   autoRefreshAfterMinutes: number;
 };
 
+/** Minimal logger interface used by core utilities. */
 export type CoreLogger = {
   debug: (msg: string, meta?: Record<string, unknown>) => void;
   info: (msg: string, meta?: Record<string, unknown>) => void;

--- a/scripts/typedoc-check.ts
+++ b/scripts/typedoc-check.ts
@@ -68,7 +68,7 @@ const PACKAGES: Record<PackageKey, PackageConfig> = {
   },
 };
 
-const DEFAULT_ENFORCED_PACKAGES: PackageKey[] = [];
+const DEFAULT_ENFORCED_PACKAGES: PackageKey[] = ["core"];
 
 const DOC_KINDS: ReflectionKind[] = [
   ReflectionKind.Class,


### PR DESCRIPTION
## Summary
Expand TSDoc coverage for core APIs and cache helpers, and fix cache metadata updates to avoid undefined hashes under exactOptionalPropertyTypes.

## Changes
- Add @param/@returns tags for core public exports and cache helper functions.
- Update cache updateFileInfo call sites to omit undefined hash values.

## Testing
- turbo run lint
- bun run lint:md
- turbo run typecheck
- turbo run test

## Issues
- Part of #222


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added SQLite-backed caching system with record search and query capabilities
  * Introduced configuration management with defaults and disk-based loading
  * Added ID tracking and management system with fingerprint-based lookup
  * Enhanced search with mentions and text filtering support
  * Added data normalization utilities for records and properties
  * Introduced relation graph building capability
  * Added waymark removal with customizable criteria
  * Enhanced insertion with position control ("before"/"after")

* **Improvements**
  * Extended format edits to include original and replacement content
  * Added comprehensive configuration options for scanning, linting, and formatting

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->