### PR TITLE
refactor(cli): scope wm doctor to tool health only

### DIFF
--- a/packages/agents/skills/waymark-cli/commands/check.md
+++ b/packages/agents/skills/waymark-cli/commands/check.md
@@ -1,0 +1,74 @@
+---
+name: check
+kind: command
+metadata:
+  wm-cmd: check
+---
+
+<!-- tldr ::: command guide for wm check -->
+
+# wm check
+
+## Synopsis
+
+Validate cross-file content integrity for waymarks.
+
+## Syntax
+
+```text
+wm check [paths...] [options]
+```
+
+## Options
+
+| Option | Description | Default |
+| --- | --- | --- |
+| `--strict` | CI mode (fail on warnings) | false |
+| `--fix` | Auto-repair safe issues (not yet implemented) | false |
+| `--json` | Output as JSON | false |
+
+## Integrity Checks
+
+| Rule | Severity | Description |
+| --- | --- | --- |
+| `duplicate-canonical` | error | Same `ref:#token` defined in multiple files |
+| `dangling-relation` | error | Relation pointing to non-existent canonical |
+| `multiple-tldr` | error | Multiple TLDRs in same file |
+| `tldr-position` | warning | TLDR not near top of file (first 20 lines) |
+| `flagged-signal` | warning | Flagged (`~`) waymark should be cleared before merge |
+| `file-read-error` | error | Unable to read file (permissions, not found) |
+| `parse-error` | error | Failed to parse waymarks in file |
+
+## Examples
+
+```bash
+wm check                      # Check current directory
+wm check src/                 # Check specific directory
+wm check --strict             # CI mode (fail on warnings)
+wm check --json               # JSON output for tooling
+wm check src/ tests/ --strict # Check multiple directories in CI
+```
+
+## Exit Codes
+
+| Code | Meaning |
+| --- | --- |
+| 0 | No errors (warnings only if not --strict) |
+| 1 | Errors found or warnings in --strict mode |
+| 2 | Usage error |
+
+## Command Model
+
+The `check` command is part of a three-tier validation model:
+
+| Command | Purpose |
+| --- | --- |
+| `wm lint` | Per-file structural validation |
+| `wm check` | Cross-file content integrity |
+| `wm doctor` | Tool/environment health |
+
+## See Also
+
+- `wm lint` - per-file structural validation
+- `wm doctor` - tool and environment health
+- `wm find --flagged` - find flagged waymarks

--- a/packages/agents/skills/waymark-cli/commands/doctor.md
+++ b/packages/agents/skills/waymark-cli/commands/doctor.md
@@ -11,28 +11,40 @@ metadata:
 
 ## Synopsis
 
-Run diagnostics on configuration, cache, and waymark integrity.
+Run diagnostics on tool installation, configuration, and environment health.
 
 ## Syntax
 
 ```text
-wm doctor [paths...] [options]
+wm doctor [options]
 ```
 
 ## Options
 
-| Option | Short | Description | Default |
-| --- | --- | --- | --- |
-| `--strict` |  | Treat warnings as failures | false |
-| `--fix` |  | Attempt safe repairs | false |
-| `--json` |  | JSON report output | false |
+| Option | Description | Default |
+| --- | --- | --- |
+| `--strict` | Treat warnings as failures | false |
+| `--fix` | Attempt safe repairs | false |
+| `--json` | JSON report output | false |
+
+## Health Checks
+
+| Check | Description |
+| --- | --- |
+| Configuration validity | Config file syntax and value ranges |
+| Cache directory | Cache directory writability |
+| Index file integrity | Index file health and consistency |
+| Git repository | Git repository detection |
+| Ignore patterns | Ignore pattern validation |
+| Performance | Performance diagnostics |
 
 ## Examples
 
 ```bash
-wm doctor
-wm doctor src/ --strict
-wm doctor --json
+wm doctor              # Run all health checks
+wm doctor --strict     # Fail on warnings
+wm doctor --json       # JSON output for tooling
+wm doctor --fix        # Attempt safe repairs
 ```
 
 ## Exit Codes
@@ -45,7 +57,18 @@ wm doctor --json
 | 3 | Config error |
 | 4 | I/O error |
 
+## Command Model
+
+The `doctor` command focuses on tool/environment health. For content validation, use other commands:
+
+| Command | Purpose |
+| --- | --- |
+| `wm lint` | Per-file structural validation |
+| `wm check` | Cross-file content integrity |
+| `wm doctor` | Tool/environment health |
+
 ## See Also
 
-- `wm lint` - lint waymarks
-- `wm config --print` - view config
+- `wm check` - cross-file content integrity
+- `wm lint` - per-file structural validation
+- `wm config --print` - view merged config

--- a/packages/agents/skills/waymark-cli/manifest.json
+++ b/packages/agents/skills/waymark-cli/manifest.json
@@ -4,6 +4,7 @@
   "description": "This skill should be used when the user asks about \"wm command\", \"waymark cli\", \"wm find\", \"wm add\", \"wm edit\", \"wm rm\", \"wm fmt\", \"wm lint\", or needs to use waymark tooling. Requires `using-waymarks` skill for syntax fundamentals. Provides comprehensive CLI command reference and workflows.",
   "commands": [
     "add",
+    "check",
     "config",
     "doctor",
     "edit",
@@ -43,6 +44,14 @@
         "path": "commands/add.md",
         "metadata": {
           "wm-cmd": "add"
+        }
+      },
+      {
+        "name": "check",
+        "kind": "command",
+        "path": "commands/check.md",
+        "metadata": {
+          "wm-cmd": "check"
         }
       },
       {

--- a/packages/cli/skills/waymark-cli/commands/check.md
+++ b/packages/cli/skills/waymark-cli/commands/check.md
@@ -1,0 +1,74 @@
+---
+name: check
+kind: command
+metadata:
+  wm-cmd: check
+---
+
+<!-- tldr ::: command guide for wm check -->
+
+# wm check
+
+## Synopsis
+
+Validate cross-file content integrity for waymarks.
+
+## Syntax
+
+```text
+wm check [paths...] [options]
+```
+
+## Options
+
+| Option | Description | Default |
+| --- | --- | --- |
+| `--strict` | CI mode (fail on warnings) | false |
+| `--fix` | Auto-repair safe issues (not yet implemented) | false |
+| `--json` | Output as JSON | false |
+
+## Integrity Checks
+
+| Rule | Severity | Description |
+| --- | --- | --- |
+| `duplicate-canonical` | error | Same `ref:#token` defined in multiple files |
+| `dangling-relation` | error | Relation pointing to non-existent canonical |
+| `multiple-tldr` | error | Multiple TLDRs in same file |
+| `tldr-position` | warning | TLDR not near top of file (first 20 lines) |
+| `flagged-signal` | warning | Flagged (`~`) waymark should be cleared before merge |
+| `file-read-error` | error | Unable to read file (permissions, not found) |
+| `parse-error` | error | Failed to parse waymarks in file |
+
+## Examples
+
+```bash
+wm check                      # Check current directory
+wm check src/                 # Check specific directory
+wm check --strict             # CI mode (fail on warnings)
+wm check --json               # JSON output for tooling
+wm check src/ tests/ --strict # Check multiple directories in CI
+```
+
+## Exit Codes
+
+| Code | Meaning |
+| --- | --- |
+| 0 | No errors (warnings only if not --strict) |
+| 1 | Errors found or warnings in --strict mode |
+| 2 | Usage error |
+
+## Command Model
+
+The `check` command is part of a three-tier validation model:
+
+| Command | Purpose |
+| --- | --- |
+| `wm lint` | Per-file structural validation |
+| `wm check` | Cross-file content integrity |
+| `wm doctor` | Tool/environment health |
+
+## See Also
+
+- `wm lint` - per-file structural validation
+- `wm doctor` - tool and environment health
+- `wm find --flagged` - find flagged waymarks

--- a/packages/cli/skills/waymark-cli/commands/doctor.md
+++ b/packages/cli/skills/waymark-cli/commands/doctor.md
@@ -11,28 +11,40 @@ metadata:
 
 ## Synopsis
 
-Run diagnostics on configuration, cache, and waymark integrity.
+Run diagnostics on tool installation, configuration, and environment health.
 
 ## Syntax
 
 ```text
-wm doctor [paths...] [options]
+wm doctor [options]
 ```
 
 ## Options
 
-| Option | Short | Description | Default |
-| --- | --- | --- | --- |
-| `--strict` |  | Treat warnings as failures | false |
-| `--fix` |  | Attempt safe repairs | false |
-| `--json` |  | JSON report output | false |
+| Option | Description | Default |
+| --- | --- | --- |
+| `--strict` | Treat warnings as failures | false |
+| `--fix` | Attempt safe repairs | false |
+| `--json` | JSON report output | false |
+
+## Health Checks
+
+| Check | Description |
+| --- | --- |
+| Configuration validity | Config file syntax and value ranges |
+| Cache directory | Cache directory writability |
+| Index file integrity | Index file health and consistency |
+| Git repository | Git repository detection |
+| Ignore patterns | Ignore pattern validation |
+| Performance | Performance diagnostics |
 
 ## Examples
 
 ```bash
-wm doctor
-wm doctor src/ --strict
-wm doctor --json
+wm doctor              # Run all health checks
+wm doctor --strict     # Fail on warnings
+wm doctor --json       # JSON output for tooling
+wm doctor --fix        # Attempt safe repairs
 ```
 
 ## Exit Codes
@@ -45,7 +57,18 @@ wm doctor --json
 | 3 | Config error |
 | 4 | I/O error |
 
+## Command Model
+
+The `doctor` command focuses on tool/environment health. For content validation, use other commands:
+
+| Command | Purpose |
+| --- | --- |
+| `wm lint` | Per-file structural validation |
+| `wm check` | Cross-file content integrity |
+| `wm doctor` | Tool/environment health |
+
 ## See Also
 
-- `wm lint` - lint waymarks
-- `wm config --print` - view config
+- `wm check` - cross-file content integrity
+- `wm lint` - per-file structural validation
+- `wm config --print` - view merged config

--- a/packages/cli/skills/waymark-cli/manifest.json
+++ b/packages/cli/skills/waymark-cli/manifest.json
@@ -4,6 +4,7 @@
   "description": "This skill should be used when the user asks about \"wm command\", \"waymark cli\", \"wm find\", \"wm add\", \"wm edit\", \"wm rm\", \"wm fmt\", \"wm lint\", or needs to use waymark tooling. Requires `using-waymarks` skill for syntax fundamentals. Provides comprehensive CLI command reference and workflows.",
   "commands": [
     "add",
+    "check",
     "config",
     "doctor",
     "edit",
@@ -43,6 +44,14 @@
         "path": "commands/add.md",
         "metadata": {
           "wm-cmd": "add"
+        }
+      },
+      {
+        "name": "check",
+        "kind": "command",
+        "path": "commands/check.md",
+        "metadata": {
+          "wm-cmd": "check"
         }
       },
       {

--- a/packages/cli/src/commands/register.ts
+++ b/packages/cli/src/commands/register.ts
@@ -588,19 +588,17 @@ Examples:
   skillCommand.addCommand(skillPathCommand);
   program.addCommand(skillCommand);
 
-  // Doctor command - health checks and diagnostics (WAY-47)
+  // Doctor command - tool and environment health checks (WAY-47)
   const doctorCommand = new Command("doctor")
-    .argument("[paths...]", "files or directories to check")
     .option("--strict", "fail on warnings (CI mode)", false)
     .option("--fix", "attempt automatic repairs", false)
     .option("--json", "output as JSON")
-    .description("run health checks and diagnostics")
+    .description("check tool and environment health")
     .addHelpText(
       "after",
       `
 Examples:
-  $ wm doctor                      # Check current directory
-  $ wm doctor src/                 # Check specific directory
+  $ wm doctor                      # Run health checks
   $ wm doctor --strict             # CI mode (fail on warnings)
   $ wm doctor --fix                # Auto-repair safe issues
   $ wm doctor --json               # JSON output for tooling
@@ -609,43 +607,35 @@ Health Checks:
   Configuration:
     - Config file exists and is valid
     - Config values are within valid ranges
+
+  Cache:
     - Cache directory is writable
     - Index files are valid JSON
-
-  Waymark Integrity:
-    - All waymarks parse correctly
-    - No duplicate canonical references
-    - No dangling relations (depends:, needs:, etc.)
-    - TLDRs are in correct positions
-    - Raised/starred signals on protected branches
+    - Cache is not stale
+    - Index size is reasonable
 
   Environment:
     - Git repository detected
     - Ignore patterns working correctly
-    - Index size is reasonable
-
-  Performance:
-    - Cache functioning correctly
-    - Index size warnings
 
 Auto-Fix Support (--fix):
   - Rebuild corrupted cache/index files
-  - Remove duplicate canonicals (keeps first)
-  - Fix TLDR positioning issues
-  - Run formatter on waymarks with syntax issues
-  - Clear flagged signals on protected branches (with confirmation)
+  - Clear stale cache entries
 
 Exit Codes:
   0  No errors (warnings only if not --strict)
   1  Errors found or warnings in --strict mode
   2  Internal/tooling error
 
+Note: For content integrity checks (duplicate canonicals, dangling relations,
+TLDR positioning, signal hygiene), use 'wm check' instead.
+
 See 'wm skill show doctor' for agent-facing documentation.
     `
     )
-    .action(async (paths: string[], options: DoctorCommandOptions) => {
+    .action(async (options: DoctorCommandOptions) => {
       try {
-        await handleDoctorCommand(program, { ...options, paths });
+        await handleDoctorCommand(program, options);
       } catch (error) {
         handleCommandError(program, error);
       }


### PR DESCRIPTION
## Summary

Refactors `wm doctor` to focus exclusively on tool/environment health, removing content integrity checks that are now handled by `wm check` (PR #232).

## Changes

- **Removed from doctor** (now in `wm check`):
  - Duplicate canonical references
  - Dangling relations
  - TLDR positioning
  - Signal hygiene checks

- **Kept in doctor** (tool health):
  - Configuration validity and ranges
  - Cache directory writability
  - Index file integrity
  - Git repository detection
  - Ignore pattern validation
  - Performance diagnostics

- Removed `[paths...]` argument (no longer scanning files)
- Updated help text to reflect focused scope
- Added note pointing users to `wm check` for content validation

## Motivation

`doctor` commands traditionally diagnose tool installation and environment issues, not content validity. This refactor aligns with that convention:

| Command | Purpose |
|---------|---------|
| `wm lint` | Per-file structural validation |
| `wm check` | Cross-file content integrity |
| `wm doctor` | Tool/environment health |

## Test Plan

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `wm doctor --help` shows updated help text
- [x] `wm doctor` runs successfully with focused checks
- [x] Content integrity errors no longer appear in doctor output

Closes #231

---
🤖 Generated with [Claude Code](https://claude.com/code)