### PR TITLE
docs(grammar): add TSDoc for grammar exports

### DIFF
--- a/packages/grammar/src/builder.ts
+++ b/packages/grammar/src/builder.ts
@@ -38,6 +38,11 @@ type ContinuationParams = {
   rawLines: string[];
 };
 
+/**
+ * Build a WaymarkRecord from parsed header and content.
+ * @param args - Record construction inputs.
+ * @returns Waymark record.
+ */
 export function buildRecord(args: BuildRecordArgs): WaymarkRecord {
   const { options, header, raw, contentText, startLine, endLine } = args;
   const file = options.file ?? "";
@@ -67,6 +72,13 @@ export function buildRecord(args: BuildRecordArgs): WaymarkRecord {
   };
 }
 
+/**
+ * Process continuation lines that follow a waymark header.
+ * @param context - Waymark parsing context.
+ * @param header - Parsed header data.
+ * @param params - Continuation processing params.
+ * @returns Continuation content segments and metadata.
+ */
 export function processContinuations(
   context: WaymarkContext,
   header: ParsedHeader,
@@ -117,6 +129,11 @@ export function processContinuations(
   return { contentSegments, endLine, extraProperties, newIndex: index };
 }
 
+/**
+ * Merge continuation properties into a record and update relations.
+ * @param record - Record to mutate.
+ * @param extraProperties - Extra properties discovered in continuations.
+ */
 export function mergeExtraProperties(
   record: WaymarkRecord,
   extraProperties: Record<string, string>
@@ -131,6 +148,13 @@ export function mergeExtraProperties(
   }
 }
 
+/**
+ * Process a single waymark header line into a record and updated cursor.
+ * @param context - Waymark parsing context.
+ * @param header - Parsed header data.
+ * @param rawLine - Raw header line string.
+ * @returns Processed waymark record and next index.
+ */
 export function processWaymarkLine(
   context: WaymarkContext,
   header: ParsedHeader,

--- a/packages/grammar/src/constants.ts
+++ b/packages/grammar/src/constants.ts
@@ -142,14 +142,22 @@ for (const def of MARKER_DEFINITIONS) {
 }
 
 // Helper to get canonical type name from any alias
-/** Resolve a marker name or alias to its canonical type. */
+/**
+ * Resolve a marker name or alias to its canonical type.
+ * @param type - Marker name or alias to resolve.
+ * @returns Canonical marker type.
+ */
 export function getCanonicalType(type: string): string {
   const def = MARKER_MAP.get(type.toLowerCase());
   return def?.name || type.toLowerCase();
 }
 
 // Helper to get type category
-/** Look up the category for a marker name or alias. */
+/**
+ * Look up the category for a marker name or alias.
+ * @param type - Marker name or alias to look up.
+ * @returns Marker category or undefined.
+ */
 export function getTypeCategory(type: string): MarkerCategory | undefined {
   const def = MARKER_MAP.get(type.toLowerCase());
   return def?.category;

--- a/packages/grammar/src/constants.ts
+++ b/packages/grammar/src/constants.ts
@@ -1,15 +1,18 @@
 // tldr ::: waymark grammar constants and blessed markers
 
+/** The sigil used to denote a waymark comment. */
 export const SIGIL = ":::" as const;
 
 // Signal constants
 // ~ = flagged (actively in-progress, branch-scoped)
 // * = starred (important, high-priority)
+/** Signal prefixes that decorate waymark markers. */
 export const SIGNALS = {
   flagged: "~",
   starred: "*",
 } as const;
 
+/** High-level category for a waymark marker. */
 export type MarkerCategory =
   | "work"
   | "info"
@@ -17,6 +20,7 @@ export type MarkerCategory =
   | "workflow"
   | "inquiry";
 
+/** Definition metadata for a single marker. */
 export type MarkerDefinition = {
   name: string;
   category: MarkerCategory;
@@ -24,6 +28,7 @@ export type MarkerDefinition = {
   description?: string;
 };
 
+/** Ordered list of blessed marker definitions. */
 export const MARKER_DEFINITIONS: MarkerDefinition[] = [
   // Work/Action
   { name: "todo", category: "work", description: "Task to be completed" },
@@ -120,12 +125,14 @@ export const MARKER_DEFINITIONS: MarkerDefinition[] = [
 // Build a flat list of all blessed markers
 // In continuation context, the parser explicitly excludes blessed markers from being
 // treated as property continuations (see parseContinuation in content.ts).
+/** Flat list of blessed marker names and aliases. */
 export const BLESSED_MARKERS = MARKER_DEFINITIONS.flatMap((def) => [
   def.name,
   ...(def.aliases || []),
 ]) as readonly string[];
 
 // Build a map for quick lookups from any marker/alias to its definition
+/** Map of marker or alias to its definition. */
 export const MARKER_MAP = new Map<string, MarkerDefinition>();
 for (const def of MARKER_DEFINITIONS) {
   MARKER_MAP.set(def.name, def);
@@ -135,18 +142,21 @@ for (const def of MARKER_DEFINITIONS) {
 }
 
 // Helper to get canonical type name from any alias
+/** Resolve a marker name or alias to its canonical type. */
 export function getCanonicalType(type: string): string {
   const def = MARKER_MAP.get(type.toLowerCase());
   return def?.name || type.toLowerCase();
 }
 
 // Helper to get type category
+/** Look up the category for a marker name or alias. */
 export function getTypeCategory(type: string): MarkerCategory | undefined {
   const def = MARKER_MAP.get(type.toLowerCase());
   return def?.category;
 }
 
 // Common marker names as string constants for runtime usage
+/** Well-known marker names exposed as string constants. */
 export const MARKERS = {
   todo: "todo",
   fix: "fix",
@@ -173,6 +183,7 @@ export const MARKERS = {
 
 // Known property keys that can act as pseudo-markers in continuation context
 // This is the single source of truth for property keys recognized by the parser and formatter
+/** Property keys that can act as pseudo-markers in continuation context. */
 export const PROPERTY_KEYS = new Set([
   // Relation keys (see, docs, from, replaces)
   "see",

--- a/packages/grammar/src/content.ts
+++ b/packages/grammar/src/content.ts
@@ -24,6 +24,12 @@ export type ContinuationResult = {
   propertyValue?: string;
 };
 
+/**
+ * Strip HTML comment closure marker from content if applicable.
+ * @param content - Raw content string.
+ * @param commentLeader - Comment leader token.
+ * @returns Content without HTML comment closure.
+ */
 export function stripHtmlCommentClosure(
   content: string,
   commentLeader: string
@@ -34,6 +40,12 @@ export function stripHtmlCommentClosure(
   return content;
 }
 
+/**
+ * Strip block comment closure marker from content if applicable.
+ * @param content - Raw content string.
+ * @param commentLeader - Comment leader token.
+ * @returns Content without block comment closure.
+ */
 export function stripBlockCommentClosure(
   content: string,
   commentLeader: string
@@ -51,6 +63,12 @@ function stripCommentClosure(content: string, commentLeader: string): string {
   );
 }
 
+/**
+ * Process a content segment, trimming markers and detecting closures.
+ * @param segment - Raw content segment.
+ * @param commentLeader - Comment leader token.
+ * @returns Parsed content segment metadata.
+ */
 export function processContentSegment(
   segment: string,
   commentLeader: string
@@ -82,6 +100,13 @@ export function processContentSegment(
   };
 }
 
+/**
+ * Parse a continuation line for a waymark block.
+ * @param line - Raw line content.
+ * @param commentLeader - Comment leader token.
+ * @param inWaymarkContext - Whether a waymark block is active.
+ * @returns Parsed continuation result, or null if not a continuation.
+ */
 export function parseContinuation(
   line: string,
   commentLeader: string,
@@ -167,6 +192,11 @@ function resolveContinuationLeader(
   return null;
 }
 
+/**
+ * Analyze content to extract properties, relations, mentions, and tags.
+ * @param content - Content text to analyze.
+ * @returns Extracted content metadata.
+ */
 export function analyzeContent(content: string): {
   properties: Record<string, string>;
   relations: WaymarkRecord["relations"];

--- a/packages/grammar/src/metadata.ts
+++ b/packages/grammar/src/metadata.ts
@@ -42,6 +42,11 @@ const TEST_TOKEN_PATTERNS = [
   "__mocks__",
 ];
 
+/**
+ * Infer language identifier from a file path.
+ * @param filePath - File path to inspect.
+ * @returns Language identifier string.
+ */
 export function inferLanguageFromFile(filePath: string | undefined): string {
   if (!filePath) {
     return "unknown";
@@ -105,6 +110,11 @@ export function inferLanguageFromFile(filePath: string | undefined): string {
 }
 
 // todo ::: @codex allow configurable overrides for file category inference #lib/parser
+/**
+ * Infer a file category (code/docs/config/etc) from a file path.
+ * @param filePath - File path to inspect.
+ * @returns File category value.
+ */
 export function inferFileCategory(
   filePath: string | undefined
 ): WaymarkRecord["fileCategory"] {

--- a/packages/grammar/src/parser.ts
+++ b/packages/grammar/src/parser.ts
@@ -12,7 +12,13 @@ import type { ParseOptions, WaymarkRecord } from "./types";
 
 const LINE_SPLIT_REGEX = /\r?\n/;
 
-/** Parse a single line into a waymark record when possible. */
+/**
+ * Parse a single line into a waymark record when possible.
+ * @param line - Raw line of text to parse.
+ * @param lineNumber - 1-based line number in the source.
+ * @param options - Optional parse options.
+ * @returns Parsed waymark record or null when no header is found.
+ */
 export function parseLine(
   line: string,
   lineNumber: number,
@@ -39,7 +45,12 @@ export function parseLine(
   });
 }
 
-/** Parse a full text buffer into waymark records. */
+/**
+ * Parse a full text buffer into waymark records.
+ * @param text - Source text to parse.
+ * @param options - Optional parse options.
+ * @returns Parsed waymark records.
+ */
 export function parse(
   text: string,
   options: ParseOptions = {}
@@ -77,7 +88,11 @@ export function parse(
   return records;
 }
 
-/** Check whether a marker type is in the blessed marker list. */
+/**
+ * Check whether a marker type is in the blessed marker list.
+ * @param type - Marker type to validate.
+ * @returns True if the type is blessed.
+ */
 export function isValidType(type: string | undefined): boolean {
   if (!type) {
     return false;

--- a/packages/grammar/src/parser.ts
+++ b/packages/grammar/src/parser.ts
@@ -12,6 +12,7 @@ import type { ParseOptions, WaymarkRecord } from "./types";
 
 const LINE_SPLIT_REGEX = /\r?\n/;
 
+/** Parse a single line into a waymark record when possible. */
 export function parseLine(
   line: string,
   lineNumber: number,
@@ -38,6 +39,7 @@ export function parseLine(
   });
 }
 
+/** Parse a full text buffer into waymark records. */
 export function parse(
   text: string,
   options: ParseOptions = {}
@@ -75,6 +77,7 @@ export function parse(
   return records;
 }
 
+/** Check whether a marker type is in the blessed marker list. */
 export function isValidType(type: string | undefined): boolean {
   if (!type) {
     return false;

--- a/packages/grammar/src/parser.ts
+++ b/packages/grammar/src/parser.ts
@@ -82,7 +82,5 @@ export function isValidType(type: string | undefined): boolean {
   if (!type) {
     return false;
   }
-  return BLESSED_MARKERS.includes(
-    type.toLowerCase() as (typeof BLESSED_MARKERS)[number]
-  );
+  return BLESSED_MARKERS.includes(type.toLowerCase());
 }

--- a/packages/grammar/src/properties.ts
+++ b/packages/grammar/src/properties.ts
@@ -24,10 +24,20 @@ export const RELATION_KIND_MAP: Record<
   replaces: "replaces",
 };
 
+/**
+ * Unescape quoted property values.
+ * @param value - Quoted value with escape sequences.
+ * @returns Unescaped value.
+ */
 export function unescapeQuotedValue(value: string): string {
   return value.replace(/\\(["\\])/g, "$1");
 }
 
+/**
+ * Split relation values by comma into trimmed tokens.
+ * @param value - Raw relation value string.
+ * @returns List of trimmed tokens.
+ */
 export function splitRelationValues(value: string): string[] {
   return value
     .split(",")
@@ -38,10 +48,20 @@ export function splitRelationValues(value: string): string[] {
 // note ::: URL schemes to preserve without # prefix in relation values
 const URL_SCHEME_PATTERN = /^[a-z][a-z0-9+.-]*:\/\//i;
 
+/**
+ * Determine whether a value is a URL.
+ * @param value - Value to test.
+ * @returns True if the value matches a URL scheme.
+ */
 export function isUrl(value: string): boolean {
   return URL_SCHEME_PATTERN.test(value);
 }
 
+/**
+ * Normalize a relation token, adding # when needed.
+ * @param token - Raw token value.
+ * @returns Normalized token or null if empty.
+ */
 export function normalizeRelationToken(token: string): string | null {
   if (token.length === 0) {
     return null;
@@ -57,6 +77,13 @@ export function normalizeRelationToken(token: string): string | null {
   return token.startsWith("#") ? token : `#${token}`;
 }
 
+/**
+ * Append normalized relation tokens to the relations list.
+ * @param relationKind - Relation kind to assign.
+ * @param value - Raw relation value.
+ * @param relations - Relations array to mutate.
+ * @param canonicalSet - Canonical token set to update for see relations.
+ */
 export function appendRelationTokens(
   relationKind: WaymarkRecord["relations"][number]["kind"],
   value: string,
@@ -82,8 +109,10 @@ export function appendRelationTokens(
 }
 
 /**
- * Mask content inside backticks to prevent property extraction
+ * Mask content inside backticks to prevent property extraction.
  * about ::: prevents parsing `key:value` patterns inside inline code
+ * @param text - Raw content string.
+ * @returns Masked content and extracted blocks.
  */
 export function maskBackticks(text: string): {
   masked: string;
@@ -121,7 +150,10 @@ export function maskBackticks(text: string): {
 }
 
 /**
- * Restore masked backtick blocks
+ * Restore masked backtick blocks.
+ * @param text - Masked content string.
+ * @param blocks - Backtick blocks to restore.
+ * @returns Unmasked content string.
  */
 export function unmaskBackticks(text: string, blocks: string[]): string {
   let result = text;
@@ -131,6 +163,11 @@ export function unmaskBackticks(text: string, blocks: string[]): string {
   return result;
 }
 
+/**
+ * Extract properties and relations from content.
+ * @param content - Content text to analyze.
+ * @returns Extracted properties, relations, and canonical tokens.
+ */
 export function extractPropertiesAndRelations(content: string): {
   properties: Record<string, string>;
   relations: WaymarkRecord["relations"];
@@ -178,6 +215,11 @@ export function extractPropertiesAndRelations(content: string): {
   };
 }
 
+/**
+ * Extract unique mentions from content.
+ * @param content - Content text to analyze.
+ * @returns Mention tokens.
+ */
 export function extractMentions(content: string): string[] {
   const mentions = new Set<string>();
 
@@ -191,6 +233,11 @@ export function extractMentions(content: string): string[] {
   return Array.from(mentions);
 }
 
+/**
+ * Extract unique tags from content.
+ * @param content - Content text to analyze.
+ * @returns Tag tokens.
+ */
 export function extractTags(content: string): string[] {
   const tags = new Set<string>();
 
@@ -204,6 +251,12 @@ export function extractTags(content: string): string[] {
   return Array.from(tags);
 }
 
+/**
+ * Add relation tokens to an existing record.
+ * @param record - Record to mutate.
+ * @param relationKind - Relation kind to add.
+ * @param value - Raw relation value string.
+ */
 export function addRelationTokens(
   record: WaymarkRecord,
   relationKind: WaymarkRecord["relations"][number]["kind"],

--- a/packages/grammar/src/properties.ts
+++ b/packages/grammar/src/properties.ts
@@ -2,14 +2,16 @@
 
 import type { WaymarkRecord } from "./types";
 
-// Exported regex patterns for reuse in styling and other contexts
+/** Regex matching `key:value` properties in waymark content. */
 // note ::: No space allowed after colon for unquoted values (key:value not key: value)
 export const PROPERTY_REGEX =
   /(?:^|[\s])([A-Za-z][A-Za-z0-9_-]*)\s*:(?:"([^"\\]*(?:\\.[^"\\]*)*)"|([^\s,]+(?:,[^\s,]+)*))/gm;
+/** Regex matching `@mention` tokens in waymark content. */
 // note ::: requires lowercase first char to reject decorators (@Component)
 // note ::: lookahead rejects both continuations and parens to prevent backtracking on @dataclass()
 export const MENTION_REGEX =
   /(?:^|[^A-Za-z0-9/_-])(@[a-z][A-Za-z0-9/_-]*)(?![A-Za-z0-9/_(-])/gm;
+/** Regex matching `#tag` tokens in waymark content. */
 export const TAG_REGEX = /(?:^|[^A-Za-z0-9._/:%-])(#[A-Za-z0-9._/:%-]+)/gm;
 
 export const RELATION_KIND_MAP: Record<

--- a/packages/grammar/src/tokenizer.ts
+++ b/packages/grammar/src/tokenizer.ts
@@ -20,10 +20,20 @@ export type ParsedHeader = {
   content: string;
 };
 
+/**
+ * Normalize a line by stripping trailing carriage returns.
+ * @param line - Raw line text.
+ * @returns Normalized line text.
+ */
 export function normalizeLine(line: string): string {
   return line.endsWith("\r") ? line.slice(0, -1) : line;
 }
 
+/**
+ * Find the comment leader at the start of a string.
+ * @param text - Text to inspect.
+ * @returns Comment leader token or null.
+ */
 export function findCommentLeader(text: string): string | null {
   for (const leader of COMMENT_LEADERS) {
     if (text.startsWith(leader)) {
@@ -33,6 +43,11 @@ export function findCommentLeader(text: string): string | null {
   return null;
 }
 
+/**
+ * Parse the signals and type segment before the sigil.
+ * @param segment - Raw segment before the sigil.
+ * @returns Parsed type, signals, and validity.
+ */
 export function parseSignalsAndType(segment: string): {
   type: string;
   signals: SignalState;
@@ -89,6 +104,11 @@ export function parseSignalsAndType(segment: string): {
   };
 }
 
+/**
+ * Parse a full waymark header line into structured data.
+ * @param line - Raw line text.
+ * @returns Parsed header or null when invalid.
+ */
 export function parseHeader(line: string): ParsedHeader | null {
   const indentMatch = line.match(LEADING_WHITESPACE_REGEX);
   const indent = indentMatch ? indentMatch[0].length : 0;

--- a/packages/grammar/src/types.ts
+++ b/packages/grammar/src/types.ts
@@ -1,5 +1,6 @@
 // tldr ::: core type definitions for waymark grammar
 
+/** Parsed representation of a waymark comment. */
 export type WaymarkRecord = {
   file: string;
   language: string;
@@ -27,6 +28,7 @@ export type WaymarkRecord = {
   codetag?: boolean;
 };
 
+/** Options that influence waymark parsing. */
 export type ParseOptions = {
   file?: string;
   language?: string;

--- a/scripts/typedoc-check.ts
+++ b/scripts/typedoc-check.ts
@@ -68,7 +68,7 @@ const PACKAGES: Record<PackageKey, PackageConfig> = {
   },
 };
 
-const DEFAULT_ENFORCED_PACKAGES: PackageKey[] = ["core", "cli"];
+const DEFAULT_ENFORCED_PACKAGES: PackageKey[] = ["core", "cli", "grammar"];
 
 const DOC_KINDS: ReflectionKind[] = [
   ReflectionKind.Class,


### PR DESCRIPTION
## Summary
Add TSDoc coverage for grammar builder, tokenizer, content parsing, properties, and metadata helpers.

## Changes
- Document exported grammar helpers with @param/@returns.
- Clarify continuation and content analysis helpers.

## Testing
- turbo run lint
- bun run lint:md
- turbo run typecheck
- turbo run test

## Issues
- Part of #222


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded public parsing API with line-level and full-text parsing functions.
  * Enhanced marker system with categories, aliases, and lookup capabilities.
  * New utilities for content analysis, property and relation extraction, and metadata inference.
  * Improved handling of relation tokens and comment closure detection.

* **Documentation**
  * Added comprehensive JSDoc comments across new public functions and types.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->