### PR TITLE
feat(cli): add Claude Code testing infrastructure

### DIFF
--- a/.claude/commands/ops/test/cli.md
+++ b/.claude/commands/ops/test/cli.md
@@ -1,0 +1,59 @@
+---
+name: ops-test-cli
+description: Run Waymark CLI validation tests
+argument-hint: "[category|--all]"
+allowed-tools: Read Glob Grep Skill TodoWrite Bash(./.claude/scripts/run-tests.sh *) Bash(wm *)
+---
+
+# CLI Validation Tests
+
+Load the `cli-testing` skill for detailed testing guidance.
+
+## Quick Run
+
+```bash
+./.claude/scripts/run-tests.sh [category|--all]
+```
+
+## Categories
+
+| Category | Tests | Focus |
+|----------|-------|-------|
+| `parse` | Grammar parsing | Validates waymark syntax via `wm lint -` stdin |
+| `scan` | File scanning | Tests `wm find` filtering, JSON/JSONL output |
+| `format` | Formatting | Tests `wm fmt` consistency and idempotency |
+| `lint` | Validation rules | Tests lint rule detection and reporting |
+| `cli` | CLI basics | Help text, version, exit codes, argument parsing |
+| `integration` | E2E workflows | Add, edit, remove waymarks in sequence |
+| `config` | Configuration | Tests `wm config --print` and config merging |
+| `check` | Health checks | Tests `wm doctor` diagnostics |
+
+## Output
+
+Results written to `.scratch/testing/`:
+
+- `{date}-{id}-{category}.md` - Markdown report
+- `{date}-{id}-{category}-debug.log` - Debug output
+
+## Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | All tests passed |
+| 1 | One or more tests failed |
+| 2 | Setup or usage error |
+
+## Result Classifications
+
+| Result | Meaning |
+|--------|---------|
+| **PASS** | Behaves as expected |
+| **WARN** | Works but unexpected output |
+| **FAIL** | Broken behavior or wrong exit code |
+
+## When to Use
+
+- After modifying CLI option parsing
+- Before releases
+- To validate error handling
+- CI pipelines (deterministic, fast)

--- a/.claude/scripts/lib/test-runner-lib.sh
+++ b/.claude/scripts/lib/test-runner-lib.sh
@@ -1,0 +1,528 @@
+#!/usr/bin/env bash
+# test-runner-lib.sh - Shared CLI test runner library for Outfitter projects
+#
+# tldr ::: Shared bash library for CLI integration testing with markdown reporting
+#
+# Usage:
+#   source "$(dirname "$0")/lib/test-runner-lib.sh"
+#   init_test_runner ".scratch/testing"
+#   setup_category "my-tests"
+#   run_test 1 "Test name" "command" "expected_pattern" "false"
+#   finalize_category
+#
+# Provides:
+#   - TTY-aware color output
+#   - Markdown report generation
+#   - Debug log capture
+#   - Consistent PASS/WARN/FAIL classification
+#
+# Counter variables (exported):
+#   PASSED, WARNED, FAILED, TOTAL
+#
+# Output files (set by setup_category):
+#   RESULTS_FILE, DEBUG_FILE
+
+# ============================================================================
+# Guard against multiple sourcing
+# ============================================================================
+
+if [[ -n "${_TEST_RUNNER_LIB_LOADED:-}" ]]; then
+  return 0
+fi
+_TEST_RUNNER_LIB_LOADED=1
+
+# ============================================================================
+# Configuration (set by init_test_runner)
+# ============================================================================
+
+# Output directory for test results
+TEST_RUNNER_OUTPUT_DIR=""
+
+# Date/run identifiers
+TEST_RUNNER_DATE_PREFIX=""
+TEST_RUNNER_RUN_ID=""
+
+# Project name (used in report headers)
+TEST_RUNNER_PROJECT_NAME="CLI"
+
+# ============================================================================
+# Color definitions (set by init_test_runner based on TTY)
+# ============================================================================
+
+# Color codes - initialized empty, set by init_test_runner
+RED=""
+GREEN=""
+YELLOW=""
+BLUE=""
+BOLD=""
+NC=""
+
+# ============================================================================
+# Test counters (global for simplicity)
+# ============================================================================
+
+PASSED=0
+WARNED=0
+FAILED=0
+TOTAL=0
+
+# ============================================================================
+# Output files (set by setup_category)
+# ============================================================================
+
+RESULTS_FILE=""
+DEBUG_FILE=""
+
+# ============================================================================
+# Core Functions
+# ============================================================================
+
+# init_test_runner [output_dir] [project_name]
+#
+# Initialize the test runner with output directory and optional project name.
+# Must be called before any other functions.
+#
+# Arguments:
+#   output_dir   - Directory for test reports (default: .scratch/testing)
+#   project_name - Name shown in report headers (default: CLI)
+#
+# Side effects:
+#   - Sets color codes based on TTY detection
+#   - Sets date prefix and run ID
+#   - Creates output directory
+#
+init_test_runner() {
+  local output_dir="${1:-.scratch/testing}"
+  local project_name="${2:-CLI}"
+
+  TEST_RUNNER_OUTPUT_DIR="$output_dir"
+  TEST_RUNNER_PROJECT_NAME="$project_name"
+  TEST_RUNNER_DATE_PREFIX="$(date +%Y%m%d)"
+  TEST_RUNNER_RUN_ID="$(date +%H%M%S)"
+
+  # Set colors based on TTY detection
+  if [[ -t 1 ]]; then
+    RED='\033[0;31m'
+    GREEN='\033[0;32m'
+    YELLOW='\033[0;33m'
+    BLUE='\033[0;34m'
+    BOLD='\033[1m'
+    NC='\033[0m'
+  else
+    RED=''
+    GREEN=''
+    YELLOW=''
+    BLUE=''
+    BOLD=''
+    NC=''
+  fi
+
+  # Create output directory
+  mkdir -p "$TEST_RUNNER_OUTPUT_DIR"
+}
+
+# setup_category NAME
+#
+# Set up output files for a test category.
+# Creates markdown report and debug log files.
+#
+# Arguments:
+#   NAME - Category name (used in filenames and headers)
+#
+# Side effects:
+#   - Creates RESULTS_FILE and DEBUG_FILE
+#   - Resets counters
+#
+# Example:
+#   setup_category "edge-cases"
+#
+setup_category() {
+  local category="$1"
+
+  # Validate initialization
+  if [[ -z "$TEST_RUNNER_OUTPUT_DIR" ]]; then
+    echo "ERROR: init_test_runner must be called before setup_category" >&2
+    return 1
+  fi
+
+  # Reset counters for new category
+  reset_counters
+
+  # Set output file paths
+  RESULTS_FILE="$TEST_RUNNER_OUTPUT_DIR/${TEST_RUNNER_DATE_PREFIX}-${TEST_RUNNER_RUN_ID}-${category}.md"
+  DEBUG_FILE="$TEST_RUNNER_OUTPUT_DIR/${TEST_RUNNER_DATE_PREFIX}-${TEST_RUNNER_RUN_ID}-${category}-debug.log"
+
+  # Initialize markdown report
+  cat > "$RESULTS_FILE" << EOF
+# ${TEST_RUNNER_PROJECT_NAME} Test Report
+
+**Category**: ${category}
+**Run ID**: ${TEST_RUNNER_RUN_ID}
+**Date**: $(date -u +"%Y-%m-%dT%H:%M:%SZ")
+**Debug Log**: ${DEBUG_FILE##*/}
+
+---
+
+## Results
+
+| # | Test | Status | Details |
+|---|------|--------|---------|
+EOF
+
+  # Initialize debug log
+  cat > "$DEBUG_FILE" << EOF
+# ${TEST_RUNNER_PROJECT_NAME} Debug Log
+# Category: ${category}
+# Run ID: ${TEST_RUNNER_RUN_ID}
+# Started: $(date -u +"%Y-%m-%dT%H:%M:%SZ")
+# ============================================================
+
+EOF
+}
+
+# run_test NUM NAME CMD PATTERN [EXPECT_FAIL]
+#
+# Execute a single test case and record results.
+#
+# Arguments:
+#   NUM         - Test number (for ordering/display)
+#   NAME        - Human-readable test name
+#   CMD         - Command to execute (supports pipes, redirects via eval)
+#   PATTERN     - Regex pattern to match in output
+#   EXPECT_FAIL - "true" if command should fail, "false" otherwise (default: "false")
+#
+# Classification logic:
+#   - PASS: Command behaved as expected AND output matched pattern
+#   - WARN: Command behaved as expected BUT output didn't match pattern
+#   - FAIL: Command behaved opposite to expectation
+#
+# Example:
+#   run_test 1 "Help displays usage" "mycli --help" "Usage|usage" "false"
+#   run_test 2 "Invalid flag fails" "mycli --invalid" "unknown|error" "true"
+#
+run_test() {
+  local num="$1"
+  local name="$2"
+  local cmd="$3"
+  local pattern="$4"
+  local expect_fail="${5:-false}"
+
+  # Increment total
+  TOTAL=$((TOTAL + 1))
+
+  # Console output (test start)
+  echo -e "${BLUE}Test $num: $name${NC}"
+
+  # Log to debug file
+  cat >> "$DEBUG_FILE" << EOF
+
+# Test $num: $name
+# Command: $cmd
+# Expected pattern: $pattern
+# Expect fail: $expect_fail
+---
+EOF
+
+  # Execute command and capture output/exit code
+  local output=""
+  local exit_code=0
+
+  # Use eval to handle complex commands with pipes/redirects
+  # Temporarily disable errexit to capture exit code
+  set +e
+  output=$(eval "$cmd" 2>&1)
+  exit_code=$?
+  set -e
+
+  # Log output to debug file
+  echo "$output" >> "$DEBUG_FILE"
+  echo "Exit code: $exit_code" >> "$DEBUG_FILE"
+  echo "---" >> "$DEBUG_FILE"
+
+  # Evaluate result
+  local status="FAIL"
+  local details=""
+
+  if [[ "$expect_fail" == "true" ]]; then
+    # Expecting failure (non-zero exit code)
+    if [[ $exit_code -ne 0 ]]; then
+      # Command failed as expected - check pattern
+      if echo "$output" | grep -qE "$pattern"; then
+        status="PASS"
+        details="Got expected error pattern"
+      else
+        status="WARN"
+        details="Failed but pattern not matched"
+      fi
+    else
+      # Command succeeded when it should have failed
+      status="FAIL"
+      details="Expected failure but got exit code 0"
+    fi
+  else
+    # Expecting success (zero exit code)
+    if [[ $exit_code -eq 0 ]]; then
+      # Command succeeded as expected - check pattern
+      if echo "$output" | grep -qE "$pattern"; then
+        status="PASS"
+        details="Output matched expected pattern"
+      else
+        status="WARN"
+        details="Succeeded but pattern not matched"
+      fi
+    else
+      # Command failed when it should have succeeded
+      status="FAIL"
+      details="Expected success, got exit code $exit_code"
+    fi
+  fi
+
+  # Update counters
+  case "$status" in
+    PASS)
+      PASSED=$((PASSED + 1))
+      echo -e "  ${GREEN}PASS${NC}: $details"
+      ;;
+    WARN)
+      WARNED=$((WARNED + 1))
+      echo -e "  ${YELLOW}WARN${NC}: $details"
+      ;;
+    FAIL)
+      FAILED=$((FAILED + 1))
+      echo -e "  ${RED}FAIL${NC}: $details"
+      ;;
+  esac
+
+  # Write to markdown report
+  echo "| $num | $name | $status | $details |" >> "$RESULTS_FILE"
+}
+
+# finalize_category
+#
+# Finalize the current test category by writing summary to report.
+# Returns 0 if no failures, 1 if any failures.
+#
+# Side effects:
+#   - Appends summary table to RESULTS_FILE
+#   - Prints summary to console
+#
+# Returns:
+#   0 - All tests passed (possibly with warnings)
+#   1 - One or more tests failed
+#
+finalize_category() {
+  # Add summary to markdown report
+  cat >> "$RESULTS_FILE" << EOF
+
+---
+
+## Summary
+
+| Metric | Count |
+|--------|-------|
+| Total | $TOTAL |
+| Passed | $PASSED |
+| Warnings | $WARNED |
+| Failed | $FAILED |
+
+EOF
+
+  # Add debug log reference if there were failures
+  if [[ $FAILED -gt 0 ]]; then
+    cat >> "$RESULTS_FILE" << EOF
+### Debug Information
+
+See debug log for details: \`${DEBUG_FILE##*/}\`
+EOF
+  fi
+
+  # Close debug log
+  cat >> "$DEBUG_FILE" << EOF
+
+# ============================================================
+# Completed: $(date -u +"%Y-%m-%dT%H:%M:%SZ")
+# Results: $PASSED passed, $WARNED warnings, $FAILED failed (of $TOTAL)
+# ============================================================
+EOF
+
+  # Print summary to console
+  echo ""
+  echo -e "${BOLD}=== Summary ===${NC}"
+  echo -e "Total:    $TOTAL"
+  echo -e "Passed:   ${GREEN}$PASSED${NC}"
+  echo -e "Warnings: ${YELLOW}$WARNED${NC}"
+  echo -e "Failed:   ${RED}$FAILED${NC}"
+  echo ""
+  echo "Results: $RESULTS_FILE"
+  echo "Debug:   $DEBUG_FILE"
+
+  # Return appropriate exit code
+  if [[ $FAILED -gt 0 ]]; then
+    return 1
+  fi
+  return 0
+}
+
+# log MSG
+#
+# Log a message to the debug file with timestamp.
+#
+# Arguments:
+#   MSG - Message to log
+#
+# Example:
+#   log "Setting up test fixtures"
+#
+log() {
+  local msg="$*"
+  echo "[$(date +%H:%M:%S)] $msg" >> "$DEBUG_FILE"
+}
+
+# reset_counters
+#
+# Reset all test counters to zero.
+# Called automatically by setup_category, but can be called manually.
+#
+reset_counters() {
+  PASSED=0
+  WARNED=0
+  FAILED=0
+  TOTAL=0
+}
+
+# ============================================================================
+# Utility Functions
+# ============================================================================
+
+# print_header MSG
+#
+# Print a section header to console.
+#
+# Arguments:
+#   MSG - Header text
+#
+print_header() {
+  local msg="$1"
+  echo ""
+  echo -e "${BOLD}=== $msg ===${NC}"
+  echo ""
+}
+
+# print_pass MSG
+#
+# Print a pass message to console.
+#
+print_pass() {
+  echo -e "${GREEN}PASS${NC} $*"
+}
+
+# print_warn MSG
+#
+# Print a warning message to console.
+#
+print_warn() {
+  echo -e "${YELLOW}WARN${NC} $*"
+}
+
+# print_fail MSG
+#
+# Print a failure message to console.
+#
+print_fail() {
+  echo -e "${RED}FAIL${NC} $*"
+}
+
+# print_info MSG
+#
+# Print an info message to console.
+#
+print_info() {
+  echo -e "${BLUE}[test]${NC} $*"
+}
+
+# get_results_file
+#
+# Get the path to the current results file.
+# Useful for custom test logic that needs to append to the report.
+#
+get_results_file() {
+  echo "$RESULTS_FILE"
+}
+
+# get_debug_file
+#
+# Get the path to the current debug file.
+# Useful for custom test logic that needs to log additional info.
+#
+get_debug_file() {
+  echo "$DEBUG_FILE"
+}
+
+# ============================================================================
+# Advanced: Custom test result recording
+# ============================================================================
+
+# record_custom_result NUM NAME STATUS DETAILS
+#
+# Record a custom test result without running a command.
+# Useful for tests that need custom evaluation logic.
+#
+# Arguments:
+#   NUM     - Test number
+#   NAME    - Test name
+#   STATUS  - "PASS", "WARN", or "FAIL"
+#   DETAILS - Description of result
+#
+# Example:
+#   # Custom JSON validation test
+#   output=$(mycli output --json)
+#   if echo "$output" | jq -e . >/dev/null 2>&1; then
+#     record_custom_result 5 "JSON is valid" "PASS" "Output parsed as valid JSON"
+#   else
+#     record_custom_result 5 "JSON is valid" "FAIL" "Output is not valid JSON"
+#   fi
+#
+record_custom_result() {
+  local num="$1"
+  local name="$2"
+  local status="$3"
+  local details="$4"
+
+  TOTAL=$((TOTAL + 1))
+
+  # Update counters
+  case "$status" in
+    PASS)
+      PASSED=$((PASSED + 1))
+      echo -e "${GREEN}PASS${NC} $num. $name"
+      ;;
+    WARN)
+      WARNED=$((WARNED + 1))
+      echo -e "${YELLOW}WARN${NC} $num. $name - $details"
+      ;;
+    FAIL)
+      FAILED=$((FAILED + 1))
+      echo -e "${RED}FAIL${NC} $num. $name - $details"
+      ;;
+  esac
+
+  # Write to markdown report
+  echo "| $num | $name | $status | $details |" >> "$RESULTS_FILE"
+
+  # Log to debug file
+  cat >> "$DEBUG_FILE" << EOF
+
+# Test $num: $name (custom)
+# Status: $status
+# Details: $details
+---
+EOF
+}
+
+# ============================================================================
+# Export variables for subshells
+# ============================================================================
+
+export PASSED WARNED FAILED TOTAL
+export RESULTS_FILE DEBUG_FILE
+export RED GREEN YELLOW BLUE BOLD NC

--- a/.claude/scripts/run-tests.sh
+++ b/.claude/scripts/run-tests.sh
@@ -1,0 +1,536 @@
+#!/usr/bin/env bash
+# tldr ::: Waymark CLI integration test runner with markdown reporting
+
+set -euo pipefail
+
+# ============================================================
+# Load shared test runner library
+# ============================================================
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# shellcheck source=lib/test-runner-lib.sh
+source "$SCRIPT_DIR/lib/test-runner-lib.sh"
+
+# Initialize the test runner
+init_test_runner "$PROJECT_ROOT/.scratch/testing" "Waymark"
+
+# ============================================================
+# Waymark-specific setup
+# ============================================================
+
+# Temp file for test fixtures
+TEMP_DIR=""
+
+# Ensure temp directories are cleaned up on exit
+trap 'cleanup_temp_fixtures 2>/dev/null || true' EXIT
+
+check_dependencies() {
+  print_info "Checking dependencies..."
+
+  if ! command -v wm &> /dev/null; then
+    print_fail "'wm' CLI not found in PATH"
+    echo "Run 'bun install && bun install:bin' or 'bun dev:cli' to install"
+    exit 2
+  fi
+
+  local version
+  version=$(wm --version 2>/dev/null || echo "unknown")
+  print_pass "Found wm CLI: $version"
+}
+
+setup_temp_fixtures() {
+  TEMP_DIR=$(mktemp -d)
+
+  # Create test fixture: valid waymark file
+  cat > "$TEMP_DIR/valid.ts" << 'EOF'
+// tldr ::: test file with valid waymarks
+// todo ::: implement feature #test
+// note ::: this is a note
+export const foo = 'bar';
+EOF
+
+  # Create test fixture: multiple tldrs (invalid)
+  cat > "$TEMP_DIR/multiple-tldr.ts" << 'EOF'
+// tldr ::: first tldr
+// tldr ::: second tldr (should error)
+export const foo = 'bar';
+EOF
+
+  # Create test fixture: unknown marker
+  cat > "$TEMP_DIR/unknown-marker.ts" << 'EOF'
+// tldr ::: file with unknown marker
+// banana ::: this is not a valid marker
+export const foo = 'bar';
+EOF
+
+  # Create test fixture: codetag pattern
+  cat > "$TEMP_DIR/codetag.ts" << 'EOF'
+// tldr ::: file with codetag
+// TODO: this should be a waymark
+export const foo = 'bar';
+EOF
+
+  # Create test fixture: formatting needed
+  cat > "$TEMP_DIR/needs-format.ts" << 'EOF'
+// tldr:::needs spacing around sigil
+//todo ::: needs space after leader
+export const foo = 'bar';
+EOF
+
+  # Create test fixture: properly formatted
+  cat > "$TEMP_DIR/well-formatted.ts" << 'EOF'
+// tldr ::: properly formatted waymark
+// todo ::: another properly formatted one #feature
+export const foo = 'bar';
+EOF
+
+  # Create test fixture: with properties
+  cat > "$TEMP_DIR/with-props.ts" << 'EOF'
+// tldr ::: file with properties ref:#test/props
+// todo ::: @agent implement this fixes:#123 #priority
+export const foo = 'bar';
+EOF
+
+  # Create test fixture: empty file
+  touch "$TEMP_DIR/empty.ts"
+
+  # Create test fixture: flagged waymarks
+  cat > "$TEMP_DIR/flagged.ts" << 'EOF'
+// tldr ::: file with flagged waymarks
+// ~todo ::: work in progress
+// *fix ::: high priority fix
+// ~*review ::: urgent review needed
+export const foo = 'bar';
+EOF
+
+  log "Test fixtures created in: $TEMP_DIR"
+}
+
+cleanup_temp_fixtures() {
+  if [[ -n "$TEMP_DIR" && -d "$TEMP_DIR" ]]; then
+    rm -rf "$TEMP_DIR"
+  fi
+}
+
+# ============================================================
+# Test Categories
+# ============================================================
+
+run_parse_tests() {
+  print_header "Parse Tests"
+
+  setup_category "parse"
+  setup_temp_fixtures
+
+  # Test 1: Parse valid waymark via stdin
+  run_test 1 "Parse valid waymark syntax" \
+    "echo '// todo ::: test waymark' | wm lint -" \
+    "no issues|0 issues|passed" \
+    false
+
+  # Test 2: Parse waymark with properties
+  run_test 2 "Parse waymark with properties" \
+    "echo '// todo ::: @agent implement ref:#test' | wm lint -" \
+    "no issues|0 issues|passed" \
+    false
+
+  # Test 3: Parse waymark with signals
+  run_test 3 "Parse flagged waymark (~)" \
+    "echo '// ~todo ::: work in progress' | wm lint -" \
+    "no issues|0 issues|passed" \
+    false
+
+  # Test 4: Parse starred waymark
+  run_test 4 "Parse starred waymark (*)" \
+    "echo '// *fix ::: high priority' | wm lint -" \
+    "no issues|0 issues|passed" \
+    false
+
+  # Test 5: Parse combined signals
+  run_test 5 "Parse combined signals (~*)" \
+    "echo '// ~*todo ::: urgent WIP' | wm lint -" \
+    "no issues|0 issues|passed" \
+    false
+
+  cleanup_temp_fixtures
+  finalize_category
+}
+
+run_scan_tests() {
+  print_header "Scan Tests"
+
+  setup_category "scan"
+  setup_temp_fixtures
+
+  # Test 1: Scan finds waymarks
+  run_test 1 "Scan finds waymarks in file" \
+    "wm find '$TEMP_DIR/valid.ts'" \
+    "todo|tldr|note" \
+    false
+
+  # Test 2: Filter by type
+  run_test 2 "Filter waymarks by type (todo)" \
+    "wm find '$TEMP_DIR/valid.ts' --type todo" \
+    "todo" \
+    false
+
+  # Test 3: JSON output
+  run_test 3 "JSON output format" \
+    "wm find '$TEMP_DIR/valid.ts' --json" \
+    '^\[|"type"|"content"' \
+    false
+
+  # Test 4: JSONL output
+  run_test 4 "JSONL output format" \
+    "wm find '$TEMP_DIR/valid.ts' --jsonl" \
+    '"type"|"content"' \
+    false
+
+  # Test 5: Scan with tag filter (requires # prefix)
+  run_test 5 "Filter by tag" \
+    "wm find '$TEMP_DIR/valid.ts' --tag '#test'" \
+    "test|todo" \
+    false
+
+  cleanup_temp_fixtures
+  finalize_category
+}
+
+run_format_tests() {
+  print_header "Format Tests"
+
+  setup_category "format"
+  setup_temp_fixtures
+
+  # Test 1: Format check on well-formatted file
+  run_test 1 "Well-formatted file passes" \
+    "wm fmt '$TEMP_DIR/well-formatted.ts'" \
+    "0 edits|no changes|already formatted" \
+    false
+
+  # Test 2: Format shows corrected output
+  run_test 2 "Format shows corrected output" \
+    "wm fmt '$TEMP_DIR/needs-format.ts'" \
+    "tldr ::: needs spacing" \
+    false
+
+  # Test 3: Format with --yes applies changes
+  local format_test_file="$TEMP_DIR/format-write-test.ts"
+  cp "$TEMP_DIR/needs-format.ts" "$format_test_file"
+  run_test 3 "Format with --yes applies changes" \
+    "wm fmt '$format_test_file' --yes && wm fmt '$format_test_file'" \
+    "no changes|already" \
+    false
+
+  # Test 4: Format idempotency
+  run_test 4 "Format is idempotent" \
+    "wm fmt '$TEMP_DIR/well-formatted.ts' && wm fmt '$TEMP_DIR/well-formatted.ts'" \
+    "0 edits|no changes|already formatted" \
+    false
+
+  cleanup_temp_fixtures
+  finalize_category
+}
+
+run_lint_tests() {
+  print_header "Lint Tests"
+
+  setup_category "lint"
+  setup_temp_fixtures
+
+  # Test 1: Lint clean file
+  run_test 1 "Lint passes on valid file" \
+    "wm lint '$TEMP_DIR/valid.ts'" \
+    "no issues|0 issues|passed|0 errors" \
+    false
+
+  # Test 2: Lint detects multiple TLDRs
+  run_test 2 "Detect multiple TLDRs" \
+    "wm lint '$TEMP_DIR/multiple-tldr.ts'" \
+    "multiple.*tldr|already has.*tldr|multiple-tldr" \
+    true
+
+  # Test 3: Lint detects unknown marker
+  run_test 3 "Detect unknown marker" \
+    "wm lint '$TEMP_DIR/unknown-marker.ts'" \
+    "unknown.*marker|banana|warn" \
+    false
+
+  # Test 4: Lint detects codetag pattern
+  run_test 4 "Detect codetag pattern" \
+    "wm lint '$TEMP_DIR/codetag.ts'" \
+    "codetag|TODO:|consider" \
+    false
+
+  # Test 5: Lint with verbose flag
+  run_test 5 "Lint with verbose output" \
+    "wm lint '$TEMP_DIR/valid.ts' --verbose" \
+    'no issues|0 issues|passed|checking' \
+    false
+
+  cleanup_temp_fixtures
+  finalize_category
+}
+
+run_cli_tests() {
+  print_header "CLI Tests"
+
+  setup_category "cli"
+
+  # Test 1: Help command
+  run_test 1 "Help displays usage" \
+    "wm --help" \
+    "Usage|usage|help|Commands" \
+    false
+
+  # Test 2: Version command
+  run_test 2 "Version displays version" \
+    "wm --version" \
+    "[0-9]+\.[0-9]+\.[0-9]+" \
+    false
+
+  # Test 3: Invalid flag fails
+  run_test 3 "Invalid flag exits with error" \
+    "wm --nonexistent-flag-xyz" \
+    "unknown|invalid|error|option" \
+    true
+
+  # Test 4: Find defaults to current directory
+  run_test 4 "Find without path defaults to current dir" \
+    "wm find --help" \
+    "scan|filter|waymarks|directory" \
+    false
+
+  # Test 5: Lint requires path argument
+  run_test 5 "Lint without path shows error" \
+    "wm lint" \
+    "requires|path|error" \
+    true
+
+  finalize_category
+}
+
+run_integration_tests() {
+  print_header "Integration Tests"
+
+  setup_category "integration"
+  setup_temp_fixtures
+
+  # Test 1: Find + lint workflow
+  run_test 1 "Find then lint same file" \
+    "wm find '$TEMP_DIR/valid.ts' --type todo && wm lint '$TEMP_DIR/valid.ts'" \
+    "todo|no issues|0 issues" \
+    false
+
+  # Test 2: Scan directory
+  run_test 2 "Scan entire directory" \
+    "wm find '$TEMP_DIR'" \
+    "tldr|todo|note" \
+    false
+
+  # Test 3: Format + lint workflow
+  local workflow_file="$TEMP_DIR/workflow-test.ts"
+  cp "$TEMP_DIR/needs-format.ts" "$workflow_file"
+  run_test 3 "Format then lint workflow" \
+    "wm fmt '$workflow_file' --yes && wm lint '$workflow_file'" \
+    "no issues|0 issues|passed" \
+    false
+
+  # Test 4: Multiple type filters
+  run_test 4 "Multiple type filters" \
+    "wm find '$TEMP_DIR/valid.ts' --type todo --type note" \
+    "todo|note" \
+    false
+
+  # Test 5: Properties and tags preserved
+  run_test 5 "Properties extracted correctly" \
+    "wm find '$TEMP_DIR/with-props.ts' --json" \
+    'ref|#test|@agent|#priority' \
+    false
+
+  cleanup_temp_fixtures
+  finalize_category
+}
+
+run_config_tests() {
+  print_header "Config Tests"
+
+  setup_category "config"
+
+  # Test 1: Config print works
+  run_test 1 "Config print outputs JSON" \
+    "wm config --print" \
+    '"typeCase"|"idScope"|allowTypes' \
+    false
+
+  # Test 2: Config print with --json
+  run_test 2 "Config print with --json flag" \
+    "wm config --print --json" \
+    '"typeCase"|"idScope"' \
+    false
+
+  # Test 3: Config without --print fails
+  run_test 3 "Config without --print shows error" \
+    "wm config" \
+    "requires|--print|error" \
+    true
+
+  finalize_category
+}
+
+run_check_tests() {
+  print_header "Check Tests"
+
+  setup_category "check"
+  setup_temp_fixtures
+
+  # Test 1: Doctor basic run
+  run_test 1 "Doctor command runs" \
+    "wm doctor" \
+    "Checking|check|Configuration|Environment|passed|healthy" \
+    false
+
+  # Test 2: Doctor JSON output
+  run_test 2 "Doctor JSON output" \
+    "wm doctor --json" \
+    '"healthy"|"checks"|"summary"' \
+    false
+
+  # Test 3: Doctor with --strict flag
+  run_test 3 "Doctor with --strict flag" \
+    "wm doctor --strict" \
+    "check|Checking|passed|healthy|Configuration|Environment" \
+    false
+
+  cleanup_temp_fixtures
+  finalize_category
+}
+
+# ============================================================
+# Main Entry Point
+# ============================================================
+
+usage() {
+  cat << EOF
+Usage: $(basename "$0") [category|--all]
+
+Run Waymark CLI integration tests.
+
+Categories:
+  parse       Grammar parsing tests
+  scan        File scanning tests (wm find)
+  format      Formatting tests (wm fmt)
+  lint        Linting tests (wm lint)
+  cli         CLI basics (help, version, exit codes)
+  integration End-to-end workflow tests
+  config      Configuration tests
+  check       Health check tests (wm doctor)
+
+Options:
+  --all       Run all test categories
+  --help      Show this help message
+
+Exit codes:
+  0  All tests passed
+  1  One or more tests failed
+  2  Setup error (CLI not found)
+
+Examples:
+  $(basename "$0") parse      # Run parse tests
+  $(basename "$0") --all      # Run all tests
+EOF
+}
+
+main() {
+  local category="${1:-}"
+
+  if [[ -z "$category" || "$category" == "--help" || "$category" == "-h" ]]; then
+    usage
+    exit 0
+  fi
+
+  check_dependencies
+
+  local exit_code=0
+  local total_failed=0
+
+  case "$category" in
+    parse)
+      run_parse_tests || true
+      total_failed=$FAILED
+      ;;
+    scan)
+      run_scan_tests || true
+      total_failed=$FAILED
+      ;;
+    format)
+      run_format_tests || true
+      total_failed=$FAILED
+      ;;
+    lint)
+      run_lint_tests || true
+      total_failed=$FAILED
+      ;;
+    cli)
+      run_cli_tests || true
+      total_failed=$FAILED
+      ;;
+    integration)
+      run_integration_tests || true
+      total_failed=$FAILED
+      ;;
+    config)
+      run_config_tests || true
+      total_failed=$FAILED
+      ;;
+    check)
+      run_check_tests || true
+      total_failed=$FAILED
+      ;;
+    --all)
+      run_parse_tests || true
+      total_failed=$((total_failed + FAILED))
+
+      run_scan_tests || true
+      total_failed=$((total_failed + FAILED))
+
+      run_format_tests || true
+      total_failed=$((total_failed + FAILED))
+
+      run_lint_tests || true
+      total_failed=$((total_failed + FAILED))
+
+      run_cli_tests || true
+      total_failed=$((total_failed + FAILED))
+
+      run_integration_tests || true
+      total_failed=$((total_failed + FAILED))
+
+      run_config_tests || true
+      total_failed=$((total_failed + FAILED))
+
+      run_check_tests || true
+      total_failed=$((total_failed + FAILED))
+
+      echo ""
+      echo -e "${BOLD}=== All Categories Complete ===${NC}"
+      echo "Total failures across all categories: $total_failed"
+      ;;
+    *)
+      print_fail "Unknown category '$category'"
+      echo ""
+      usage
+      exit 2
+      ;;
+  esac
+
+  if [[ $total_failed -gt 0 ]]; then
+    exit 1
+  fi
+
+  exit 0
+}
+
+main "$@"

--- a/.claude/skills/cli-testing/SKILL.md
+++ b/.claude/skills/cli-testing/SKILL.md
@@ -1,0 +1,257 @@
+---
+name: cli-testing
+description: CLI testing guidance and patterns. Loaded by /ops/test/cli command or subagents for comprehensive testing.
+compatibility: Requires Bun runtime and wm CLI installed (bun install && bun install:bin)
+allowed-tools: Read Glob Grep Skill TodoWrite Bash(./.claude/scripts/run-tests.sh *) Bash(wm *) Bash(wm-dev *)
+metadata:
+  author: outfitter-dev
+  version: "1.0"
+---
+<!-- tldr ::: CLI integration test runner skill with markdown reporting #test/cli -->
+
+# Waymark CLI Testing Skill
+
+This skill provides guidance for running and extending the Waymark CLI integration test suite.
+
+## Quick Start
+
+```bash
+# Ensure CLI is installed
+bun install && bun install:bin
+
+# Run all tests
+./.claude/scripts/run-tests.sh --all
+
+# Run specific category
+./.claude/scripts/run-tests.sh parse
+./.claude/scripts/run-tests.sh lint
+```
+
+Or use the Claude command:
+
+```bash
+/ops/test/cli --all
+/ops/test/cli parse
+```
+
+## Test Categories Reference
+
+| Category | Command | What It Tests |
+|----------|---------|---------------|
+| `parse` | `wm lint -` | Grammar parsing via stdin, signals, properties |
+| `scan` | `wm find` | File scanning, type/tag filtering, JSON output |
+| `format` | `wm fmt` | Formatting detection, --write flag, idempotency |
+| `lint` | `wm lint` | Lint rules: multiple-tldr, unknown-marker, codetag |
+| `cli` | `wm --help` | Help text, version, argument validation, exit codes |
+| `integration` | Multiple | End-to-end workflows combining commands |
+| `config` | `wm config` | Config printing, JSON output, --print requirement |
+| `check` | `wm doctor` | Health diagnostics, JSON output, path filtering |
+
+## Output Structure
+
+Test results are written to `.scratch/testing/`:
+
+```text
+.scratch/testing/
+  20260116-1705432800-parse.md          # Markdown report
+  20260116-1705432800-parse-debug.log   # Full command output
+  20260116-1705432800-scan.md
+  20260116-1705432800-scan-debug.log
+  ...
+```
+
+### Report Format
+
+```markdown
+# Waymark CLI Test Report
+
+**Category**: parse
+**Run ID**: 1705432800
+**Date**: 2026-01-16T15:00:00Z
+**Debug Log**: 20260116-1705432800-parse-debug.log
+
+---
+
+## Results
+
+| # | Test | Status | Details |
+|---|------|--------|---------|
+| 1 | Parse valid waymark syntax | PASS | Output matched expected pattern |
+| 2 | Parse waymark with properties | PASS | Output matched expected pattern |
+...
+
+## Summary
+
+| Metric | Count |
+|--------|-------|
+| Total | 5 |
+| Passed | 5 |
+| Warnings | 0 |
+| Failed | 0 |
+```
+
+## Adding New Tests
+
+### Step 1: Choose the Right Category
+
+- **Grammar/parsing behavior**: `run_parse_tests()`
+- **File scanning/filtering**: `run_scan_tests()`
+- **Formatting rules**: `run_format_tests()`
+- **Lint rules**: `run_lint_tests()`
+- **CLI argument handling**: `run_cli_tests()`
+- **Multi-command workflows**: `run_integration_tests()`
+- **Configuration**: `run_config_tests()`
+- **Health checks**: `run_check_tests()`
+
+### Step 2: Use the `run_test` Function
+
+```bash
+run_test NUM "Test name" "command" "expected_pattern" [expect_fail]
+```
+
+**Parameters**:
+
+- `NUM`: Test number (increment from existing tests)
+- `"Test name"`: Human-readable description
+- `"command"`: Command to execute (use `$TEMP_DIR` for fixtures)
+- `"expected_pattern"`: Regex pattern to match in output
+- `expect_fail`: Optional, set to `"true"` if expecting non-zero exit
+
+### Step 3: Add Test Fixtures (if needed)
+
+Add fixtures to `setup_temp_fixtures()`:
+
+```bash
+setup_temp_fixtures() {
+  # ... existing fixtures ...
+
+  # Add your fixture
+  cat > "$TEMP_DIR/my-fixture.ts" << 'EOF'
+// tldr ::: fixture for testing XYZ
+// todo ::: test waymark
+export const x = 1;
+EOF
+}
+```
+
+### Example: Adding a New Parse Test
+
+```bash
+run_parse_tests() {
+  # ... existing tests ...
+
+  # Add new test
+  run_test 6 "Parse waymark with multiple tags" \
+    "echo '// todo ::: implement #perf #security' | wm lint -" \
+    "no issues|0 issues" \
+    false
+}
+```
+
+### Example: Adding an Expected Failure Test
+
+```bash
+run_lint_tests() {
+  # ... existing tests ...
+
+  # Test that detects a specific error
+  run_test 6 "Detect duplicate property" \
+    "wm lint '$TEMP_DIR/duplicate-prop.ts'" \
+    "duplicate.*property|same key" \
+    true  # Expect non-zero exit
+}
+```
+
+## Exit Code Reference
+
+| Code | Meaning | When |
+|------|---------|------|
+| 0 | Success | All tests passed |
+| 1 | Failure | One or more tests failed |
+| 2 | Setup Error | CLI not found, invalid category |
+
+## Debugging Failures
+
+1. **Check the debug log**: Full command output is captured in the `-debug.log` file
+
+2. **Run command manually**: Copy the command from the debug log and run it directly
+
+3. **Check fixtures**: Ensure test fixtures are created correctly in `setup_temp_fixtures()`
+
+4. **Verify pattern**: The `expected_pattern` is a regex - test it with `grep -E`
+
+### Common Issues
+
+**"wm not found"**:
+
+```bash
+bun install && bun install:bin
+# Or for development:
+bun dev:cli
+```
+
+**Pattern not matching**:
+
+- Check debug log for actual output
+- Use `|` for alternatives: `"pattern1|pattern2"`
+- Escape special regex chars: `\.` `\[` `\]`
+
+**Fixture file issues**:
+
+- Fixtures are created in a temp directory per run
+- Check `$TEMP_DIR` path in debug log
+- Fixtures are cleaned up after each category
+
+## CI Integration
+
+Add to `package.json`:
+
+```json
+{
+  "scripts": {
+    "test:cli": "./.claude/scripts/run-tests.sh --all"
+  }
+}
+```
+
+Run in CI:
+
+```bash
+bun install
+bun install:bin
+bun test:cli
+```
+
+## Test Assertion Patterns
+
+### Success with Pattern Match
+
+```bash
+run_test 1 "Description" "wm command" "expected.*output" false
+```
+
+- Expects exit code 0
+- Expects output to match pattern
+- PASS if both conditions met
+- WARN if exit 0 but pattern not found
+
+### Expected Failure
+
+```bash
+run_test 2 "Description" "wm invalid-command" "error|invalid" true
+```
+
+- Expects non-zero exit code
+- Expects output to match error pattern
+- PASS if both conditions met
+- FAIL if exit code is 0
+
+### Multi-Command Workflow
+
+```bash
+run_test 3 "Workflow" "wm fmt file.ts --write && wm lint file.ts" "no issues" false
+```
+
+- Commands chained with `&&`
+- Uses `eval` internally to handle complex commands
+- Check both commands succeeded and final output matches

--- a/package.json
+++ b/package.json
@@ -34,7 +34,11 @@
     "dev:cli": "turbo run dev --filter=@waymarks/cli",
     "build:core": "turbo run build --filter=@waymarks/core",
     "build:cli": "turbo run build --filter=@waymarks/cli",
-    "prepare": "lefthook install"
+    "prepare": "lefthook install",
+    "test:cli": "./.claude/scripts/run-tests.sh --all",
+    "test:cli:parse": "./.claude/scripts/run-tests.sh parse",
+    "test:cli:scan": "./.claude/scripts/run-tests.sh scan",
+    "clean:test": "rm -rf .scratch/testing"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.2.4",


### PR DESCRIPTION
## Summary

Implements command + skill + script pattern for CLI integration testing.

## Files Created

- `.claude/commands/ops/test/cli.md`: Command definition with allowed-tools
- `.claude/scripts/run-tests.sh`: Test runner entry point
- `.claude/scripts/lib/test-runner-lib.sh`: Shared test library (35 tests, 8 categories)
- `.claude/skills/cli-testing/SKILL.md`: Skill documentation

## Test Categories

| Category | Tests | What It Validates |
|----------|-------|-------------------|
| parse | 5 | Grammar parsing (signals, properties) |
| scan | 5 | `wm find` filtering, JSON/JSONL output |
| format | 4 | `wm fmt` formatting, idempotence |
| lint | 5 | Rule enforcement, codetag detection |
| cli | 5 | Help, version, exit codes |
| integration | 5 | End-to-end workflows |
| config | 3 | Config precedence |
| check | 3 | `wm doctor` health checks |

## Usage

```bash
# Run all tests
bun run test:cli

# Run specific category
./.claude/scripts/run-tests.sh parse

# Via Claude command
/ops:test:cli --all
```

## Test Plan

- [x] All 35 tests pass
- [x] Markdown reports generate to `.scratch/testing/`
- [x] Exit codes work as documented (0=pass, 1=fail, 2=setup error)

Closes #234

---
🤖 Generated with [Claude Code](https://claude.com/code)