### PR TITLE
docs(core): document cache row type [WAY-95]

### DIFF
--- a/packages/core/src/cache/serialization.ts
+++ b/packages/core/src/cache/serialization.ts
@@ -2,6 +2,7 @@
 
 import type { WaymarkRecord } from "@waymarks/grammar";
 
+/** Serialized cache row representation of a waymark record. */
 export type WaymarkRow = {
   filePath: string;
   startLine: number;


### PR DESCRIPTION
## Summary
- document Waymark cache row type to complete core public TSDoc coverage

## Testing
- bun scripts/typedoc-check.ts core
- turbo run lint
- bun run lint:md
- turbo run typecheck
- turbo run test
