### PR TITLE
docs(agents): add TSDoc for agent exports

### DIFF
--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -4,14 +4,18 @@ import { readFile } from "node:fs/promises";
 
 import { formatText, parse, resolveConfig } from "@waymarks/core";
 import packageJson from "../package.json" with { type: "json" };
+import type { PartialWaymarkConfig } from "./types.ts";
 
 export type { ParseOptions, WaymarkRecord } from "@waymarks/core";
 export type { PartialWaymarkConfig } from "./types.ts";
 
 /** Options for configuring the agent toolkit. */
 export type AgentToolkitOptions = {
-  config?: import("./types.ts").PartialWaymarkConfig;
+  config?: PartialWaymarkConfig;
 };
+
+/** Current agent package version. */
+export const agentVersion = packageJson.version;
 
 /**
  * Creates an agent toolkit with waymark parsing, formatting, and scanning capabilities.
@@ -31,7 +35,7 @@ export function createAgentToolkit(options: AgentToolkitOptions = {}) {
   const config = resolveConfig(options.config ?? {});
 
   return {
-    agentVersion: packageJson.version,
+    agentVersion,
 
     /**
      * Parse waymark syntax from a source string.
@@ -84,6 +88,3 @@ export function createAgentToolkit(options: AgentToolkitOptions = {}) {
     },
   };
 }
-
-/** Current agent package version. */
-export const agentVersion = packageJson.version;

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -8,6 +8,7 @@ import packageJson from "../package.json" with { type: "json" };
 export type { ParseOptions, WaymarkRecord } from "@waymarks/core";
 export type { PartialWaymarkConfig } from "./types.ts";
 
+/** Options for configuring the agent toolkit. */
 export type AgentToolkitOptions = {
   config?: import("./types.ts").PartialWaymarkConfig;
 };
@@ -84,4 +85,5 @@ export function createAgentToolkit(options: AgentToolkitOptions = {}) {
   };
 }
 
+/** Current agent package version. */
 export const agentVersion = packageJson.version;

--- a/packages/agents/tsconfig.build.json
+++ b/packages/agents/tsconfig.build.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["./src/**/*"]
+}

--- a/scripts/typedoc-check.ts
+++ b/scripts/typedoc-check.ts
@@ -73,6 +73,7 @@ const DEFAULT_ENFORCED_PACKAGES: PackageKey[] = [
   "cli",
   "grammar",
   "mcp",
+  "agents",
 ];
 
 const DOC_KINDS: ReflectionKind[] = [


### PR DESCRIPTION
## Summary
Finalize TypeDoc coverage for the agents package and include it in the TypeDoc enforcement list.

## Changes
- Document agent toolkit options/version exports and clean up imports.
- Add agents to the TypeDoc coverage enforcement list.

## Testing
- turbo run lint
- bun run lint:md
- turbo run typecheck
- turbo run test

## Issues
- Part of #222


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Toolkit now exposes a top-level agentVersion constant for clearer runtime visibility.
  * Public type for toolkit configuration standardized and a related config type re-exported for consumers.

* **Documentation**
  * Minor inline docs and header polish to improve clarity and discoverability.

* **Chores**
  * Added build config for the agents package and included agents in the enforced documentation checks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->