### PR TITLE
feat(cli): add wm check command for content integrity validation

### DIFF
--- a/packages/cli/src/commands/check.ts
+++ b/packages/cli/src/commands/check.ts
@@ -1,0 +1,392 @@
+// tldr ::: cross-file content integrity validation for waymarks
+
+import { readFile } from "node:fs/promises";
+import { parse, type WaymarkRecord } from "@waymarks/core";
+import chalk from "chalk";
+import type { CommandContext } from "../types.ts";
+import { expandInputPaths } from "../utils/fs.ts";
+
+// about ::: threshold for TLDR position warning (lines from top)
+const TLDR_TOP_LINES_MAX = 20;
+
+// about ::: max length for content preview in suggestions
+const CONTENT_PREVIEW_LENGTH = 50;
+
+// about ::: relation kinds that must reference existing canonicals
+const CANONICAL_RELATIONS: WaymarkRecord["relations"][number]["kind"][] = [
+  "from",
+  "replaces",
+  "see",
+  "docs",
+];
+
+/**
+ * Severity levels for check issues.
+ */
+export type CheckSeverity = "error" | "warning";
+
+/**
+ * A single issue found during content integrity checking.
+ */
+export type CheckIssue = {
+  file: string;
+  line?: number;
+  rule: string;
+  severity: CheckSeverity;
+  message: string;
+  suggestion?: string;
+};
+
+/**
+ * Report containing all check results.
+ */
+export type CheckReport = {
+  issues: CheckIssue[];
+  summary: {
+    total: number;
+    errors: number;
+    warnings: number;
+  };
+  passed: boolean;
+};
+
+/**
+ * Command options for the check command.
+ */
+export type CheckCommandOptions = {
+  paths?: string[];
+  strict?: boolean;
+  fix?: boolean;
+  json?: boolean;
+};
+
+/**
+ * Result of running the check command.
+ */
+export type CheckCommandResult = {
+  output: string;
+  exitCode: number;
+  report: CheckReport;
+};
+
+// about ::: builds map of canonical tokens to their locations
+function buildCanonicalMap(
+  records: WaymarkRecord[]
+): Map<string, { file: string; line: number }[]> {
+  const canonicals = new Map<string, { file: string; line: number }[]>();
+  for (const record of records) {
+    for (const token of record.canonicals || []) {
+      if (!canonicals.has(token)) {
+        canonicals.set(token, []);
+      }
+      canonicals
+        .get(token)
+        ?.push({ file: record.file, line: record.startLine });
+    }
+  }
+  return canonicals;
+}
+
+// about ::: checks for duplicate canonical references across files
+function checkDuplicateCanonicals(
+  canonicals: Map<string, { file: string; line: number }[]>
+): CheckIssue[] {
+  const issues: CheckIssue[] = [];
+
+  for (const [token, occurrences] of canonicals) {
+    if (occurrences.length > 1) {
+      const firstOccurrence = occurrences[0];
+      const locations = occurrences
+        .map((o) => `${o.file}:${o.line}`)
+        .join(", ");
+      const issue: CheckIssue = {
+        file: firstOccurrence?.file ?? "unknown",
+        rule: "duplicate-canonical",
+        severity: "error",
+        message: `Duplicate canonical reference: ${token} defined in ${occurrences.length} places`,
+        suggestion: `Remove duplicates. Found at: ${locations}`,
+      };
+      if (firstOccurrence?.line !== undefined) {
+        issue.line = firstOccurrence.line;
+      }
+      issues.push(issue);
+    }
+  }
+
+  return issues;
+}
+
+// about ::: checks if a relation token should skip canonical validation
+function shouldSkipCanonicalValidation(token: string): boolean {
+  // ID references (wrapped in [[...]]) reference by ID, not canonical
+  const isIdReference = token.startsWith("[[") && token.endsWith("]]");
+  // URLs are external references, not canonicals
+  const isUrl = token.startsWith("http://") || token.startsWith("https://");
+  return isIdReference || isUrl;
+}
+
+// about ::: creates a dangling relation issue
+function createDanglingRelationIssue(
+  record: WaymarkRecord,
+  relation: { kind: string; token: string }
+): CheckIssue {
+  return {
+    file: record.file,
+    line: record.startLine,
+    rule: "dangling-relation",
+    severity: "error",
+    message: `Dangling relation: ${relation.kind}:${relation.token} (canonical not found)`,
+    suggestion: `Add a waymark with ref:${relation.token} or remove this relation`,
+  };
+}
+
+// about ::: checks for relations pointing to non-existent canonicals
+function checkDanglingRelations(
+  records: WaymarkRecord[],
+  canonicals: Map<string, { file: string; line: number }[]>
+): CheckIssue[] {
+  const issues: CheckIssue[] = [];
+
+  for (const record of records) {
+    for (const relation of record.relations || []) {
+      if (!CANONICAL_RELATIONS.includes(relation.kind)) {
+        continue;
+      }
+      if (shouldSkipCanonicalValidation(relation.token)) {
+        continue;
+      }
+
+      if (!canonicals.has(relation.token)) {
+        issues.push(createDanglingRelationIssue(record, relation));
+      }
+    }
+  }
+
+  return issues;
+}
+
+// about ::: groups TLDR records by file
+function groupTldrsByFile(
+  records: WaymarkRecord[]
+): Map<string, WaymarkRecord[]> {
+  const tldrByFile = new Map<string, WaymarkRecord[]>();
+  for (const record of records) {
+    if (record.type === "tldr") {
+      if (!tldrByFile.has(record.file)) {
+        tldrByFile.set(record.file, []);
+      }
+      tldrByFile.get(record.file)?.push(record);
+    }
+  }
+  return tldrByFile;
+}
+
+// about ::: creates issue for multiple TLDRs in a file
+function createMultipleTldrIssue(
+  file: string,
+  tldrs: WaymarkRecord[]
+): CheckIssue {
+  const secondTldr = tldrs[1];
+  const issue: CheckIssue = {
+    file,
+    rule: "multiple-tldr",
+    severity: "error",
+    message: `Multiple TLDRs in file (found ${tldrs.length})`,
+    suggestion: "Consolidate into single TLDR at top of file",
+  };
+  if (secondTldr?.startLine !== undefined) {
+    issue.line = secondTldr.startLine;
+  }
+  return issue;
+}
+
+// about ::: creates issue for TLDR not at top of file
+function createTldrPositionIssue(
+  file: string,
+  tldr: WaymarkRecord
+): CheckIssue {
+  return {
+    file,
+    line: tldr.startLine,
+    rule: "tldr-position",
+    severity: "warning",
+    message: `TLDR should be near top of file (found at line ${tldr.startLine}, expected within first ${TLDR_TOP_LINES_MAX} lines)`,
+    suggestion: "Move TLDR to top of file after shebang/frontmatter",
+  };
+}
+
+// about ::: checks that TLDRs are positioned near the top of files
+function checkTldrPositioning(records: WaymarkRecord[]): CheckIssue[] {
+  const issues: CheckIssue[] = [];
+  const tldrByFile = groupTldrsByFile(records);
+
+  for (const [file, tldrs] of tldrByFile) {
+    if (tldrs.length > 1) {
+      issues.push(createMultipleTldrIssue(file, tldrs));
+    }
+
+    for (const tldr of tldrs) {
+      if (tldr.startLine > TLDR_TOP_LINES_MAX) {
+        issues.push(createTldrPositionIssue(file, tldr));
+      }
+    }
+  }
+
+  return issues;
+}
+
+// about ::: truncates content for display in suggestions
+function truncateContent(content: string): string {
+  if (content.length <= CONTENT_PREVIEW_LENGTH) {
+    return content;
+  }
+  return `${content.slice(0, CONTENT_PREVIEW_LENGTH)}...`;
+}
+
+// about ::: checks for flagged (~) signals that should be cleared before merge
+function checkSignalHygiene(records: WaymarkRecord[]): CheckIssue[] {
+  const issues: CheckIssue[] = [];
+
+  for (const record of records) {
+    if (record.signals.flagged) {
+      const preview = truncateContent(record.contentText);
+      issues.push({
+        file: record.file,
+        line: record.startLine,
+        rule: "flagged-signal",
+        severity: "warning",
+        message: `Flagged waymark (~${record.type}) should be cleared before merging`,
+        suggestion: `Remove the ~ signal or complete the work: ${preview}`,
+      });
+    }
+  }
+
+  return issues;
+}
+
+// about ::: parses all files and collects waymark records
+async function parseFiles(
+  paths: string[],
+  context: CommandContext
+): Promise<{ records: WaymarkRecord[]; parseErrors: CheckIssue[] }> {
+  const records: WaymarkRecord[] = [];
+  const parseErrors: CheckIssue[] = [];
+
+  const inputPaths = paths.length > 0 ? paths : ["."];
+  const files = await expandInputPaths(inputPaths, context.config);
+
+  for (const filePath of files) {
+    try {
+      const source = await readFile(filePath, "utf-8");
+      const fileRecords = parse(source, { file: filePath });
+      records.push(...fileRecords);
+    } catch (error) {
+      parseErrors.push({
+        file: filePath,
+        rule: "parse-error",
+        severity: "error",
+        message: `Parse error: ${error instanceof Error ? error.message : String(error)}`,
+      });
+    }
+  }
+
+  return { records, parseErrors };
+}
+
+/**
+ * Run content integrity checks on waymarks.
+ * @param context - CLI context with config.
+ * @param options - Check command options.
+ * @returns Check report with issues found.
+ */
+export async function runCheckCommand(
+  context: CommandContext,
+  options: CheckCommandOptions
+): Promise<CheckReport> {
+  const { records, parseErrors } = await parseFiles(
+    options.paths ?? [],
+    context
+  );
+
+  const issues: CheckIssue[] = [...parseErrors];
+
+  // Build canonical map for relation checks
+  const canonicals = buildCanonicalMap(records);
+
+  // Run all checks
+  issues.push(...checkDuplicateCanonicals(canonicals));
+  issues.push(...checkDanglingRelations(records, canonicals));
+  issues.push(...checkTldrPositioning(records));
+  issues.push(...checkSignalHygiene(records));
+
+  // Calculate summary
+  const errors = issues.filter((i) => i.severity === "error").length;
+  const warnings = issues.filter((i) => i.severity === "warning").length;
+
+  // Determine pass/fail based on strict mode
+  const passed = options.strict ? errors === 0 && warnings === 0 : errors === 0;
+
+  return {
+    issues,
+    summary: {
+      total: issues.length,
+      errors,
+      warnings,
+    },
+    passed,
+  };
+}
+
+// about ::: formats severity label with color
+function formatSeverityLabel(severity: CheckSeverity): string {
+  return severity === "error" ? chalk.red("error") : chalk.yellow("warn");
+}
+
+// about ::: formats a single issue for CLI output
+function formatIssue(issue: CheckIssue): string {
+  const location = issue.line ? `${issue.file}:${issue.line}` : issue.file;
+  const severity = formatSeverityLabel(issue.severity);
+  let output = `${location} ${severity} ${issue.rule}: ${issue.message}`;
+  if (issue.suggestion) {
+    output += `\n  ${chalk.dim(`-> ${issue.suggestion}`)}`;
+  }
+  return output;
+}
+
+/**
+ * Format check report for human-readable CLI output.
+ * @param report - Check report to format.
+ * @returns Formatted output string.
+ */
+export function formatCheckReport(report: CheckReport): string {
+  if (report.issues.length === 0) {
+    return chalk.green("check: all integrity checks passed");
+  }
+
+  const lines: string[] = [];
+
+  for (const issue of report.issues) {
+    lines.push(formatIssue(issue));
+  }
+
+  lines.push("");
+
+  const errorText =
+    report.summary.errors === 1 ? "1 error" : `${report.summary.errors} errors`;
+  const warningText =
+    report.summary.warnings === 1
+      ? "1 warning"
+      : `${report.summary.warnings} warnings`;
+
+  if (report.summary.errors > 0 && report.summary.warnings > 0) {
+    lines.push(
+      chalk.bold(`check: ${chalk.red(errorText)}, ${chalk.yellow(warningText)}`)
+    );
+  } else if (report.summary.errors > 0) {
+    lines.push(chalk.bold(`check: ${chalk.red(errorText)}`));
+  } else {
+    lines.push(chalk.bold(`check: ${chalk.yellow(warningText)}`));
+  }
+
+  return lines.join("\n");
+}


### PR DESCRIPTION
## Summary

Adds a new `wm check` command for cross-file content integrity validation, separating these concerns from `wm doctor` which now focuses on tool health.

## Changes

- New `packages/cli/src/commands/check.ts` implementing 5 integrity checks:
  - **duplicate-canonical** (error) - Same `ref:#token` defined in multiple files
  - **dangling-relation** (error) - Relations pointing to non-existent canonicals
  - **multiple-tldr** (error) - Multiple TLDRs in same file
  - **tldr-position** (warning) - TLDR not near top of file
  - **flagged-signal** (warning) - Raised (`~`) signals that should be cleared before merge

- Registered command in `register.ts` with full help text
- Added handler in `program.ts`

## Usage

```bash
wm check                    # Check current directory
wm check src/               # Check specific directory  
wm check --strict           # CI mode (fail on warnings)
wm check --json             # JSON output for tooling
```

## Command Model

This establishes a clear separation of concerns:
- `wm lint` → Per-file structural validation
- `wm check` → Cross-file content integrity
- `wm doctor` → Tool/environment health

## Test Plan

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `wm check --help` shows correct help text
- [x] `wm check` runs and detects issues in example files
- [x] `wm check --json` outputs valid JSON report

Closes #230

---
🤖 Generated with [Claude Code](https://claude.com/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new "check" CLI command to validate content integrity across Waymark files.
  * Detects duplicate canonicals, broken cross-file references, TLDR placement/multiplicity issues, and signal-hygiene warnings.
  * Supports strict mode (CI-friendly), an auto-fix option, and JSON output for tooling.
  * Produces human-readable, colored reports, shows progress during runs, and returns a failing exit code when checks fail.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->