### PR TITLE
feat(grammar): add language registry with comment capability defaults [WAY-96]

### DIFF
--- a/packages/grammar/src/index.ts
+++ b/packages/grammar/src/index.ts
@@ -17,6 +17,13 @@ export type {
   DocstringKind,
 } from "./docstrings";
 export { detectDocstring, extractSummary } from "./docstrings";
+export type { CommentCapability, LanguageRegistry } from "./languages";
+export {
+  canHaveComments,
+  DEFAULT_LANGUAGE_REGISTRY,
+  getCommentCapability,
+  getLanguageId,
+} from "./languages";
 export { isValidType, parse, parseLine } from "./parser";
 export {
   MENTION_REGEX,

--- a/packages/grammar/src/languages.test.ts
+++ b/packages/grammar/src/languages.test.ts
@@ -536,4 +536,58 @@ describe("custom registry support", () => {
     expect(cap?.language).toBe("custom-typescript");
     expect(cap?.leaders).toEqual(["###"]);
   });
+
+  test(".d.mts uses .mts mapping when available in custom registry", () => {
+    const customRegistry = {
+      byExtension: new Map([
+        [".mts", { language: "custom-mts", leaders: ["//"] as const }],
+        [".ts", { language: "custom-ts", leaders: ["//"] as const }],
+      ]),
+      byBasename: new Map(),
+    };
+
+    const cap = getCommentCapability("types.d.mts", customRegistry);
+    expect(cap).toBeDefined();
+    expect(cap?.language).toBe("custom-mts");
+  });
+
+  test(".d.cts uses .cts mapping when available in custom registry", () => {
+    const customRegistry = {
+      byExtension: new Map([
+        [".cts", { language: "custom-cts", leaders: ["//"] as const }],
+        [".ts", { language: "custom-ts", leaders: ["//"] as const }],
+      ]),
+      byBasename: new Map(),
+    };
+
+    const cap = getCommentCapability("types.d.cts", customRegistry);
+    expect(cap).toBeDefined();
+    expect(cap?.language).toBe("custom-cts");
+  });
+
+  test(".d.mts falls back to .ts when .mts not in registry", () => {
+    const customRegistry = {
+      byExtension: new Map([
+        [".ts", { language: "custom-ts", leaders: ["//"] as const }],
+      ]),
+      byBasename: new Map(),
+    };
+
+    const cap = getCommentCapability("types.d.mts", customRegistry);
+    expect(cap).toBeDefined();
+    expect(cap?.language).toBe("custom-ts");
+  });
+
+  test(".d.cts falls back to .ts when .cts not in registry", () => {
+    const customRegistry = {
+      byExtension: new Map([
+        [".ts", { language: "custom-ts", leaders: ["//"] as const }],
+      ]),
+      byBasename: new Map(),
+    };
+
+    const cap = getCommentCapability("types.d.cts", customRegistry);
+    expect(cap).toBeDefined();
+    expect(cap?.language).toBe("custom-ts");
+  });
 });

--- a/packages/grammar/src/languages.test.ts
+++ b/packages/grammar/src/languages.test.ts
@@ -1,0 +1,539 @@
+// tldr ::: unit tests for language registry and comment capability detection
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  canHaveComments,
+  DEFAULT_LANGUAGE_REGISTRY,
+  getCommentCapability,
+  getLanguageId,
+} from "./languages";
+
+describe("getCommentCapability", () => {
+  describe("C-style comments (// and /*)", () => {
+    test("returns capability for TypeScript files", () => {
+      const cap = getCommentCapability("src/index.ts");
+      expect(cap).toBeDefined();
+      expect(cap?.language).toBe("typescript");
+      expect(cap?.leaders).toContain("//");
+      expect(cap?.leaders).toContain("/*");
+    });
+
+    test("returns capability for JavaScript files", () => {
+      const cap = getCommentCapability("lib/utils.js");
+      expect(cap).toBeDefined();
+      expect(cap?.language).toBe("javascript");
+      expect(cap?.leaders).toContain("//");
+    });
+
+    test("returns capability for Go files", () => {
+      const cap = getCommentCapability("main.go");
+      expect(cap).toBeDefined();
+      expect(cap?.language).toBe("go");
+      expect(cap?.leaders).toContain("//");
+    });
+
+    test("returns capability for Rust files", () => {
+      const cap = getCommentCapability("src/lib.rs");
+      expect(cap).toBeDefined();
+      expect(cap?.language).toBe("rust");
+      expect(cap?.leaders).toContain("//");
+    });
+
+    test("returns capability for Java files", () => {
+      const cap = getCommentCapability("App.java");
+      expect(cap).toBeDefined();
+      expect(cap?.language).toBe("java");
+      expect(cap?.leaders).toContain("//");
+    });
+
+    test("returns capability for JSONC files", () => {
+      const cap = getCommentCapability("tsconfig.jsonc");
+      expect(cap).toBeDefined();
+      expect(cap?.language).toBe("jsonc");
+      expect(cap?.leaders).toContain("//");
+    });
+
+    test("returns capability for JSON5 files", () => {
+      const cap = getCommentCapability("config.json5");
+      expect(cap).toBeDefined();
+      expect(cap?.language).toBe("json5");
+      expect(cap?.leaders).toContain("//");
+    });
+  });
+
+  describe("Hash comments (#)", () => {
+    test("returns capability for Python files", () => {
+      const cap = getCommentCapability("script.py");
+      expect(cap).toBeDefined();
+      expect(cap?.language).toBe("python");
+      expect(cap?.leaders).toEqual(["#"]);
+    });
+
+    test("returns capability for Ruby files", () => {
+      const cap = getCommentCapability("app.rb");
+      expect(cap).toBeDefined();
+      expect(cap?.language).toBe("ruby");
+      expect(cap?.leaders).toEqual(["#"]);
+    });
+
+    test("returns capability for shell scripts", () => {
+      const cap = getCommentCapability("deploy.sh");
+      expect(cap).toBeDefined();
+      expect(cap?.language).toBe("shell");
+      expect(cap?.leaders).toEqual(["#"]);
+    });
+
+    test("returns capability for YAML files", () => {
+      const cap = getCommentCapability("config.yaml");
+      expect(cap).toBeDefined();
+      expect(cap?.language).toBe("yaml");
+      expect(cap?.leaders).toEqual(["#"]);
+    });
+
+    test("returns capability for TOML files", () => {
+      const cap = getCommentCapability("Cargo.toml");
+      expect(cap).toBeDefined();
+      expect(cap?.language).toBe("toml");
+      expect(cap?.leaders).toEqual(["#"]);
+    });
+  });
+
+  describe("SQL-style comments (--)", () => {
+    test("returns capability for SQL files", () => {
+      const cap = getCommentCapability("schema.sql");
+      expect(cap).toBeDefined();
+      expect(cap?.language).toBe("sql");
+      expect(cap?.leaders).toEqual(["--"]);
+    });
+
+    test("returns capability for Lua files", () => {
+      const cap = getCommentCapability("init.lua");
+      expect(cap).toBeDefined();
+      expect(cap?.language).toBe("lua");
+      expect(cap?.leaders).toEqual(["--"]);
+    });
+
+    test("returns capability for Haskell files", () => {
+      const cap = getCommentCapability("Main.hs");
+      expect(cap).toBeDefined();
+      expect(cap?.language).toBe("haskell");
+      expect(cap?.leaders).toEqual(["--"]);
+    });
+  });
+
+  describe("HTML-style comments (<!--)", () => {
+    test("returns capability for Markdown files", () => {
+      const cap = getCommentCapability("README.md");
+      expect(cap).toBeDefined();
+      expect(cap?.language).toBe("markdown");
+      expect(cap?.leaders).toEqual(["<!--"]);
+    });
+
+    test("returns capability for HTML files", () => {
+      const cap = getCommentCapability("index.html");
+      expect(cap).toBeDefined();
+      expect(cap?.language).toBe("html");
+      expect(cap?.leaders).toEqual(["<!--"]);
+    });
+
+    test("returns capability for XML files", () => {
+      const cap = getCommentCapability("config.xml");
+      expect(cap).toBeDefined();
+      expect(cap?.language).toBe("xml");
+      expect(cap?.leaders).toEqual(["<!--"]);
+    });
+
+    test("returns capability for SVG files", () => {
+      const cap = getCommentCapability("icon.svg");
+      expect(cap).toBeDefined();
+      expect(cap?.language).toBe("svg");
+      expect(cap?.leaders).toEqual(["<!--"]);
+    });
+  });
+
+  describe("CSS files (/* only)", () => {
+    test("returns capability for CSS files", () => {
+      const cap = getCommentCapability("styles.css");
+      expect(cap).toBeDefined();
+      expect(cap?.language).toBe("css");
+      expect(cap?.leaders).toEqual(["/*"]);
+    });
+
+    test("returns capability for SCSS files with both styles", () => {
+      const cap = getCommentCapability("styles.scss");
+      expect(cap).toBeDefined();
+      expect(cap?.language).toBe("scss");
+      expect(cap?.leaders).toContain("//");
+      expect(cap?.leaders).toContain("/*");
+    });
+  });
+
+  describe("files without comment support", () => {
+    test("returns empty leaders for JSON files", () => {
+      const cap = getCommentCapability("package.json");
+      expect(cap).toBeDefined();
+      expect(cap?.language).toBe("json");
+      expect(cap?.leaders).toEqual([]);
+    });
+
+    test("returns empty leaders for CSV files", () => {
+      const cap = getCommentCapability("data.csv");
+      expect(cap).toBeDefined();
+      expect(cap?.language).toBe("data");
+      expect(cap?.leaders).toEqual([]);
+    });
+
+    test("returns empty leaders for TSV files", () => {
+      const cap = getCommentCapability("data.tsv");
+      expect(cap).toBeDefined();
+      expect(cap?.leaders).toEqual([]);
+    });
+
+    test("returns empty leaders for Parquet files", () => {
+      const cap = getCommentCapability("data.parquet");
+      expect(cap).toBeDefined();
+      expect(cap?.leaders).toEqual([]);
+    });
+
+    test("returns empty leaders for lock files", () => {
+      const cap = getCommentCapability("deps.lock");
+      expect(cap).toBeDefined();
+      expect(cap?.leaders).toEqual([]);
+    });
+
+    test("returns empty leaders for bun.lockb", () => {
+      const cap = getCommentCapability("bun.lockb");
+      expect(cap).toBeDefined();
+      expect(cap?.leaders).toEqual([]);
+    });
+  });
+
+  describe("basename matching", () => {
+    test("matches Dockerfile", () => {
+      const cap = getCommentCapability("Dockerfile");
+      expect(cap).toBeDefined();
+      expect(cap?.language).toBe("dockerfile");
+      expect(cap?.leaders).toEqual(["#"]);
+    });
+
+    test("matches Dockerfile in path", () => {
+      const cap = getCommentCapability("docker/Dockerfile");
+      expect(cap).toBeDefined();
+      expect(cap?.language).toBe("dockerfile");
+    });
+
+    test("matches Makefile", () => {
+      const cap = getCommentCapability("Makefile");
+      expect(cap).toBeDefined();
+      expect(cap?.language).toBe("makefile");
+      expect(cap?.leaders).toEqual(["#"]);
+    });
+
+    test("matches Jenkinsfile", () => {
+      const cap = getCommentCapability("Jenkinsfile");
+      expect(cap).toBeDefined();
+      expect(cap?.language).toBe("groovy");
+      expect(cap?.leaders).toContain("//");
+    });
+
+    test("matches .gitignore", () => {
+      const cap = getCommentCapability(".gitignore");
+      expect(cap).toBeDefined();
+      expect(cap?.language).toBe("gitignore");
+      expect(cap?.leaders).toEqual(["#"]);
+    });
+
+    test("matches .env", () => {
+      const cap = getCommentCapability(".env");
+      expect(cap).toBeDefined();
+      expect(cap?.language).toBe("dotenv");
+      expect(cap?.leaders).toEqual(["#"]);
+    });
+
+    test("matches .env.local", () => {
+      const cap = getCommentCapability(".env.local");
+      expect(cap).toBeDefined();
+      expect(cap?.language).toBe("dotenv");
+    });
+
+    test("matches package-lock.json as no comments", () => {
+      const cap = getCommentCapability("package-lock.json");
+      expect(cap).toBeDefined();
+      expect(cap?.language).toBe("json");
+      expect(cap?.leaders).toEqual([]);
+    });
+
+    test("matches .bashrc", () => {
+      const cap = getCommentCapability(".bashrc");
+      expect(cap).toBeDefined();
+      expect(cap?.language).toBe("bash");
+      expect(cap?.leaders).toEqual(["#"]);
+    });
+
+    test("matches Gemfile", () => {
+      const cap = getCommentCapability("Gemfile");
+      expect(cap).toBeDefined();
+      expect(cap?.language).toBe("ruby");
+    });
+  });
+
+  describe("unknown extensions", () => {
+    test("returns undefined for unknown extension", () => {
+      const cap = getCommentCapability("mystery.xyz");
+      expect(cap).toBeUndefined();
+    });
+
+    test("returns undefined for extensionless files not in basename map", () => {
+      const cap = getCommentCapability("unknownfile");
+      expect(cap).toBeUndefined();
+    });
+
+    test("returns undefined for made-up extensions", () => {
+      const cap = getCommentCapability("file.asdfghjkl");
+      expect(cap).toBeUndefined();
+    });
+  });
+
+  describe("case sensitivity", () => {
+    test("handles uppercase extensions", () => {
+      const cap = getCommentCapability("README.MD");
+      expect(cap).toBeDefined();
+      expect(cap?.language).toBe("markdown");
+    });
+
+    test("handles mixed case extensions", () => {
+      const cap = getCommentCapability("script.Py");
+      expect(cap).toBeDefined();
+      expect(cap?.language).toBe("python");
+    });
+
+    test("handles uppercase JSON", () => {
+      const cap = getCommentCapability("data.JSON");
+      expect(cap).toBeDefined();
+      expect(cap?.language).toBe("json");
+      expect(cap?.leaders).toEqual([]);
+    });
+
+    test("handles mixed case TypeScript", () => {
+      const cap = getCommentCapability("index.Ts");
+      expect(cap).toBeDefined();
+      expect(cap?.language).toBe("typescript");
+    });
+
+    // Basenames are case-sensitive (Dockerfile != dockerfile)
+    test("basename matching is case-sensitive", () => {
+      const cap = getCommentCapability("dockerfile");
+      // Should fall through to extension check, which returns undefined
+      expect(cap).toBeUndefined();
+    });
+  });
+
+  describe("edge cases", () => {
+    test("handles .d.ts declaration files", () => {
+      const cap = getCommentCapability("types.d.ts");
+      expect(cap).toBeDefined();
+      expect(cap?.language).toBe("typescript");
+      expect(cap?.leaders).toContain("//");
+    });
+
+    test("handles .d.tsx declaration files", () => {
+      const cap = getCommentCapability("components.d.tsx");
+      expect(cap).toBeDefined();
+      expect(cap?.language).toBe("tsx");
+    });
+
+    test("handles .d.mts declaration files", () => {
+      const cap = getCommentCapability("module.d.mts");
+      expect(cap).toBeDefined();
+      expect(cap?.language).toBe("typescript");
+    });
+
+    test("handles .d.cts declaration files", () => {
+      const cap = getCommentCapability("common.d.cts");
+      expect(cap).toBeDefined();
+      expect(cap?.language).toBe("typescript");
+    });
+
+    test("handles paths with directories", () => {
+      const cap = getCommentCapability(
+        "/Users/dev/project/src/utils/helpers.ts"
+      );
+      expect(cap).toBeDefined();
+      expect(cap?.language).toBe("typescript");
+    });
+
+    test("handles relative paths", () => {
+      const cap = getCommentCapability("./src/index.ts");
+      expect(cap).toBeDefined();
+      expect(cap?.language).toBe("typescript");
+    });
+
+    test("handles files with multiple dots", () => {
+      const cap = getCommentCapability("app.config.ts");
+      expect(cap).toBeDefined();
+      expect(cap?.language).toBe("typescript");
+    });
+
+    test("handles .test.ts as TypeScript", () => {
+      const cap = getCommentCapability("utils.test.ts");
+      expect(cap).toBeDefined();
+      expect(cap?.language).toBe("typescript");
+    });
+
+    test("handles .spec.js as JavaScript", () => {
+      const cap = getCommentCapability("component.spec.js");
+      expect(cap).toBeDefined();
+      expect(cap?.language).toBe("javascript");
+    });
+  });
+});
+
+describe("canHaveComments", () => {
+  test("returns true for TypeScript files", () => {
+    expect(canHaveComments("index.ts")).toBe(true);
+  });
+
+  test("returns true for Python files", () => {
+    expect(canHaveComments("script.py")).toBe(true);
+  });
+
+  test("returns true for Markdown files", () => {
+    expect(canHaveComments("README.md")).toBe(true);
+  });
+
+  test("returns false for JSON files (known, no comments)", () => {
+    expect(canHaveComments("package.json")).toBe(false);
+  });
+
+  test("returns false for CSV files (known, no comments)", () => {
+    expect(canHaveComments("data.csv")).toBe(false);
+  });
+
+  test("returns undefined for unknown extensions", () => {
+    expect(canHaveComments("mystery.xyz")).toBeUndefined();
+  });
+
+  test("returns true for Dockerfile (basename)", () => {
+    expect(canHaveComments("Dockerfile")).toBe(true);
+  });
+
+  test("returns false for package-lock.json (basename, no comments)", () => {
+    expect(canHaveComments("package-lock.json")).toBe(false);
+  });
+
+  test("handles case insensitivity", () => {
+    expect(canHaveComments("FILE.JSON")).toBe(false);
+    expect(canHaveComments("SCRIPT.PY")).toBe(true);
+  });
+});
+
+describe("getLanguageId", () => {
+  test("returns language for TypeScript", () => {
+    expect(getLanguageId("index.ts")).toBe("typescript");
+  });
+
+  test("returns language for TSX", () => {
+    expect(getLanguageId("Component.tsx")).toBe("tsx");
+  });
+
+  test("returns language for Python", () => {
+    expect(getLanguageId("script.py")).toBe("python");
+  });
+
+  test("returns language for JSON (even without comments)", () => {
+    expect(getLanguageId("data.json")).toBe("json");
+  });
+
+  test("returns language for Dockerfile", () => {
+    expect(getLanguageId("Dockerfile")).toBe("dockerfile");
+  });
+
+  test("returns language for .gitignore", () => {
+    expect(getLanguageId(".gitignore")).toBe("gitignore");
+  });
+
+  test("returns undefined for unknown extension", () => {
+    expect(getLanguageId("mystery.xyz")).toBeUndefined();
+  });
+
+  test("handles case insensitivity", () => {
+    expect(getLanguageId("FILE.TS")).toBe("typescript");
+  });
+
+  test("returns correct language for .d.ts", () => {
+    expect(getLanguageId("types.d.ts")).toBe("typescript");
+  });
+});
+
+// Minimum expected counts for registry size validation
+const MIN_EXTENSION_COUNT = 80;
+const MIN_BASENAME_COUNT = 30;
+
+describe("DEFAULT_LANGUAGE_REGISTRY", () => {
+  test("byExtension is a ReadonlyMap", () => {
+    expect(DEFAULT_LANGUAGE_REGISTRY.byExtension).toBeInstanceOf(Map);
+  });
+
+  test("byBasename is a ReadonlyMap", () => {
+    expect(DEFAULT_LANGUAGE_REGISTRY.byBasename).toBeInstanceOf(Map);
+  });
+
+  test("contains expected number of extensions (approximately 80+)", () => {
+    expect(DEFAULT_LANGUAGE_REGISTRY.byExtension.size).toBeGreaterThanOrEqual(
+      MIN_EXTENSION_COUNT
+    );
+  });
+
+  test("contains expected number of basenames (approximately 30+)", () => {
+    expect(DEFAULT_LANGUAGE_REGISTRY.byBasename.size).toBeGreaterThanOrEqual(
+      MIN_BASENAME_COUNT
+    );
+  });
+
+  test("registry is frozen (immutable)", () => {
+    expect(Object.isFrozen(DEFAULT_LANGUAGE_REGISTRY)).toBe(true);
+  });
+
+  test("leaders arrays are frozen (immutable)", () => {
+    const cap = DEFAULT_LANGUAGE_REGISTRY.byExtension.get(".ts");
+    expect(cap).toBeDefined();
+    expect(Object.isFrozen(cap?.leaders)).toBe(true);
+  });
+});
+
+describe("custom registry support", () => {
+  test("allows passing custom registry", () => {
+    const customRegistry = {
+      byExtension: new Map([
+        [".custom", { language: "custom-lang", leaders: ["%%"] as const }],
+      ]),
+      byBasename: new Map([
+        ["CustomFile", { language: "custom-file", leaders: ["@@"] as const }],
+      ]),
+    };
+
+    const cap = getCommentCapability("test.custom", customRegistry);
+    expect(cap).toBeDefined();
+    expect(cap?.language).toBe("custom-lang");
+    expect(cap?.leaders).toEqual(["%%"]);
+
+    const baseCap = getCommentCapability("CustomFile", customRegistry);
+    expect(baseCap).toBeDefined();
+    expect(baseCap?.language).toBe("custom-file");
+  });
+
+  test("custom registry can override defaults", () => {
+    const customRegistry = {
+      byExtension: new Map([
+        [".ts", { language: "custom-typescript", leaders: ["###"] as const }],
+      ]),
+      byBasename: new Map(),
+    };
+
+    const cap = getCommentCapability("index.ts", customRegistry);
+    expect(cap).toBeDefined();
+    expect(cap?.language).toBe("custom-typescript");
+    expect(cap?.leaders).toEqual(["###"]);
+  });
+});

--- a/packages/grammar/src/languages.ts
+++ b/packages/grammar/src/languages.ts
@@ -332,15 +332,17 @@ export function getCommentCapability(
 
   // Handle special case: .d.ts, .d.tsx, .d.mts, .d.cts
   const lower = filePath.toLowerCase();
-  if (
-    lower.endsWith(".d.ts") ||
-    lower.endsWith(".d.mts") ||
-    lower.endsWith(".d.cts")
-  ) {
+  if (lower.endsWith(".d.ts")) {
     return registry.byExtension.get(".ts");
   }
   if (lower.endsWith(".d.tsx")) {
     return registry.byExtension.get(".tsx");
+  }
+  if (lower.endsWith(".d.mts")) {
+    return registry.byExtension.get(".mts") ?? registry.byExtension.get(".ts");
+  }
+  if (lower.endsWith(".d.cts")) {
+    return registry.byExtension.get(".cts") ?? registry.byExtension.get(".ts");
   }
 
   // Check extension (case-insensitive)

--- a/packages/grammar/src/languages.ts
+++ b/packages/grammar/src/languages.ts
@@ -1,0 +1,403 @@
+// tldr ::: language registry with comment capability mappings for file extensions and basenames
+
+import { basename, extname } from "node:path";
+
+/**
+ * Comment capability for a language, including supported comment leaders.
+ * An empty `leaders` array indicates the language has no comment syntax.
+ */
+export type CommentCapability = {
+  readonly leaders: readonly string[];
+  readonly language: string;
+};
+
+/**
+ * Registry mapping file extensions and basenames to their comment capabilities.
+ * Use `byExtension` for extension-based lookups (include leading dot).
+ * Use `byBasename` for exact filename matches (e.g., Dockerfile, Makefile).
+ */
+export type LanguageRegistry = {
+  readonly byExtension: ReadonlyMap<string, CommentCapability>;
+  readonly byBasename: ReadonlyMap<string, CommentCapability>;
+};
+
+// Helper to create CommentCapability with readonly arrays
+function capability(language: string, leaders: string[]): CommentCapability {
+  return { language, leaders: Object.freeze(leaders) as readonly string[] };
+}
+
+// No comment support
+const NO_COMMENTS = capability("data", []);
+
+// Common comment patterns
+const C_STYLE = (lang: string) => capability(lang, ["//", "/*"]);
+const HASH = (lang: string) => capability(lang, ["#"]);
+const SQL_STYLE = (lang: string) => capability(lang, ["--"]);
+const HTML_STYLE = (lang: string) => capability(lang, ["<!--"]);
+const PERCENT = (lang: string) => capability(lang, ["%"]);
+const SEMICOLON = (lang: string) => capability(lang, [";"]);
+
+// Extension mappings - organized by comment style
+const EXTENSION_ENTRIES: [string, CommentCapability][] = [
+  // ═══════════════════════════════════════════════════════════════════════════
+  // No comment support
+  // ═══════════════════════════════════════════════════════════════════════════
+  [".json", capability("json", [])],
+  [".csv", NO_COMMENTS],
+  [".tsv", NO_COMMENTS],
+  [".parquet", NO_COMMENTS],
+  [".avro", NO_COMMENTS],
+  [".lock", NO_COMMENTS],
+  [".lockb", NO_COMMENTS],
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // C-style comments (// and /*)
+  // ═══════════════════════════════════════════════════════════════════════════
+  // TypeScript
+  [".ts", C_STYLE("typescript")],
+  [".tsx", C_STYLE("tsx")],
+  [".mts", C_STYLE("typescript")],
+  [".cts", C_STYLE("typescript")],
+
+  // JavaScript
+  [".js", C_STYLE("javascript")],
+  [".jsx", C_STYLE("jsx")],
+  [".mjs", C_STYLE("javascript")],
+  [".cjs", C_STYLE("javascript")],
+
+  // JSON with comments
+  [".jsonc", C_STYLE("jsonc")],
+  [".json5", C_STYLE("json5")],
+
+  // Systems languages
+  [".go", C_STYLE("go")],
+  [".rs", C_STYLE("rust")],
+  [".c", C_STYLE("c")],
+  [".h", C_STYLE("c")],
+  [".cpp", C_STYLE("cpp")],
+  [".cc", C_STYLE("cpp")],
+  [".cxx", C_STYLE("cpp")],
+  [".hpp", C_STYLE("cpp")],
+  [".hxx", C_STYLE("cpp")],
+
+  // JVM languages
+  [".java", C_STYLE("java")],
+  [".kt", C_STYLE("kotlin")],
+  [".kts", C_STYLE("kotlin")],
+  [".scala", C_STYLE("scala")],
+  [".groovy", C_STYLE("groovy")],
+
+  // .NET languages
+  [".cs", C_STYLE("csharp")],
+  [".fs", C_STYLE("fsharp")],
+
+  // Mobile
+  [".swift", C_STYLE("swift")],
+  [".m", C_STYLE("objective-c")],
+  [".mm", C_STYLE("objective-cpp")],
+
+  // Web (C-style)
+  [".php", C_STYLE("php")],
+  [".dart", C_STYLE("dart")],
+  [".v", C_STYLE("v")],
+  [".zig", C_STYLE("zig")],
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // CSS/styling (block comments only)
+  // ═══════════════════════════════════════════════════════════════════════════
+  [".css", capability("css", ["/*"])],
+  [".scss", capability("scss", ["//", "/*"])],
+  [".sass", capability("sass", ["//", "/*"])],
+  [".less", capability("less", ["//", "/*"])],
+  [".styl", capability("stylus", ["//", "/*"])],
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // Hash comments (#)
+  // ═══════════════════════════════════════════════════════════════════════════
+  // Python
+  [".py", HASH("python")],
+  [".pyi", HASH("python")],
+  [".pyw", HASH("python")],
+  [".pyx", HASH("cython")],
+
+  // Ruby
+  [".rb", HASH("ruby")],
+  [".rake", HASH("ruby")],
+  [".gemspec", HASH("ruby")],
+
+  // Shell
+  [".sh", HASH("shell")],
+  [".bash", HASH("bash")],
+  [".zsh", HASH("zsh")],
+  [".fish", HASH("fish")],
+  [".ksh", HASH("ksh")],
+  [".csh", HASH("csh")],
+
+  // Config formats
+  [".yaml", HASH("yaml")],
+  [".yml", HASH("yaml")],
+  [".toml", HASH("toml")],
+  [".ini", HASH("ini")],
+  [".conf", HASH("conf")],
+  [".cfg", HASH("conf")],
+
+  // Other hash-comment languages
+  [".r", HASH("r")],
+  [".R", HASH("r")],
+  [".pl", HASH("perl")],
+  [".pm", HASH("perl")],
+  [".ex", HASH("elixir")],
+  [".exs", HASH("elixir")],
+  [".jl", HASH("julia")],
+  [".dockerfile", HASH("dockerfile")],
+  [".tf", HASH("terraform")],
+  [".tfvars", HASH("terraform")],
+  [".hcl", HASH("hcl")],
+  [".nix", HASH("nix")],
+  [".coffee", HASH("coffeescript")],
+  [".cr", HASH("crystal")],
+  [".nim", HASH("nim")],
+  [".ps1", HASH("powershell")],
+  [".psm1", HASH("powershell")],
+  [".psd1", HASH("powershell")],
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // SQL-style comments (--)
+  // ═══════════════════════════════════════════════════════════════════════════
+  [".sql", SQL_STYLE("sql")],
+  [".lua", SQL_STYLE("lua")],
+  [".hs", SQL_STYLE("haskell")],
+  [".lhs", SQL_STYLE("haskell")],
+  [".pgsql", SQL_STYLE("plpgsql")],
+  [".plsql", SQL_STYLE("plsql")],
+  [".ada", SQL_STYLE("ada")],
+  [".adb", SQL_STYLE("ada")],
+  [".ads", SQL_STYLE("ada")],
+  [".vhd", SQL_STYLE("vhdl")],
+  [".vhdl", SQL_STYLE("vhdl")],
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // HTML-style comments (<!--)
+  // ═══════════════════════════════════════════════════════════════════════════
+  [".md", HTML_STYLE("markdown")],
+  [".mdx", HTML_STYLE("mdx")],
+  [".markdown", HTML_STYLE("markdown")],
+  [".html", HTML_STYLE("html")],
+  [".htm", HTML_STYLE("html")],
+  [".xhtml", HTML_STYLE("html")],
+  [".xml", HTML_STYLE("xml")],
+  [".svg", HTML_STYLE("svg")],
+  [".vue", HTML_STYLE("vue")],
+  [".svelte", HTML_STYLE("svelte")],
+  [".astro", HTML_STYLE("astro")],
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // Percent comments (%)
+  // ═══════════════════════════════════════════════════════════════════════════
+  [".tex", PERCENT("latex")],
+  [".sty", PERCENT("latex")],
+  [".cls", PERCENT("latex")],
+  [".bib", PERCENT("bibtex")],
+  [".erl", PERCENT("erlang")],
+  [".hrl", PERCENT("erlang")],
+  [".pro", PERCENT("prolog")],
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // Semicolon comments (;)
+  // ═══════════════════════════════════════════════════════════════════════════
+  [".asm", SEMICOLON("assembly")],
+  [".s", SEMICOLON("assembly")],
+  [".S", SEMICOLON("assembly")],
+  [".el", SEMICOLON("elisp")],
+  [".clj", SEMICOLON("clojure")],
+  [".cljs", SEMICOLON("clojurescript")],
+  [".cljc", SEMICOLON("clojure")],
+  [".edn", SEMICOLON("edn")],
+  [".lisp", SEMICOLON("lisp")],
+  [".cl", SEMICOLON("common-lisp")],
+  [".scm", SEMICOLON("scheme")],
+  [".rkt", SEMICOLON("racket")],
+];
+
+// Basename mappings for files without extensions
+const BASENAME_ENTRIES: [string, CommentCapability][] = [
+  // Build/task files
+  ["Dockerfile", HASH("dockerfile")],
+  ["Containerfile", HASH("dockerfile")],
+  ["Makefile", HASH("makefile")],
+  ["GNUmakefile", HASH("makefile")],
+  ["Justfile", HASH("just")],
+  ["Rakefile", HASH("ruby")],
+  ["Gemfile", HASH("ruby")],
+  ["Vagrantfile", HASH("ruby")],
+  ["Brewfile", HASH("ruby")],
+  ["Procfile", HASH("procfile")],
+  ["Jenkinsfile", C_STYLE("groovy")],
+  ["Podfile", HASH("ruby")],
+
+  // Shell config
+  [".bashrc", HASH("bash")],
+  [".bash_profile", HASH("bash")],
+  [".zshrc", HASH("zsh")],
+  [".zprofile", HASH("zsh")],
+  [".profile", HASH("shell")],
+  [".zshenv", HASH("zsh")],
+
+  // Git/VCS
+  [".gitignore", HASH("gitignore")],
+  [".gitattributes", HASH("gitattributes")],
+  [".gitmodules", HASH("gitconfig")],
+  [".dockerignore", HASH("dockerignore")],
+  [".npmignore", HASH("npmignore")],
+  [".eslintignore", HASH("eslintignore")],
+  [".prettierignore", HASH("prettierignore")],
+
+  // Environment
+  [".env", HASH("dotenv")],
+  [".env.local", HASH("dotenv")],
+  [".env.development", HASH("dotenv")],
+  [".env.production", HASH("dotenv")],
+  [".env.test", HASH("dotenv")],
+  [".env.example", HASH("dotenv")],
+  [".envrc", HASH("direnv")],
+
+  // Editor config
+  [".editorconfig", HASH("editorconfig")],
+
+  // No comment support
+  ["package-lock.json", capability("json", [])],
+  ["bun.lockb", NO_COMMENTS],
+  ["yarn.lock", capability("yaml", [])], // yarn.lock uses yaml-like comments
+  ["pnpm-lock.yaml", HASH("yaml")],
+  ["Cargo.lock", capability("toml", [])], // TOML but typically not edited
+  ["composer.lock", capability("json", [])],
+  ["Gemfile.lock", NO_COMMENTS],
+];
+
+// Build the registry maps
+const extensionMap = new Map<string, CommentCapability>();
+for (const [ext, cap] of EXTENSION_ENTRIES) {
+  extensionMap.set(ext.toLowerCase(), cap);
+}
+
+const basenameMap = new Map<string, CommentCapability>();
+for (const [name, cap] of BASENAME_ENTRIES) {
+  basenameMap.set(name, cap);
+}
+
+/**
+ * Default language registry with comprehensive extension and basename mappings.
+ * Covers ~80 common file extensions and ~30 basenames.
+ */
+export const DEFAULT_LANGUAGE_REGISTRY: LanguageRegistry = Object.freeze({
+  byExtension: extensionMap,
+  byBasename: basenameMap,
+});
+
+/**
+ * Look up comment capability for a file by its path.
+ * Checks basename first (for files like Dockerfile, Makefile), then extension.
+ * Returns undefined for unknown file types.
+ *
+ * @param filePath - Path to the file (can be relative or absolute)
+ * @param registry - Language registry to use (defaults to DEFAULT_LANGUAGE_REGISTRY)
+ * @returns Comment capability or undefined if file type is not recognized
+ *
+ * @example
+ * ```typescript
+ * getCommentCapability("src/index.ts")
+ * // => { language: "typescript", leaders: ["//", "/*"] }
+ *
+ * getCommentCapability("data.json")
+ * // => { language: "json", leaders: [] }
+ *
+ * getCommentCapability("Dockerfile")
+ * // => { language: "dockerfile", leaders: ["#"] }
+ *
+ * getCommentCapability("mystery.xyz")
+ * // => undefined
+ * ```
+ */
+export function getCommentCapability(
+  filePath: string,
+  registry: LanguageRegistry = DEFAULT_LANGUAGE_REGISTRY
+): CommentCapability | undefined {
+  const name = basename(filePath);
+
+  // Check basename first (for Dockerfile, Makefile, etc.)
+  const byBasename = registry.byBasename.get(name);
+  if (byBasename) {
+    return byBasename;
+  }
+
+  // Handle special case: .d.ts, .d.tsx, .d.mts, .d.cts
+  const lower = filePath.toLowerCase();
+  if (
+    lower.endsWith(".d.ts") ||
+    lower.endsWith(".d.mts") ||
+    lower.endsWith(".d.cts")
+  ) {
+    return registry.byExtension.get(".ts");
+  }
+  if (lower.endsWith(".d.tsx")) {
+    return registry.byExtension.get(".tsx");
+  }
+
+  // Check extension (case-insensitive)
+  const ext = extname(name).toLowerCase();
+  if (ext) {
+    return registry.byExtension.get(ext);
+  }
+
+  return;
+}
+
+/**
+ * Check if a file can have comments based on its extension or basename.
+ * Returns true if the file type is known and supports comment syntax.
+ * Returns false if the file type is known but has no comment syntax (e.g., .json).
+ * Returns undefined if the file type is not recognized.
+ *
+ * @param filePath - Path to the file (can be relative or absolute)
+ * @param registry - Language registry to use (defaults to DEFAULT_LANGUAGE_REGISTRY)
+ * @returns true if file can have comments, false if it cannot, undefined if unknown
+ *
+ * @example
+ * ```typescript
+ * canHaveComments("src/index.ts")   // => true
+ * canHaveComments("data.json")      // => false (known, no comments)
+ * canHaveComments("mystery.xyz")    // => undefined (unknown)
+ * ```
+ */
+export function canHaveComments(
+  filePath: string,
+  registry: LanguageRegistry = DEFAULT_LANGUAGE_REGISTRY
+): boolean | undefined {
+  const cap = getCommentCapability(filePath, registry);
+  if (cap === undefined) {
+    return;
+  }
+  return cap.leaders.length > 0;
+}
+
+/**
+ * Get the language identifier for a file based on its extension or basename.
+ * Returns undefined for unknown file types.
+ *
+ * @param filePath - Path to the file (can be relative or absolute)
+ * @param registry - Language registry to use (defaults to DEFAULT_LANGUAGE_REGISTRY)
+ * @returns Language identifier string or undefined if not recognized
+ *
+ * @example
+ * ```typescript
+ * getLanguageId("src/index.ts")  // => "typescript"
+ * getLanguageId("Dockerfile")    // => "dockerfile"
+ * getLanguageId("mystery.xyz")   // => undefined
+ * ```
+ */
+export function getLanguageId(
+  filePath: string,
+  registry: LanguageRegistry = DEFAULT_LANGUAGE_REGISTRY
+): string | undefined {
+  return getCommentCapability(filePath, registry)?.language;
+}


### PR DESCRIPTION
## Summary

Add a comprehensive language registry that maps file extensions and basenames to their comment capabilities. This becomes the single source of truth for determining which files can contain waymarks.

## Changes

- Add `CommentCapability` and `LanguageRegistry` types
- Add `DEFAULT_LANGUAGE_REGISTRY` with ~85 extensions and ~38 basenames
- Add `getCommentCapability()`, `canHaveComments()`, `getLanguageId()` functions
- Use `ReadonlyMap` and `readonly` arrays to prevent mutation
- Handle case-insensitive extension matching
- Support special cases like `.d.ts`, `Dockerfile`, `.gitignore`

## Extension Categories

| Category | Extensions |
|----------|------------|
| No comments | `.json`, `.csv`, `.tsv`, `.parquet`, `.lock` |
| C-family (`//`, `/*`) | `.ts`, `.js`, `.go`, `.rs`, `.java`, `.jsonc`, `.json5` |
| Hash (`#`) | `.py`, `.rb`, `.sh`, `.yaml`, `.toml` |
| SQL (`--`) | `.sql`, `.lua`, `.hs` |
| HTML (`<!--`) | `.md`, `.html`, `.xml` |

## Test Plan

- [x] 80 tests covering all extension categories
- [x] Basename matching tests
- [x] Case sensitivity tests
- [x] Unknown extension handling

Fixes WAY-96

🤖 Generated with [Claude Code](https://claude.ai/code)