### PR TITLE
docs(cli): add TSDoc for CLI exports

### DIFF
--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -63,6 +63,11 @@ export type ParsedAddArgs = {
   options: AddCommandOptions;
 };
 
+/**
+ * Build insertion specs and options from parsed add command input.
+ * @param input - Parsed positional arguments and flags.
+ * @returns Parsed insertion specs and options.
+ */
 export function buildAddArgs(input: AddCommandInput): ParsedAddArgs {
   const state = createInitialState();
   const { options } = input;
@@ -337,6 +342,12 @@ function buildInsertOptions(state: InsertParseState): AddCommandOptions {
   return { ...state.optionState };
 }
 
+/**
+ * Execute the `wm add` command with parsed inputs.
+ * @param parsed - Parsed insertion specs and options.
+ * @param context - CLI context with config, logger, and filesystem helpers.
+ * @returns Results, summary, output text, and exit code.
+ */
 export async function runAddCommand(
   parsed: ParsedAddArgs,
   context: CommandContext

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -26,6 +26,12 @@ function serializeConfig(
   return JSON.stringify(config, null, indent);
 }
 
+/**
+ * Execute the `wm config` command to print resolved configuration.
+ * @param context - CLI context with config.
+ * @param options - Command options controlling output.
+ * @returns Output payload and exit code.
+ */
 export function runConfigCommand(
   context: CommandContext,
   options: ConfigCommandOptions = {}

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -61,6 +61,12 @@ export type DoctorCommandOptions = {
 };
 
 // about ::: orchestrates all diagnostic checks and returns comprehensive report
+/**
+ * Run the doctor diagnostics and return a report.
+ * @param context - CLI context with config and logger.
+ * @param options - Doctor command options.
+ * @returns Comprehensive doctor report.
+ */
 export async function runDoctorCommand(
   context: CommandContext,
   options: DoctorCommandOptions
@@ -579,6 +585,11 @@ async function checkPerformance(
 }
 
 // about ::: renders check results with color coded severity indicators
+/**
+ * Format a doctor report for CLI output.
+ * @param report - Doctor report to format.
+ * @returns Human-readable report string.
+ */
 export function formatDoctorReport(report: DoctorReport): string {
   const lines: string[] = [];
 

--- a/packages/cli/src/commands/find.ts
+++ b/packages/cli/src/commands/find.ts
@@ -22,6 +22,8 @@ export type FindCommandOptions = {
 
 /**
  * Scan the provided file and run structured searches across the resulting records.
+ * @param options - Find command options, including filters and config.
+ * @returns Matching waymark records.
  */
 export async function findRecords(
   options: FindCommandOptions
@@ -45,6 +47,8 @@ export async function findRecords(
 
 /**
  * Parse CLI arguments for the find command into structured options.
+ * @param argv - Raw CLI arguments.
+ * @returns Parsed find options excluding config.
  */
 export function parseFindArgs(
   argv: string[]

--- a/packages/cli/src/commands/fmt.ts
+++ b/packages/cli/src/commands/fmt.ts
@@ -16,6 +16,12 @@ export type FormatCommandOptions = {
 const IGNORE_FILE_MARKER_PATTERN =
   /^\s*(\/\/|#|--|<!--)\s*waymark-ignore-file\b/;
 
+/**
+ * Format a single file and optionally write changes.
+ * @param options - Target file and write preference.
+ * @param context - CLI context with config.
+ * @returns Formatting result details.
+ */
 export async function formatFile(
   options: { filePath: string; write: boolean },
   context: CommandContext
@@ -73,6 +79,12 @@ async function filterFilesWithWaymarks(paths: string[]): Promise<string[]> {
   return results;
 }
 
+/**
+ * Expand input globs and filter to files with waymarks.
+ * @param inputs - Input paths or globs.
+ * @param config - Resolved waymark configuration.
+ * @returns Expanded list of file paths.
+ */
 export async function expandFormatPaths(
   inputs: string[],
   config: WaymarkConfig
@@ -81,6 +93,11 @@ export async function expandFormatPaths(
   return await filterFilesWithWaymarks(expanded);
 }
 
+/**
+ * Parse fmt CLI arguments into options.
+ * @param argv - Raw CLI arguments.
+ * @returns Parsed format options.
+ */
 export function parseFormatArgs(argv: string[]): FormatCommandOptions {
   if (argv.length === 0) {
     throw new Error("fmt requires at least one file path");

--- a/packages/cli/src/commands/graph.ts
+++ b/packages/cli/src/commands/graph.ts
@@ -13,6 +13,13 @@ export type ParsedGraphArgs = {
   json: boolean;
 };
 
+/**
+ * Scan records and build relation graph edges.
+ * @param filePaths - Paths or globs to scan.
+ * @param config - Resolved waymark configuration.
+ * @param scanOptions - Optional scan runtime options.
+ * @returns Relation graph edges.
+ */
 export async function graphRecords(
   filePaths: string[],
   config: WaymarkConfig,
@@ -26,6 +33,11 @@ export async function graphRecords(
   return buildRelationGraph(records).edges;
 }
 
+/**
+ * Parse CLI arguments for the graph command.
+ * @param argv - Raw CLI arguments.
+ * @returns Parsed graph arguments.
+ */
 export function parseGraphArgs(argv: string[]): ParsedGraphArgs {
   const json = argv.includes("--json");
   const filePaths = argv.filter((arg) => !arg.startsWith("-"));

--- a/packages/cli/src/commands/help/index.ts
+++ b/packages/cli/src/commands/help/index.ts
@@ -14,7 +14,9 @@ export type { CommandConfig, FlagConfig, HelpRegistry } from "./types.ts";
 import { getHelp } from "./render.ts";
 
 /**
- * Display help and exit
+ * Display help text to stdout.
+ * @param commandName - Optional command name to scope output.
+ * @returns Exit code to use for the CLI.
  */
 export function displayHelp(commandName?: string): number {
   const helpText = getHelp(commandName);

--- a/packages/cli/src/commands/help/render.ts
+++ b/packages/cli/src/commands/help/render.ts
@@ -19,7 +19,9 @@ function renderFlag(flag: FlagConfig): string {
 }
 
 /**
- * Render command-specific help
+ * Render command-specific help content.
+ * @param config - Command configuration to render.
+ * @returns Formatted help text.
  */
 export function renderCommandHelp(config: CommandConfig): string {
   const sections: string[] = [];
@@ -53,7 +55,8 @@ export function renderCommandHelp(config: CommandConfig): string {
 }
 
 /**
- * Render global help (main command overview + command list)
+ * Render global help (main command overview + command list).
+ * @returns Formatted help text.
  */
 export function renderGlobalHelp(): string {
   const sections: string[] = [];
@@ -120,7 +123,9 @@ export function renderGlobalHelp(): string {
 }
 
 /**
- * Get help text for a command or global help
+ * Get help text for a command or global help.
+ * @param commandName - Optional command name to scope output.
+ * @returns Help text for the requested command or fallback.
  */
 export function getHelp(commandName?: string): string {
   if (!commandName) {

--- a/packages/cli/src/commands/help/topics/index.ts
+++ b/packages/cli/src/commands/help/topics/index.ts
@@ -18,6 +18,11 @@ export type HelpTopic = keyof typeof helpTopics;
 
 export const helpTopicNames = Object.keys(helpTopics) as HelpTopic[];
 
+/**
+ * Resolve the help text for a known topic.
+ * @param name - Topic name to look up.
+ * @returns Help text or null if missing.
+ */
 export function getTopicHelp(name: string): string | null {
   const normalized = name.trim().toLowerCase();
   if (!normalized) {

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -23,6 +23,11 @@ const CONFIG_FORMATS: ConfigFormat[] = ["toml", "jsonc", "yaml", "yml"];
 const CONFIG_PRESETS: ConfigPreset[] = ["full", "minimal"];
 const CONFIG_SCOPES: ConfigScope[] = ["project", "user"];
 
+/**
+ * Execute the `wm init` command to generate configuration files.
+ * @param options - CLI options for format, preset, and scope.
+ * @returns Promise that resolves when initialization completes.
+ */
 export async function runInitCommand(
   options: InitCommandOptions = {}
 ): Promise<void> {

--- a/packages/cli/src/commands/lint.ts
+++ b/packages/cli/src/commands/lint.ts
@@ -393,6 +393,11 @@ function buildLintRules(): LintRule[] {
   ];
 }
 
+/**
+ * Parse CLI arguments for the lint command.
+ * @param argv - Raw CLI arguments.
+ * @returns Parsed lint command options.
+ */
 export function parseLintArgs(argv: string[]): LintCommandOptions {
   const json = argv.includes("--json");
   const filePaths = argv.filter((arg) => !arg.startsWith("-"));
@@ -402,6 +407,13 @@ export function parseLintArgs(argv: string[]): LintCommandOptions {
   return { filePaths, json };
 }
 
+/**
+ * Run lint rules against the provided file paths.
+ * @param filePaths - Paths or globs to scan.
+ * @param allowTypes - Allowed marker types from config.
+ * @param config - Resolved waymark configuration.
+ * @returns Lint report with collected issues.
+ */
 export async function lintFiles(
   filePaths: string[],
   allowTypes: string[],

--- a/packages/cli/src/commands/modify.ts
+++ b/packages/cli/src/commands/modify.ts
@@ -117,6 +117,14 @@ type InteractiveStep = {
   build: (state: InteractiveAnswers) => Record<string, unknown>;
 };
 
+/**
+ * Execute the `wm modify` command to update an existing waymark.
+ * @param context - CLI context with config and logging.
+ * @param targetArg - Target file/line input.
+ * @param options - Modify command options.
+ * @param io - IO adapters for prompts and stdin.
+ * @returns CLI result payload and exit code.
+ */
 export async function runModifyCommand(
   context: CommandContext,
   targetArg: string | undefined,
@@ -301,6 +309,11 @@ export type ApplyResult = {
   firstLine: string;
 };
 
+/**
+ * Apply requested modifications to a waymark record.
+ * @param args - Modification inputs and context.
+ * @returns Updated waymark fields and first line output.
+ */
 export function applyModifications(args: ApplyArgs): ApplyResult {
   const { record, config, baseContent, resolvedContent, options } = args;
 
@@ -350,6 +363,12 @@ function determineSignals(
   };
 }
 
+/**
+ * Preserve trailing ID tokens when content changes.
+ * @param original - Original content with potential ID.
+ * @param updated - Updated content without ID.
+ * @returns Updated content with ID preserved when present.
+ */
 export function preserveId(original: string, updated: string): string {
   const originalId = extractTrailingId(original);
   if (!originalId) {
@@ -829,6 +848,12 @@ function resolveMarkerChoices(
 
 const TRAILING_NEWLINE_REGEX = /\r?\n$/;
 
+/**
+ * Resolve content input from flags or stdin.
+ * @param options - Modify command options.
+ * @param stdin - Readable stream for stdin input.
+ * @returns Resolved content string, or undefined if not provided.
+ */
 export async function resolveContentInput(
   options: ModifyOptions,
   stdin: NodeJS.ReadableStream

--- a/packages/cli/src/commands/register.ts
+++ b/packages/cli/src/commands/register.ts
@@ -67,6 +67,11 @@ type CommandHandlers = {
   writeStdout: (message: string) => void;
 };
 
+/**
+ * Register CLI commands and handlers on the commander program.
+ * @param program - Commander program instance.
+ * @param handlers - Handler callbacks for each command.
+ */
 export function registerCommands(
   program: Command,
   handlers: CommandHandlers

--- a/packages/cli/src/commands/remove.ts
+++ b/packages/cli/src/commands/remove.ts
@@ -110,6 +110,11 @@ function createInitialState(): RemoveParseState {
   };
 }
 
+/**
+ * Build remove specs and options from parsed remove command input.
+ * @param input - Parsed targets and flags.
+ * @returns Parsed remove args.
+ */
 export function buildRemoveArgs(input: RemoveCommandInput): ParsedRemoveArgs {
   const state = createInitialState();
   const { targets, options } = input;
@@ -252,6 +257,13 @@ function buildCriteriaSpec(state: RemoveParseState): RemovalSpec | undefined {
   };
 }
 
+/**
+ * Execute the `wm remove` command with parsed inputs.
+ * @param parsed - Parsed removal args.
+ * @param context - CLI context with config and filesystem helpers.
+ * @param execution - Optional execution overrides (write, etc.).
+ * @returns Removal results, summary, output, and exit code.
+ */
 export async function runRemoveCommand(
   parsed: ParsedRemoveArgs,
   context: CommandContext,

--- a/packages/cli/src/commands/scan.ts
+++ b/packages/cli/src/commands/scan.ts
@@ -107,6 +107,13 @@ function scanCodetags(source: string, filePath: string): WaymarkRecord[] {
   return records;
 }
 
+/**
+ * Scan file paths for waymark records.
+ * @param filePaths - Paths or globs to scan.
+ * @param config - Resolved waymark configuration.
+ * @param options - Runtime scan options (cache, metrics, codetags).
+ * @returns Parsed waymark records.
+ */
 export async function scanRecords(
   filePaths: string[],
   config: WaymarkConfig,
@@ -188,6 +195,11 @@ function createCache(options: ScanRuntimeOptions): WaymarkCache | undefined {
   return new WaymarkCache();
 }
 
+/**
+ * Parse CLI arguments for the scan command.
+ * @param argv - Raw CLI arguments.
+ * @returns Parsed scan arguments.
+ */
 export function parseScanArgs(argv: string[]): ParsedScanArgs {
   if (argv.length === 0) {
     throw new Error("scan requires a file path");

--- a/packages/cli/src/commands/scan.ts
+++ b/packages/cli/src/commands/scan.ts
@@ -111,7 +111,7 @@ function scanCodetags(source: string, filePath: string): WaymarkRecord[] {
  * Scan file paths for waymark records.
  * @param filePaths - Paths or globs to scan.
  * @param config - Resolved waymark configuration.
- * @param options - Runtime scan options (cache, metrics, codetags).
+ * @param options - Runtime scan options (cache, cachePath, metrics).
  * @returns Parsed waymark records.
  */
 export async function scanRecords(

--- a/packages/cli/src/commands/skill.ts
+++ b/packages/cli/src/commands/skill.ts
@@ -36,6 +36,12 @@ function formatJsonOutput(payload: unknown): string {
   return JSON.stringify(payload, null, 2);
 }
 
+/**
+ * Execute the `wm skill` command (core skill content or JSON).
+ * @param options - Output formatting options.
+ * @param overrides - Overrides for skill directory resolution.
+ * @returns Output payload and exit code.
+ */
 export async function runSkillCommand(
   options: SkillCommandOptions = {},
   overrides: SkillCommandOverrides = {}
@@ -111,6 +117,13 @@ function resolveSkillSection(
   return null;
 }
 
+/**
+ * Execute the `wm skill show` command for a specific section.
+ * @param section - Section name to display.
+ * @param options - Output formatting options.
+ * @param overrides - Overrides for skill directory resolution.
+ * @returns Output payload and exit code.
+ */
 export async function runSkillShowCommand(
   section: string,
   options: SkillCommandOptions = {},
@@ -144,6 +157,11 @@ export async function runSkillShowCommand(
   };
 }
 
+/**
+ * Execute the `wm skill list` command to enumerate sections.
+ * @param overrides - Overrides for skill directory resolution.
+ * @returns Output payload and exit code.
+ */
 export async function runSkillListCommand(
   overrides: SkillCommandOverrides = {}
 ): Promise<SkillCommandResult> {
@@ -187,6 +205,11 @@ export async function runSkillListCommand(
   };
 }
 
+/**
+ * Execute the `wm skill path` command to print the skills directory.
+ * @param overrides - Overrides for skill directory resolution.
+ * @returns Output payload and exit code.
+ */
 export function runSkillPathCommand(
   overrides: SkillCommandOverrides = {}
 ): SkillCommandResult {

--- a/packages/cli/src/commands/tui.ts
+++ b/packages/cli/src/commands/tui.ts
@@ -1,5 +1,9 @@
 // tldr ::: placeholder tui command handler
 
+/**
+ * Print the placeholder TUI message.
+ * @returns Exit code for the CLI.
+ */
 export function displayTuiMessage(): number {
   process.stdout.write(
     "TUI mode is not yet implemented. Track progress in PLAN.md Phase 3.\n"

--- a/packages/cli/src/commands/unified/filters.ts
+++ b/packages/cli/src/commands/unified/filters.ts
@@ -6,6 +6,9 @@ import type { UnifiedCommandOptions } from "./types";
 
 /**
  * Apply filters to scanned records based on unified command options.
+ * @param records - Records to filter.
+ * @param options - Filter options from unified command.
+ * @returns Filtered records.
  */
 export function applyFilters(
   records: WaymarkRecord[],

--- a/packages/cli/src/commands/unified/flag-handlers.ts
+++ b/packages/cli/src/commands/unified/flag-handlers.ts
@@ -35,7 +35,11 @@ export type ParseState = {
 };
 
 /**
- * Handle context display flags
+ * Handle context display flags.
+ * @param token - Current CLI token.
+ * @param iterator - Iterator for remaining args.
+ * @param state - Parse state to update.
+ * @returns Whether the token was handled.
  */
 export function handleContextFlags(
   token: string,
@@ -58,7 +62,11 @@ export function handleContextFlags(
 }
 
 /**
- * Handle grouping and sorting flags
+ * Handle grouping and sorting flags.
+ * @param token - Current CLI token.
+ * @param iterator - Iterator for remaining args.
+ * @param state - Parse state to update.
+ * @returns Whether the token was handled.
  */
 export function handleGroupSortFlags(
   token: string,
@@ -100,7 +108,11 @@ export function handleGroupSortFlags(
 }
 
 /**
- * Handle pagination flags
+ * Handle pagination flags.
+ * @param token - Current CLI token.
+ * @param iterator - Iterator for remaining args.
+ * @param state - Parse state to update.
+ * @returns Whether the token was handled.
  */
 export function handlePaginationFlags(
   token: string,
@@ -138,7 +150,10 @@ function handleFormattingFlags(token: string, state: ParseState): boolean {
 }
 
 /**
- * Handle mode and display flags
+ * Handle mode and display flags.
+ * @param token - Current CLI token.
+ * @param state - Parse state to update.
+ * @returns Whether the token was handled.
  */
 export function handleModeDisplayFlags(
   token: string,

--- a/packages/cli/src/commands/unified/index.ts
+++ b/packages/cli/src/commands/unified/index.ts
@@ -18,8 +18,10 @@ export type UnifiedCommandResult = {
 const DEFAULT_CHALK_LEVEL = chalk.level;
 
 /**
- * Unified command handler that intelligently routes to scan/find/map/graph behavior
- * based on flags and arguments provided.
+ * Unified command handler that routes to scan/find/graph behavior.
+ * @param options - Unified command options.
+ * @param context - CLI context with config and globals.
+ * @returns Output payload and optional records.
  */
 export async function runUnifiedCommand(
   options: UnifiedCommandOptions,

--- a/packages/cli/src/commands/unified/parser.ts
+++ b/packages/cli/src/commands/unified/parser.ts
@@ -18,7 +18,8 @@ import { parseQuery } from "./query-parser";
 import type { UnifiedCommandOptions } from "./types";
 
 /**
- * Create initial parse state
+ * Create initial parse state.
+ * @returns Initialized parse state object.
  */
 export function createParseState(): ParseState {
   return {
@@ -80,7 +81,10 @@ function looksLikeFilePath(token: string): boolean {
 }
 
 /**
- * Process a single token during argument parsing
+ * Process a single token during argument parsing.
+ * @param token - Current CLI token to process.
+ * @param iterator - Iterator for remaining arguments.
+ * @param state - Parse state to mutate.
  */
 export function processToken(
   token: string,
@@ -140,7 +144,9 @@ export function processToken(
 }
 
 /**
- * Build final options from parse state
+ * Build final options from parse state.
+ * @param state - Collected parse state.
+ * @returns Unified command options.
  */
 export function buildOptions(state: ParseState): UnifiedCommandOptions {
   const options: UnifiedCommandOptions = {
@@ -256,6 +262,8 @@ function applyPaginationOptions(
 
 /**
  * Parse CLI arguments for the unified command.
+ * @param argv - Raw CLI arguments.
+ * @returns Parsed unified command options.
  */
 export function parseUnifiedArgs(argv: string[]): UnifiedCommandOptions {
   const state = createParseState();

--- a/packages/cli/src/commands/unified/parsers.ts
+++ b/packages/cli/src/commands/unified/parsers.ts
@@ -3,7 +3,10 @@
 import type { createArgIterator } from "../../utils/flags/iterator";
 
 /**
- * Parse a non-negative integer argument
+ * Parse a non-negative integer argument.
+ * @param token - Flag token being parsed.
+ * @param iterator - Iterator for remaining args.
+ * @returns Parsed non-negative integer.
  */
 export function parseNonNegativeInt(
   token: string,
@@ -21,7 +24,10 @@ export function parseNonNegativeInt(
 }
 
 /**
- * Parse a positive integer argument
+ * Parse a positive integer argument.
+ * @param token - Flag token being parsed.
+ * @param iterator - Iterator for remaining args.
+ * @returns Parsed positive integer.
  */
 export function parsePositiveInt(
   token: string,
@@ -39,7 +45,11 @@ export function parsePositiveInt(
 }
 
 /**
- * Parse an enum value argument
+ * Parse an enum value argument.
+ * @param token - Flag token being parsed.
+ * @param iterator - Iterator for remaining args.
+ * @param validValues - Allowed enum values.
+ * @returns Parsed enum value.
  */
 export function parseEnumValue<T extends string>(
   token: string,

--- a/packages/cli/src/commands/unified/query-parser.ts
+++ b/packages/cli/src/commands/unified/query-parser.ts
@@ -28,12 +28,14 @@ export type ParsedQuery = {
 };
 
 /**
- * Parse a query string into structured filters
+ * Parse a query string into structured filters.
  *
  * Examples:
  *   "todo @agent #perf" → types: [todo], mentions: [@agent], tags: [#perf]
  *   "fix !@alice" → types: [fix], exclusions.mentions: [@alice]
  *   "owner:@alice" → properties: { owner: "@alice" }
+ * @param query - Raw query string.
+ * @returns Parsed query tokens and filters.
  */
 export function parseQuery(query: string): ParsedQuery {
   const tokens = tokenize(query);

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -37,6 +37,10 @@ let customRunner: ChildRunner | undefined;
 const NPM_UPDATE_ARGS = ["install", "-g", "@waymarks/cli"];
 const UPDATE_COMMAND_ALLOWLIST = new Set(["npm", "pnpm", "bun", "yarn"]);
 
+/**
+ * Inject a custom child-process runner for tests.
+ * @param fn - Optional runner override.
+ */
 export function __setChildRunner(fn?: ChildRunner): void {
   customRunner = fn;
 }
@@ -61,6 +65,11 @@ function runChild(command: string, args: string[]): Promise<number> {
   });
 }
 
+/**
+ * Detect how the CLI was installed based on the executable path.
+ * @param executablePath - Optional path override for detection.
+ * @returns Detected install method metadata.
+ */
 export function detectInstallMethod(executablePath?: string): InstallDetection {
   let resolvedPath = "";
   try {
@@ -193,6 +202,11 @@ async function confirmUpdateCommand(
   );
 }
 
+/**
+ * Execute the `wm update` command with the provided options.
+ * @param options - Update command options.
+ * @returns Result metadata including exit code.
+ */
 export async function runUpdateCommand(
   options: UpdateCommandOptions = {}
 ): Promise<UpdateCommandResult> {

--- a/packages/cli/src/errors.ts
+++ b/packages/cli/src/errors.ts
@@ -12,10 +12,20 @@ export class CliError extends Error {
   }
 }
 
+/**
+ * Create a CLI error with a usage exit code.
+ * @param message - Error message to display.
+ * @returns CLI error instance.
+ */
 export function createUsageError(message: string): CliError {
   return new CliError(message, ExitCode.usageError);
 }
 
+/**
+ * Create a CLI error with a config exit code.
+ * @param message - Error message to display.
+ * @returns CLI error instance.
+ */
 export function createConfigError(message: string): CliError {
   return new CliError(message, ExitCode.configError);
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -11,9 +11,9 @@ import {
 
 /** @internal */
 export const __test = programTest;
-/** Build the CLI program with all commands registered. */
+/** Build a Commander program with all CLI commands registered. */
 export const createProgram = programCreateProgram;
-/** Run the CLI with the provided argv array. */
+/** Run the CLI with a custom argv array, capturing stdout/stderr. Returns exit code and captured output. */
 export const runCli = programRunCli;
 
 if (import.meta.main) {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -9,8 +9,11 @@ import {
   runMain,
 } from "./program.ts";
 
+/** @internal */
 export const __test = programTest;
+/** Build the CLI program with all commands registered. */
 export const createProgram = programCreateProgram;
+/** Run the CLI with the provided argv array. */
 export const runCli = programRunCli;
 
 if (import.meta.main) {

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -1080,6 +1080,7 @@ function buildCustomHelpFormatter() {
   };
 }
 
+/** Build a Commander program with all CLI commands registered. */
 export async function createProgram(): Promise<Command> {
   // Read version from package.json
   const packageJsonPath = new URL("../package.json", import.meta.url);
@@ -1208,6 +1209,7 @@ Note: For agent-facing documentation, use "wm skill".
   return program;
 }
 
+/** Run the CLI using process argv when invoked as a script. */
 export function runMain(): void {
   registerSignalHandlers();
   createProgram()
@@ -1220,7 +1222,7 @@ export function runMain(): void {
     });
 }
 
-// For testing
+/** Run the CLI with a custom argv array, capturing stdout/stderr. */
 export async function runCli(argv: string[]): Promise<{
   exitCode: number;
   stdout: string;
@@ -1277,6 +1279,7 @@ export async function runCli(argv: string[]): Promise<{
   };
 }
 
+/** @internal */
 export const __test = {
   createProgram,
 };

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -1209,7 +1209,7 @@ Note: For agent-facing documentation, use "wm skill".
   return program;
 }
 
-/** Run the CLI using process argv when invoked as a script. */
+/** Run the CLI using process.argv when invoked as a script. Exits the process with appropriate exit code. */
 export function runMain(): void {
   registerSignalHandlers();
   createProgram()

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -1080,7 +1080,10 @@ function buildCustomHelpFormatter() {
   };
 }
 
-/** Build a Commander program with all CLI commands registered. */
+/**
+ * Build a Commander program with all CLI commands registered.
+ * @returns Configured Commander program instance.
+ */
 export async function createProgram(): Promise<Command> {
   // Read version from package.json
   const packageJsonPath = new URL("../package.json", import.meta.url);
@@ -1209,7 +1212,10 @@ Note: For agent-facing documentation, use "wm skill".
   return program;
 }
 
-/** Run the CLI using process.argv when invoked as a script. Exits the process with appropriate exit code. */
+/**
+ * Run the CLI using process.argv when invoked as a script. Exits the process with appropriate exit code.
+ * @returns No return value; process exits after execution.
+ */
 export function runMain(): void {
   registerSignalHandlers();
   createProgram()
@@ -1222,7 +1228,11 @@ export function runMain(): void {
     });
 }
 
-/** Run the CLI with a custom argv array, capturing stdout/stderr. */
+/**
+ * Run the CLI with a custom argv array, capturing stdout/stderr.
+ * @param argv - Command-line arguments (excluding node and binary).
+ * @returns Exit code and captured stdout/stderr.
+ */
 export async function runCli(argv: string[]): Promise<{
   exitCode: number;
   stdout: string;

--- a/packages/cli/src/skills/parser.ts
+++ b/packages/cli/src/skills/parser.ts
@@ -139,6 +139,10 @@ function extractFrontmatter(raw: string): {
   };
 }
 
+/**
+ * Resolve the skills directory by scanning expected locations or env override.
+ * @returns Absolute path to the skills directory.
+ */
 export function resolveSkillDir(): string {
   if (SKILL_DIR_CACHE.value) {
     return SKILL_DIR_CACHE.value;
@@ -174,6 +178,11 @@ export function resolveSkillDir(): string {
   );
 }
 
+/**
+ * Load and parse the skill manifest from a skills directory.
+ * @param skillDir - Absolute path to the skills directory.
+ * @returns Parsed skill manifest data.
+ */
 export async function loadSkillManifest(
   skillDir: string
 ): Promise<SkillManifest> {
@@ -182,6 +191,14 @@ export async function loadSkillManifest(
   return JSON.parse(raw) as SkillManifest;
 }
 
+/**
+ * Load and parse a single skill section file.
+ * @param skillDir - Absolute path to the skills directory.
+ * @param sectionName - Name of the section in the manifest.
+ * @param kind - Section category to assign.
+ * @param relativePath - Relative path to the section content.
+ * @returns Parsed section metadata and content.
+ */
 export async function loadSkillSection(
   skillDir: string,
   sectionName: string,
@@ -200,6 +217,11 @@ export async function loadSkillSection(
   };
 }
 
+/**
+ * Load the full skill manifest and referenced sections.
+ * @param skillDir - Absolute path to the skills directory.
+ * @returns Aggregated skill data with sections attached.
+ */
 export async function loadSkillData(skillDir: string): Promise<SkillData> {
   const manifest = await loadSkillManifest(skillDir);
   const entryPath = manifest.entry || "SKILL.md";
@@ -237,6 +259,11 @@ export async function loadSkillData(skillDir: string): Promise<SkillData> {
   };
 }
 
+/**
+ * List the named sections grouped by type.
+ * @param manifest - Skill manifest to inspect.
+ * @returns Grouped section names for commands, references, and examples.
+ */
 export function listSkillSections(manifest: SkillManifest): {
   commands: string[];
   references: string[];

--- a/packages/cli/src/utils/context.ts
+++ b/packages/cli/src/utils/context.ts
@@ -5,6 +5,11 @@ import { createConfigError } from "../errors.ts";
 import type { CommandContext, GlobalOptions } from "../types.ts";
 import { resolveWorkspaceRoot } from "./workspace.ts";
 
+/**
+ * Create a command context by loading config and workspace info.
+ * @param globalOptions - Parsed global CLI options.
+ * @returns Command context with config and workspace root.
+ */
 export async function createContext(
   globalOptions: GlobalOptions
 ): Promise<CommandContext> {

--- a/packages/cli/src/utils/display/formatters/enhanced.ts
+++ b/packages/cli/src/utils/display/formatters/enhanced.ts
@@ -386,7 +386,10 @@ function formatCompactRecord(
 }
 
 /**
- * Format records in enhanced ripgrep-style output
+ * Format records in enhanced ripgrep-style output.
+ * @param records - Records to format.
+ * @param options - Display options affecting output.
+ * @returns Formatted output string.
  */
 export function formatEnhanced(
   records: WaymarkRecord[],

--- a/packages/cli/src/utils/display/formatters/long.ts
+++ b/packages/cli/src/utils/display/formatters/long.ts
@@ -4,7 +4,9 @@ import type { WaymarkRecord } from "@waymarks/core";
 import { sanitizeInlineText } from "../sanitize";
 
 /**
- * Format records with long display (all properties shown)
+ * Format records with long display (all properties shown).
+ * @param records - Records to format.
+ * @returns Long formatted output string.
  */
 export function formatLong(records: WaymarkRecord[]): string {
   const lines: string[] = [];

--- a/packages/cli/src/utils/display/formatters/strip-markers.ts
+++ b/packages/cli/src/utils/display/formatters/strip-markers.ts
@@ -10,8 +10,11 @@ const BLOCK_COMMENT_END_PATTERN = /\s*\*\/.*$/;
 const SQL_COMMENT_PATTERN = /^.*?--\s*/;
 
 /**
- * Strip comment markers from a waymark's raw text
- * Extracts just the waymark content without the comment syntax
+ * Strip comment markers from a waymark's raw text.
+ * Extracts just the waymark content without the comment syntax.
+ * @param raw - Raw comment text.
+ * @param commentLeader - Comment leader token (e.g. //, <!--).
+ * @returns Stripped content string.
  */
 export function stripCommentMarkers(
   raw: string,
@@ -59,7 +62,10 @@ export function stripCommentMarkers(
 }
 
 /**
- * Strip comment markers from multi-line waymark content
+ * Strip comment markers from multi-line waymark content.
+ * @param lines - Raw comment lines.
+ * @param commentLeader - Comment leader token.
+ * @returns Stripped content lines.
  */
 export function stripCommentMarkersMultiLine(
   lines: string[],

--- a/packages/cli/src/utils/display/formatters/styles.ts
+++ b/packages/cli/src/utils/display/formatters/styles.ts
@@ -105,7 +105,9 @@ function unmaskCodeBlocks(text: string, blocks: string[]): string {
 }
 
 /**
- * Get color for a waymark type based on its category
+ * Get color for a waymark type based on its category.
+ * @param type - Waymark type string.
+ * @returns Chalk color function.
  */
 export function getTypeColor(type: string): typeof chalk {
   const category = getTypeCategory(type);
@@ -142,7 +144,10 @@ export function getTypeColor(type: string): typeof chalk {
 }
 
 /**
- * Style a waymark type with appropriate color and signals
+ * Style a waymark type with appropriate color and signals.
+ * @param type - Waymark type string.
+ * @param signals - Signal flags to include.
+ * @returns Styled type string.
  */
 export function styleType(
   type: string,
@@ -161,15 +166,19 @@ export function styleType(
 }
 
 /**
- * Style the ::: sigil (always dim)
+ * Style the ::: sigil (always dim).
+ * @param text - Sigil text to style.
+ * @returns Styled sigil string.
  */
 export function styleSigil(text: string): string {
   return chalk.dim(text);
 }
 
 /**
- * Style a mention (@user, not @scope/package)
- * Mentions never have / or : in them
+ * Style a mention (@user, not @scope/package).
+ * Mentions never have / or : in them.
+ * @param text - Mention text.
+ * @returns Styled mention string.
  */
 export function styleMention(text: string): string {
   if (text.includes("/") || text.includes(":")) {
@@ -179,14 +188,18 @@ export function styleMention(text: string): string {
 }
 
 /**
- * Style a tag (#tag or #tag:subtag)
+ * Style a tag (#tag or #tag:subtag).
+ * @param text - Tag text.
+ * @returns Styled tag string.
  */
 export function styleTag(text: string): string {
   return chalk.bold.cyan(text);
 }
 
 /**
- * Style a scoped package reference (@scope/package or @scope/package^v1.0.0)
+ * Style a scoped package reference (@scope/package or @scope/package^v1.0.0).
+ * @param text - Scope text.
+ * @returns Styled scope string.
  */
 export function styleScope(text: string): string {
   if (text.includes("/")) {
@@ -196,31 +209,39 @@ export function styleScope(text: string): string {
 }
 
 /**
- * Style a property key (dim)
+ * Style a property key (dim).
+ * @param text - Property key text.
+ * @returns Styled property string.
  */
 export function styleProperty(text: string): string {
   return chalk.dim(text);
 }
 
 /**
- * Style a line number (dim)
- * Accepts either a number or a padded string to preserve alignment
+ * Style a line number (dim).
+ * Accepts either a number or a padded string to preserve alignment.
+ * @param num - Line number or padded string.
+ * @returns Styled line number string.
  */
 export function styleLineNumber(num: number | string): string {
   return chalk.dim(`${num}`);
 }
 
 /**
- * Style a file path (bold, no underline)
+ * Style a file path (bold, no underline).
+ * @param path - File path to style.
+ * @returns Styled file path.
  */
 export function styleFilePath(path: string): string {
   return chalk.bold(path);
 }
 
 /**
- * Apply inline styling to waymark content text
- * Styles tags, properties, mentions, and scopes within the content
- * Order matters: tags first (to avoid conflict with properties containing colons)
+ * Apply inline styling to waymark content text.
+ * Styles tags, properties, mentions, and scopes within the content.
+ * Order matters: tags first (to avoid conflict with properties containing colons).
+ * @param content - Raw content text to style.
+ * @returns Styled content string.
  */
 export function styleContent(content: string): string {
   const sanitized = sanitizeInlineText(content);

--- a/packages/cli/src/utils/display/formatters/text.ts
+++ b/packages/cli/src/utils/display/formatters/text.ts
@@ -9,7 +9,9 @@ import type { DisplayOptions } from "../types";
 const LINE_NUMBER_WIDTH = 3;
 
 /**
- * Format a single record in simple format
+ * Format a single record in simple format.
+ * @param record - Record to format.
+ * @returns Formatted record string.
  */
 export function formatRecordSimple(record: WaymarkRecord): string {
   const signals =
@@ -21,7 +23,10 @@ export function formatRecordSimple(record: WaymarkRecord): string {
 }
 
 /**
- * Format a single record with context lines
+ * Format a single record with context lines.
+ * @param record - Record to format.
+ * @param options - Display options including context settings.
+ * @returns Formatted record string with context.
  */
 export function formatRecordWithContext(
   record: WaymarkRecord,
@@ -61,7 +66,10 @@ export function formatRecordWithContext(
 }
 
 /**
- * Format records with text display (default, with optional context)
+ * Format records with text display (default, with optional context).
+ * @param records - Records to format.
+ * @param options - Display options including context settings.
+ * @returns Formatted output string.
  */
 export function formatText(
   records: WaymarkRecord[],
@@ -89,7 +97,9 @@ export function formatText(
 }
 
 /**
- * Format records with flat display (one per line)
+ * Format records with flat display (one per line).
+ * @param records - Records to format.
+ * @returns Flat formatted output string.
  */
 export function formatFlat(records: WaymarkRecord[]): string {
   return records.map((r) => formatRecordSimple(r)).join("\n");

--- a/packages/cli/src/utils/display/formatters/tree.ts
+++ b/packages/cli/src/utils/display/formatters/tree.ts
@@ -34,7 +34,9 @@ function formatTreeDirectory(
 }
 
 /**
- * Format records with tree display (grouped by directory structure)
+ * Format records with tree display (grouped by directory structure).
+ * @param records - Records to format.
+ * @returns Tree-formatted output string.
  */
 export function formatTree(records: WaymarkRecord[]): string {
   // Group by directory

--- a/packages/cli/src/utils/display/grouping.ts
+++ b/packages/cli/src/utils/display/grouping.ts
@@ -8,7 +8,10 @@ import { sanitizeInlineText } from "./sanitize";
 import type { DisplayOptions } from "./types";
 
 /**
- * Compute grouping key for a single record
+ * Compute grouping key for a single record.
+ * @param record - Record to group.
+ * @param groupBy - Grouping key.
+ * @returns Group key string.
  */
 export function getGroupKey(record: WaymarkRecord, groupBy: GroupBy): string {
   switch (groupBy) {
@@ -48,7 +51,10 @@ export function getGroupKey(record: WaymarkRecord, groupBy: GroupBy): string {
 }
 
 /**
- * Group records by specified field
+ * Group records by specified field.
+ * @param records - Records to group.
+ * @param groupBy - Grouping key.
+ * @returns Map of group keys to records.
  */
 export function groupRecords(
   records: WaymarkRecord[],
@@ -67,7 +73,10 @@ export function groupRecords(
 }
 
 /**
- * Format records with grouping
+ * Format records with grouping.
+ * @param records - Records to format.
+ * @param options - Display options including groupBy.
+ * @returns Formatted grouped output.
  */
 export function formatGrouped(
   records: WaymarkRecord[],

--- a/packages/cli/src/utils/display/index.ts
+++ b/packages/cli/src/utils/display/index.ts
@@ -14,7 +14,10 @@ import type { DisplayOptions } from "./types";
 export type { DisplayOptions } from "./types";
 
 /**
- * Format waymark records according to display options
+ * Format waymark records according to display options.
+ * @param records - Records to format.
+ * @param options - Display options and formatting preferences.
+ * @returns Formatted output string.
  */
 export function formatRecords(
   records: WaymarkRecord[],

--- a/packages/cli/src/utils/display/pagination.ts
+++ b/packages/cli/src/utils/display/pagination.ts
@@ -4,7 +4,11 @@ import type { WaymarkRecord } from "@waymarks/core";
 import { DEFAULT_PAGE_SIZE } from "./types";
 
 /**
- * Apply pagination to records
+ * Apply pagination to records.
+ * @param records - Records to paginate.
+ * @param limit - Page size limit.
+ * @param page - Page number (1-based).
+ * @returns Paginated records.
  */
 export function paginateRecords(
   records: WaymarkRecord[],

--- a/packages/cli/src/utils/display/sanitize.ts
+++ b/packages/cli/src/utils/display/sanitize.ts
@@ -3,6 +3,11 @@
 const CONTROL_CHAR_PATTERN = "[\\u0000-\\u001F\\u007F]";
 const CONTROL_CHAR_REGEX = new RegExp(CONTROL_CHAR_PATTERN, "g");
 
+/**
+ * Strip control characters from a string for CLI output.
+ * @param value - Input string to sanitize.
+ * @returns Sanitized string.
+ */
 export function sanitizeInlineText(value: string): string {
   return value.replace(CONTROL_CHAR_REGEX, "");
 }

--- a/packages/cli/src/utils/display/sorting.ts
+++ b/packages/cli/src/utils/display/sorting.ts
@@ -5,7 +5,11 @@ import type { WaymarkRecord } from "@waymarks/core";
 import type { SortBy } from "../../commands/unified/types";
 
 /**
- * Sort records by specified field
+ * Sort records by specified field.
+ * @param records - Records to sort.
+ * @param sortBy - Sort key.
+ * @param reverse - Whether to reverse the result.
+ * @returns Sorted records.
  */
 export function sortRecords(
   records: WaymarkRecord[],

--- a/packages/cli/src/utils/file-line.ts
+++ b/packages/cli/src/utils/file-line.ts
@@ -10,6 +10,12 @@ type FileLineParseMessages = {
   invalidLine: string;
 };
 
+/**
+ * Parse a FILE:LINE token into structured data.
+ * @param value - Input string containing file and line.
+ * @param messages - Error messages for invalid input.
+ * @returns Parsed file and line target.
+ */
 export function parseFileLineTarget(
   value: string,
   messages: FileLineParseMessages

--- a/packages/cli/src/utils/flags/iterator.ts
+++ b/packages/cli/src/utils/flags/iterator.ts
@@ -42,6 +42,8 @@ export class ArgIterator {
 
 /**
  * Create an iterator configured for the provided argv slice.
+ * @param argv - Argument list to iterate over.
+ * @returns Argument iterator.
  */
 export function createArgIterator(argv: readonly string[]): ArgIterator {
   return new ArgIterator(argv);
@@ -49,6 +51,8 @@ export function createArgIterator(argv: readonly string[]): ArgIterator {
 
 /**
  * Determine whether the token represents a flag (prefixed with a dash).
+ * @param token - Token to inspect.
+ * @returns True if the token is a flag.
  */
 export function isFlag(token: string | undefined): boolean {
   return typeof token === "string" && token.startsWith("-");
@@ -56,6 +60,9 @@ export function isFlag(token: string | undefined): boolean {
 
 /**
  * Check whether a token matches any of the provided flag names.
+ * @param token - Token to inspect.
+ * @param names - List of flag names to match.
+ * @returns True if the token matches one of the names.
  */
 export function matchesFlag(
   token: string | undefined,

--- a/packages/cli/src/utils/flags/json.ts
+++ b/packages/cli/src/utils/flags/json.ts
@@ -10,6 +10,9 @@ export type JsonFlagState = {
 
 /**
  * Toggle JSON output mode when the `--json` or `--jsonl` flag is encountered.
+ * @param token - Current CLI token.
+ * @param state - JSON flag parsing state to mutate.
+ * @returns Whether the token was handled.
  */
 export function handleJsonFlag(
   token: string | undefined,

--- a/packages/cli/src/utils/flags/mention.ts
+++ b/packages/cli/src/utils/flags/mention.ts
@@ -5,6 +5,10 @@ import { handleStringListFlag } from "./string-list";
 
 /**
  * Capture mention flag values into the provided accumulator.
+ * @param token - Current CLI token.
+ * @param iterator - Iterator for remaining args.
+ * @param mentions - Accumulator for mention values.
+ * @returns Whether the token was handled.
  */
 export function handleMentionFlag(
   token: string | undefined,

--- a/packages/cli/src/utils/flags/string-list.ts
+++ b/packages/cli/src/utils/flags/string-list.ts
@@ -5,6 +5,10 @@ import { matchesFlag } from "./iterator";
 
 /**
  * Generic helper for flags that accept a single string value and can repeat.
+ * @param token - Current CLI token.
+ * @param iterator - Iterator for remaining args.
+ * @param options - Flag names, target list, and normalization settings.
+ * @returns Whether the token was handled.
  */
 export function handleStringListFlag(
   token: string | undefined,

--- a/packages/cli/src/utils/flags/summary.ts
+++ b/packages/cli/src/utils/flags/summary.ts
@@ -8,6 +8,9 @@ export type SummaryFlagState = {
 
 /**
  * Enable summary output when the `--summary` flag is encountered.
+ * @param token - Current CLI token.
+ * @param state - Summary flag state to mutate.
+ * @returns Whether the token was handled.
  */
 export function handleSummaryFlag(
   token: string | undefined,

--- a/packages/cli/src/utils/flags/tag.ts
+++ b/packages/cli/src/utils/flags/tag.ts
@@ -5,6 +5,10 @@ import { handleStringListFlag } from "./string-list";
 
 /**
  * Collect tag flag values into the provided accumulator.
+ * @param token - Current CLI token.
+ * @param iterator - Iterator for remaining args.
+ * @param tags - Accumulator for tag values.
+ * @returns Whether the token was handled.
  */
 export function handleTagFlag(
   token: string | undefined,

--- a/packages/cli/src/utils/flags/tldr.ts
+++ b/packages/cli/src/utils/flags/tldr.ts
@@ -5,6 +5,9 @@ import { matchesFlag } from "./iterator";
 /**
  * Add "tldr" to the types array when the `--tldr` flag is encountered.
  * This is a convenience shorthand for `--type tldr`.
+ * @param token - Current CLI token.
+ * @param types - Array to push the tldr marker into.
+ * @returns Whether the token was handled.
  */
 export function handleTldrFlag(
   token: string | undefined,

--- a/packages/cli/src/utils/flags/type.ts
+++ b/packages/cli/src/utils/flags/type.ts
@@ -5,6 +5,10 @@ import { handleStringListFlag } from "./string-list";
 
 /**
  * Collect waymark type flag values (case-normalized) into the provided accumulator.
+ * @param token - Current CLI token.
+ * @param iterator - Iterator for remaining args.
+ * @param types - Accumulator for type values.
+ * @returns Whether the token was handled.
  */
 export function handleTypeFlag(
   token: string | undefined,

--- a/packages/cli/src/utils/fs.ts
+++ b/packages/cli/src/utils/fs.ts
@@ -295,6 +295,7 @@ function normalizePathForOutput(path: string): string {
  * working directory, throwing a descriptive error when it cannot be found.
  *
  * @param path - The file path to verify
+ * @returns Nothing. Throws when the path cannot be resolved.
  * @throws Error if the path does not resolve to an existing file
  */
 export function ensureFileExists(path: string): void {

--- a/packages/cli/src/utils/id-manager.ts
+++ b/packages/cli/src/utils/id-manager.ts
@@ -10,6 +10,12 @@ export type CreateIdManagerOptions = {
   interactive?: boolean;
 };
 
+/**
+ * Create a WaymarkIdManager configured for the current CLI context.
+ * @param context - CLI context with config and workspace root.
+ * @param options - Options controlling interactive behavior.
+ * @returns ID manager instance or undefined when disabled.
+ */
 export async function createIdManager(
   context: CommandContext,
   options: CreateIdManagerOptions = {}

--- a/packages/cli/src/utils/ignore.ts
+++ b/packages/cli/src/utils/ignore.ts
@@ -95,6 +95,11 @@ export class IgnoreFilter {
 // Cache filters by root directory for performance
 const filterCache = new Map<string, IgnoreFilter>();
 
+/**
+ * Get a cached ignore filter for the provided options.
+ * @param options - Root directory and ignore configuration.
+ * @returns Ignore filter instance.
+ */
 export function getIgnoreFilter(options: IgnoreOptions): IgnoreFilter {
   const cacheKey = `${options.rootDir}:${options.config.respectGitignore}:${options.config.skipPaths.join(",")}:${options.config.includePaths.join(",")}`;
 
@@ -108,7 +113,9 @@ export function getIgnoreFilter(options: IgnoreOptions): IgnoreFilter {
   return filter;
 }
 
-// Clear cache (useful for testing)
+/**
+ * Clear the ignore filter cache (useful for tests).
+ */
 export function clearIgnoreCache(): void {
   filterCache.clear();
 }

--- a/packages/cli/src/utils/logger.ts
+++ b/packages/cli/src/utils/logger.ts
@@ -31,10 +31,12 @@ export type LoggerOptions = {
 };
 
 /**
- * Create a configured pino logger instance
+ * Create a configured pino logger instance.
  *
  * For CLI tools, we default to 'warn' level to keep output clean.
  * Use --verbose flag to set level to 'info' or --debug for 'debug'.
+ * @param options - Logger configuration options.
+ * @returns Configured pino logger instance.
  */
 export function createLogger(options: LoggerOptions = {}): pino.Logger {
   const {

--- a/packages/cli/src/utils/options.ts
+++ b/packages/cli/src/utils/options.ts
@@ -2,6 +2,11 @@
 
 import type { CliScopeOption, GlobalOptions } from "../types.ts";
 
+/**
+ * Parse global CLI options and return remaining args.
+ * @param argv - Raw CLI arguments.
+ * @returns Parsed global options and the rest of args.
+ */
 export function parseGlobalOptions(argv: string[]): {
   globalOptions: GlobalOptions;
   rest: string[];
@@ -34,6 +39,13 @@ export function parseGlobalOptions(argv: string[]): {
   return { globalOptions, rest };
 }
 
+/**
+ * Consume the --config option from the argument stream.
+ * @param globalOptions - Options object to mutate.
+ * @param iterator - Iterator over CLI args.
+ * @param arg - Current argument token.
+ * @returns Whether the token was consumed.
+ */
 export function consumeConfigOption(
   globalOptions: GlobalOptions,
   iterator: IterableIterator<string>,
@@ -58,6 +70,13 @@ export function consumeConfigOption(
   return false;
 }
 
+/**
+ * Consume the --scope option from the argument stream.
+ * @param globalOptions - Options object to mutate.
+ * @param iterator - Iterator over CLI args.
+ * @param arg - Current argument token.
+ * @returns Whether the token was consumed.
+ */
 export function consumeScopeOption(
   globalOptions: GlobalOptions,
   iterator: IterableIterator<string>,
@@ -82,6 +101,11 @@ export function consumeScopeOption(
   return false;
 }
 
+/**
+ * Normalize a scope string into a valid scope value.
+ * @param value - Scope string from CLI.
+ * @returns Normalized scope option.
+ */
 export function normalizeScope(value: string): CliScopeOption {
   if (value === "default" || value === "project" || value === "user") {
     return value;
@@ -91,6 +115,12 @@ export function normalizeScope(value: string): CliScopeOption {
   );
 }
 
+/**
+ * Consume log level flags from the argument stream.
+ * @param globalOptions - Options object to mutate.
+ * @param arg - Current argument token.
+ * @returns Whether the token was consumed.
+ */
 export function consumeLogLevelOption(
   globalOptions: GlobalOptions,
   arg: string

--- a/packages/cli/src/utils/output.ts
+++ b/packages/cli/src/utils/output.ts
@@ -48,6 +48,12 @@ function cleanRecord(record: WaymarkRecord): Partial<WaymarkRecord> {
   return cleaned;
 }
 
+/**
+ * Render waymark records in the requested output format.
+ * @param records - Waymark records to render.
+ * @param format - Output format selection.
+ * @returns Rendered output string.
+ */
 export function renderRecords(
   records: WaymarkRecord[],
   format: ScanOutputFormat

--- a/packages/cli/src/utils/prompts.ts
+++ b/packages/cli/src/utils/prompts.ts
@@ -16,6 +16,10 @@ type PromptPolicy = {
 let promptPolicy: PromptPolicy = { allowed: true };
 
 // note ::: central prompt policy for --no-input enforcement [[cli/no-input]]
+/**
+ * Set prompt policy based on no-input flags and TTY detection.
+ * @param options - Prompt policy inputs.
+ */
 export function setPromptPolicy(options: {
   noInput?: boolean;
   isTty?: boolean;
@@ -35,6 +39,10 @@ export function setPromptPolicy(options: {
   promptPolicy = { allowed: true };
 }
 
+/**
+ * Assert that prompting is allowed for a given action.
+ * @param action - Description of the prompt action.
+ */
 export function assertPromptAllowed(action: string): void {
   if (promptPolicy.allowed) {
     return;
@@ -57,6 +65,11 @@ export type ConfirmOptions = {
   default?: boolean;
 };
 
+/**
+ * Show a confirmation prompt.
+ * @param options - Confirmation prompt options.
+ * @returns True when confirmed.
+ */
 export async function confirm(options: ConfirmOptions): Promise<boolean> {
   assertPromptAllowed("confirmation");
   const { confirmed } = await inquirer.prompt<{ confirmed: boolean }>([
@@ -76,6 +89,11 @@ export type WriteConfirmationOptions = {
   actionVerb?: string; // "format", "migrate", etc.
 };
 
+/**
+ * Show a confirmation prompt before writing changes.
+ * @param options - Write confirmation options.
+ * @returns True when confirmed.
+ */
 export async function confirmWrite(
   options: WriteConfirmationOptions
 ): Promise<boolean> {
@@ -100,6 +118,11 @@ type WaymarkChoice = {
   short: string;
 };
 
+/**
+ * Prompt the user to select a waymark from a list.
+ * @param options - Selection prompt options.
+ * @returns Selected waymark or undefined if cancelled.
+ */
 export async function selectWaymark(
   options: SelectWaymarkOptions
 ): Promise<WaymarkRecord | undefined> {

--- a/packages/cli/src/utils/properties.ts
+++ b/packages/cli/src/utils/properties.ts
@@ -8,6 +8,11 @@ export type PropertyEntry = {
 const PROPERTY_ERROR_MESSAGE =
   "--property expects key=value or key:value format";
 
+/**
+ * Parse a key/value property entry from CLI input.
+ * @param value - Property string in key=value or key:value form.
+ * @returns Parsed property entry.
+ */
 export function parsePropertyEntry(value: string): PropertyEntry {
   const separatorIndex =
     value.indexOf("=") >= 0 ? value.indexOf("=") : value.indexOf(":");

--- a/packages/cli/src/utils/spinner.ts
+++ b/packages/cli/src/utils/spinner.ts
@@ -28,6 +28,11 @@ const noopSpinner: SpinnerHandle = {
   fail: noop,
 };
 
+/**
+ * Create a spinner handle (no-op if disabled).
+ * @param options - Spinner configuration.
+ * @returns Spinner handle.
+ */
 export function createSpinner(options: SpinnerOptions): SpinnerHandle {
   if (!options.enabled) {
     return noopSpinner;

--- a/packages/cli/src/utils/stdin.ts
+++ b/packages/cli/src/utils/stdin.ts
@@ -1,5 +1,10 @@
 // tldr ::: helpers for consuming CLI input streams
 
+/**
+ * Read all data from a stream into a string.
+ * @param stream - Readable stream to consume.
+ * @returns Stream contents as UTF-8 string.
+ */
 export async function readStream(
   stream: NodeJS.ReadableStream
 ): Promise<string> {
@@ -14,6 +19,10 @@ export async function readStream(
   return Buffer.concat(chunks).toString("utf8");
 }
 
+/**
+ * Read all data from stdin into a string.
+ * @returns Stdin contents as UTF-8 string.
+ */
 export async function readFromStdin(): Promise<string> {
   return await readStream(process.stdin);
 }

--- a/packages/cli/src/utils/terminal.ts
+++ b/packages/cli/src/utils/terminal.ts
@@ -20,10 +20,19 @@ function isDumbTerminal(): boolean {
   return process.env.TERM === "dumb";
 }
 
+/**
+ * Determine whether interactive prompts can be shown.
+ * @returns True if stdin and stdout are TTYs.
+ */
 export function canPrompt(): boolean {
   return Boolean(process.stdin.isTTY && process.stdout.isTTY);
 }
 
+/**
+ * Determine whether colored output should be used.
+ * @param noColorFlag - Flag indicating color should be disabled.
+ * @returns True if color should be enabled.
+ */
 export function shouldUseColor(noColorFlag?: boolean): boolean {
   if (noColorFlag) {
     return false;
@@ -43,6 +52,10 @@ export function shouldUseColor(noColorFlag?: boolean): boolean {
   return true;
 }
 
+/**
+ * Get terminal capability information.
+ * @returns Terminal info (TTY, color support, width).
+ */
 export function getTerminalInfo(): TerminalInfo {
   const isTty = Boolean(process.stdout.isTTY);
   const width = isTty

--- a/packages/cli/src/utils/workspace.ts
+++ b/packages/cli/src/utils/workspace.ts
@@ -3,6 +3,11 @@
 import { existsSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 
+/**
+ * Resolve the workspace root by searching for a .waymark directory.
+ * @param start - Directory to start searching from.
+ * @returns Resolved workspace root path.
+ */
 export function resolveWorkspaceRoot(start = process.cwd()): string {
   let current = resolve(start);
 

--- a/scripts/typedoc-check.ts
+++ b/scripts/typedoc-check.ts
@@ -68,7 +68,7 @@ const PACKAGES: Record<PackageKey, PackageConfig> = {
   },
 };
 
-const DEFAULT_ENFORCED_PACKAGES: PackageKey[] = ["core"];
+const DEFAULT_ENFORCED_PACKAGES: PackageKey[] = ["core", "cli"];
 
 const DOC_KINDS: ReflectionKind[] = [
   ReflectionKind.Class,


### PR DESCRIPTION
## Summary
Add TSDoc coverage across CLI command handlers, flag parsers, and display utilities.

## Changes
- Document command helpers, argument parsers, and option resolvers with @param/@returns.
- Add TSDoc tags across display formatters, grouping, pagination, and prompt utilities.

## Testing
- turbo run lint
- bun run lint:md
- turbo run typecheck
- turbo run test

## Issues
- Part of #222


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded CLI public surface for programmatic use and automation; new command entry points for add/remove/modify/scan/lint/fmt/skill/update and improved workspace & terminal helpers.
  * TUI placeholder output and richer output rendering/formats (json/jsonl/text).

* **Bug Fixes**
  * Help now writes to stdout and returns an exit code instead of exiting the process.

* **Documentation**
  * Comprehensive JSDoc added across commands and utilities.

* **Chores**
  * Documentation checks now include the CLI package.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->