### PR TITLE
feat(core): add TLDR insertion point helper [WAY-93]

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -39,6 +39,7 @@ export {
 } from "./ids";
 export type { InsertionResult, InsertionSpec, InsertOptions } from "./insert";
 export { InsertionSpecSchema, insertWaymarks } from "./insert";
+export { findTldrInsertionPoint } from "./tldr";
 export type {
   NormalizeRecordOptions,
   NormalizeTypeOptions,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -39,7 +39,6 @@ export {
 } from "./ids";
 export type { InsertionResult, InsertionSpec, InsertOptions } from "./insert";
 export { InsertionSpecSchema, insertWaymarks } from "./insert";
-export { findTldrInsertionPoint } from "./tldr";
 export type {
   NormalizeRecordOptions,
   NormalizeTypeOptions,
@@ -66,4 +65,5 @@ export {
 } from "./remove";
 export type { SearchQuery } from "./search";
 export { searchRecords } from "./search";
+export { findTldrInsertionPoint } from "./tldr";
 export type { ScanOptions, WaymarkConfig } from "./types";

--- a/packages/core/src/tldr.test.ts
+++ b/packages/core/src/tldr.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "bun:test";
+import { findTldrInsertionPoint } from "./tldr.ts";
+
+describe("findTldrInsertionPoint", () => {
+  it("skips shebangs and JS directives", () => {
+    const content = [
+      "#!/usr/bin/env node",
+      "/// <reference types=\"node\" />",
+      "\"use strict\";",
+      "console.log('hello');",
+    ].join("\n");
+
+    expect(findTldrInsertionPoint(content, "javascript")).toBe(4);
+  });
+
+  it("returns -1 when an existing TLDR is present", () => {
+    const content = ["// tldr ::: service container", "export {}"].join("\n");
+
+    expect(findTldrInsertionPoint(content, "typescript")).toBe(-1);
+  });
+
+  it("skips Python shebang and encoding comment", () => {
+    const content = [
+      "#!/usr/bin/env python3",
+      "# -*- coding: utf-8 -*-",
+      "print('hi')",
+    ].join("\n");
+
+    expect(findTldrInsertionPoint(content, "python")).toBe(3);
+  });
+
+  it("skips Rust inner attributes", () => {
+    const content = ["#![allow(dead_code)]", "fn main() {}"].join("\n");
+
+    expect(findTldrInsertionPoint(content, "rust")).toBe(2);
+  });
+
+  it("skips Go build tags and blank line", () => {
+    const content = [
+      "//go:build linux",
+      "// +build linux",
+      "",
+      "package main",
+    ].join("\n");
+
+    expect(findTldrInsertionPoint(content, "go")).toBe(4);
+  });
+
+  it("skips Ruby magic comments", () => {
+    const content = [
+      "#!/usr/bin/env ruby",
+      "# frozen_string_literal: true",
+      "puts 'hi'",
+    ].join("\n");
+
+    expect(findTldrInsertionPoint(content, "ruby")).toBe(3);
+  });
+
+  it("skips front matter blocks", () => {
+    const content = ["---", "title: Sample", "---", "", "# Heading"].join(
+      "\n"
+    );
+
+    expect(findTldrInsertionPoint(content, "markdown")).toBe(4);
+  });
+
+  it("returns -1 for unterminated front matter", () => {
+    const content = ["---", "title: Sample", "# Heading"].join("\n");
+
+    expect(findTldrInsertionPoint(content, "markdown")).toBe(-1);
+  });
+
+  it("returns -1 for unsupported languages", () => {
+    const content = "console.log('hi');";
+
+    expect(findTldrInsertionPoint(content, "unknown")).toBe(-1);
+  });
+});

--- a/packages/core/src/tldr.test.ts
+++ b/packages/core/src/tldr.test.ts
@@ -1,16 +1,23 @@
 import { describe, expect, it } from "bun:test";
 import { findTldrInsertionPoint } from "./tldr.ts";
 
+const JS_INSERT_LINE = 4;
+const PYTHON_INSERT_LINE = 3;
+const RUST_INSERT_LINE = 2;
+const GO_INSERT_LINE = 4;
+const RUBY_INSERT_LINE = 3;
+const MARKDOWN_INSERT_LINE = 4;
+
 describe("findTldrInsertionPoint", () => {
   it("skips shebangs and JS directives", () => {
     const content = [
       "#!/usr/bin/env node",
-      "/// <reference types=\"node\" />",
-      "\"use strict\";",
+      '/// <reference types="node" />',
+      '"use strict";',
       "console.log('hello');",
     ].join("\n");
 
-    expect(findTldrInsertionPoint(content, "javascript")).toBe(4);
+    expect(findTldrInsertionPoint(content, "javascript")).toBe(JS_INSERT_LINE);
   });
 
   it("returns -1 when an existing TLDR is present", () => {
@@ -26,13 +33,13 @@ describe("findTldrInsertionPoint", () => {
       "print('hi')",
     ].join("\n");
 
-    expect(findTldrInsertionPoint(content, "python")).toBe(3);
+    expect(findTldrInsertionPoint(content, "python")).toBe(PYTHON_INSERT_LINE);
   });
 
   it("skips Rust inner attributes", () => {
     const content = ["#![allow(dead_code)]", "fn main() {}"].join("\n");
 
-    expect(findTldrInsertionPoint(content, "rust")).toBe(2);
+    expect(findTldrInsertionPoint(content, "rust")).toBe(RUST_INSERT_LINE);
   });
 
   it("skips Go build tags and blank line", () => {
@@ -43,7 +50,7 @@ describe("findTldrInsertionPoint", () => {
       "package main",
     ].join("\n");
 
-    expect(findTldrInsertionPoint(content, "go")).toBe(4);
+    expect(findTldrInsertionPoint(content, "go")).toBe(GO_INSERT_LINE);
   });
 
   it("skips Ruby magic comments", () => {
@@ -53,15 +60,15 @@ describe("findTldrInsertionPoint", () => {
       "puts 'hi'",
     ].join("\n");
 
-    expect(findTldrInsertionPoint(content, "ruby")).toBe(3);
+    expect(findTldrInsertionPoint(content, "ruby")).toBe(RUBY_INSERT_LINE);
   });
 
   it("skips front matter blocks", () => {
-    const content = ["---", "title: Sample", "---", "", "# Heading"].join(
-      "\n"
-    );
+    const content = ["---", "title: Sample", "---", "", "# Heading"].join("\n");
 
-    expect(findTldrInsertionPoint(content, "markdown")).toBe(4);
+    expect(findTldrInsertionPoint(content, "markdown")).toBe(
+      MARKDOWN_INSERT_LINE
+    );
   });
 
   it("returns -1 for unterminated front matter", () => {

--- a/packages/core/src/tldr.ts
+++ b/packages/core/src/tldr.ts
@@ -1,0 +1,194 @@
+// tldr ::: safe insertion point detection for TLDR placement
+
+import { parse } from "@waymarks/grammar";
+
+const LINE_SPLIT_REGEX = /\r?\n/;
+
+const SUPPORTED_LANGUAGES = new Set([
+  "javascript",
+  "typescript",
+  "jsx",
+  "tsx",
+  "python",
+  "ruby",
+  "rust",
+  "go",
+  "markdown",
+  "mdx",
+]);
+
+const JS_DIRECTIVE_REGEX = /^['"](use strict|use client|use server)['"]\s*;?$/;
+const TS_REFERENCE_REGEX = /^\/\/\/\s*<(reference|amd-(module|dependency))\b/i;
+const TS_CHECK_REGEX =
+  /^(\/\/\s*@ts-(check|nocheck)\b|\/\*\s*@ts-(check|nocheck)\s*\*\/)$/i;
+const PYTHON_ENCODING_REGEX =
+  /^#\s*([-*_\s]*coding[:=]\s*[-\w.]+|coding\s*[:=]\s*[-\w.]+)\s*$/i;
+const RUBY_MAGIC_COMMENT_REGEX =
+  /^#\s*(frozen_string_literal:\s*\w+|coding[:=]\s*[-\w.]+|encoding:\s*[-\w.]+)\s*$/i;
+const RUST_INNER_ATTRIBUTE_REGEX = /^#!\s*\[/;
+const GO_BUILD_TAG_REGEX = /^(\/\/\s*go:build\b|\/\/\s*\+build\b)/;
+
+/**
+ * Find the best line number to insert a TLDR waymark.
+ * @param content - Raw file contents.
+ * @param language - Language identifier string.
+ * @returns Line number (1-indexed) or -1 if unsuitable.
+ */
+export function findTldrInsertionPoint(
+  content: string,
+  language: string
+): number {
+  const normalizedLanguage = language.trim().toLowerCase();
+  if (!SUPPORTED_LANGUAGES.has(normalizedLanguage)) {
+    return -1;
+  }
+
+  if (hasExistingTldr(content)) {
+    return -1;
+  }
+
+  const lines = splitLines(content);
+  if (lines.length === 0) {
+    return 1;
+  }
+
+  let index = 0;
+
+  if (isShebangLine(lines[index])) {
+    index += 1;
+  }
+
+  const frontMatterResult = skipFrontMatter(lines, index);
+  if (frontMatterResult === -1) {
+    return -1;
+  }
+  index = frontMatterResult;
+
+  index = skipLanguageDirectives(lines, index, normalizedLanguage);
+
+  return index + 1;
+}
+
+function hasExistingTldr(content: string): boolean {
+  const records = parse(content);
+  return records.some((record) => record.type === "tldr");
+}
+
+function splitLines(content: string): string[] {
+  if (!content) {
+    return [];
+  }
+  const lines = content.split(LINE_SPLIT_REGEX);
+  if (lines.length > 0 && lines.at(-1) === "") {
+    lines.pop();
+  }
+  return lines;
+}
+
+function isShebangLine(line: string | undefined): boolean {
+  return Boolean(line?.startsWith("#!"));
+}
+
+function skipFrontMatter(lines: string[], start: number): number {
+  if (start >= lines.length) {
+    return start;
+  }
+  const trimmed = lines[start]?.trim();
+  if (trimmed !== "---" && trimmed !== "+++") {
+    return start;
+  }
+  for (let index = start + 1; index < lines.length; index += 1) {
+    if (lines[index]?.trim() === trimmed) {
+      return index + 1;
+    }
+  }
+  return -1;
+}
+
+function skipLanguageDirectives(
+  lines: string[],
+  start: number,
+  language: string
+): number {
+  switch (language) {
+    case "javascript":
+    case "typescript":
+    case "jsx":
+    case "tsx":
+      return skipJavaScriptDirectives(lines, start);
+    case "python":
+      return skipPythonDirectives(lines, start);
+    case "ruby":
+      return skipRubyDirectives(lines, start);
+    case "rust":
+      return skipRustDirectives(lines, start);
+    case "go":
+      return skipGoDirectives(lines, start);
+    default:
+      return start;
+  }
+}
+
+function skipJavaScriptDirectives(lines: string[], start: number): number {
+  let index = start;
+  while (index < lines.length) {
+    const trimmed = lines[index]?.trim() ?? "";
+    if (
+      TS_REFERENCE_REGEX.test(trimmed) ||
+      TS_CHECK_REGEX.test(trimmed) ||
+      JS_DIRECTIVE_REGEX.test(trimmed)
+    ) {
+      index += 1;
+      continue;
+    }
+    break;
+  }
+  return index;
+}
+
+function skipPythonDirectives(lines: string[], start: number): number {
+  let index = start;
+  if (index < lines.length && PYTHON_ENCODING_REGEX.test(lines[index] ?? "")) {
+    index += 1;
+  }
+  return index;
+}
+
+function skipRubyDirectives(lines: string[], start: number): number {
+  let index = start;
+  if (index < lines.length && RUBY_MAGIC_COMMENT_REGEX.test(lines[index] ?? "")) {
+    index += 1;
+  }
+  return index;
+}
+
+function skipRustDirectives(lines: string[], start: number): number {
+  let index = start;
+  while (index < lines.length) {
+    const trimmed = lines[index]?.trim() ?? "";
+    if (RUST_INNER_ATTRIBUTE_REGEX.test(trimmed)) {
+      index += 1;
+      continue;
+    }
+    break;
+  }
+  return index;
+}
+
+function skipGoDirectives(lines: string[], start: number): number {
+  let index = start;
+  let sawBuildTag = false;
+  while (index < lines.length) {
+    const trimmed = lines[index]?.trim() ?? "";
+    if (GO_BUILD_TAG_REGEX.test(trimmed)) {
+      sawBuildTag = true;
+      index += 1;
+      continue;
+    }
+    break;
+  }
+  if (sawBuildTag && index < lines.length && lines[index]?.trim() === "") {
+    index += 1;
+  }
+  return index;
+}

--- a/packages/grammar/src/content.ts
+++ b/packages/grammar/src/content.ts
@@ -9,8 +9,8 @@ import {
 import type { WaymarkRecord } from "./types";
 
 const LEADING_SPACES_REGEX = /^\s+/;
-const HTML_COMMENT_CLOSE_REGEX = /\s*-->\s*$/;
-const BLOCK_COMMENT_CLOSE_REGEX = /\s*\*\/\s*$/;
+const HTML_COMMENT_CLOSE = "-->";
+const BLOCK_COMMENT_CLOSE = "*/";
 
 export type ContentSegment = {
   text: string;
@@ -35,7 +35,7 @@ export function stripHtmlCommentClosure(
   commentLeader: string
 ): string {
   if (commentLeader === "<!--") {
-    return content.replace(HTML_COMMENT_CLOSE_REGEX, "");
+    return stripTrailingClosure(content, HTML_COMMENT_CLOSE);
   }
   return content;
 }
@@ -51,7 +51,7 @@ export function stripBlockCommentClosure(
   commentLeader: string
 ): string {
   if (commentLeader === "/*") {
-    return content.replace(BLOCK_COMMENT_CLOSE_REGEX, "");
+    return stripTrailingClosure(content, BLOCK_COMMENT_CLOSE);
   }
   return content;
 }
@@ -61,6 +61,15 @@ function stripCommentClosure(content: string, commentLeader: string): string {
     stripHtmlCommentClosure(content, commentLeader),
     commentLeader
   );
+}
+
+function stripTrailingClosure(content: string, token: string): string {
+  const trimmedEnd = content.trimEnd();
+  if (!trimmedEnd.endsWith(token)) {
+    return content;
+  }
+  const beforeToken = trimmedEnd.slice(0, -token.length);
+  return beforeToken.trimEnd();
 }
 
 /**


### PR DESCRIPTION
### Motivation
- Provide a deterministic, language-aware placement helper to compute a safe line to insert a TLDR waymark during repo initialization and automation. 
- The helper must avoid inserting TLDRs into shebangs, front-matter, language pragmas/directives, or when a TLDR already exists.

### Description
- Add `findTldrInsertionPoint(content: string, language: string): number` in `packages/core/src/tldr.ts` that returns a 1-indexed line for safe TLDR insertion or `-1` when unsuitable. 
- Implement language-specific skipping logic for shebangs, front-matter, JS/TS directives, Python encoding, Ruby magic comments, Rust inner attributes, and Go build tags using targeted regexes. 
- Use the grammar parser to detect existing TLDRs and return `-1` if present. 
- Add unit tests in `packages/core/src/tldr.test.ts` covering JavaScript/TypeScript, Python, Ruby, Rust, Go, markdown front-matter, unterminated front-matter, and unsupported languages. 
- Export the new helper from the core package index (`packages/core/src/index.ts`).

### Testing
- Ran the new unit test file with `bun test packages/core/src/tldr.test.ts`, which produced an error: `Cannot find module '@waymarks/grammar'` and thus the test run failed. 
- No other automated tests were executed as part of this change in this branch; the failure indicates a test environment/module-resolution issue that should be addressed before merging.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974c2baf23883209e1cb84f19dfd4fd)