### PR TITLE
feat(core): add config-aware language resolution [WAY-97]

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -44,6 +44,11 @@ export type {
   InsertOptions,
 } from "./insert";
 export { bulkInsert, InsertionSpecSchema, insertWaymarks } from "./insert";
+export {
+  buildLanguageRegistry,
+  canHaveWaymarks,
+  getCommentLeaders,
+} from "./languages";
 export type {
   NormalizeRecordOptions,
   NormalizeTypeOptions,
@@ -71,4 +76,4 @@ export {
 export type { SearchQuery } from "./search";
 export { searchRecords } from "./search";
 export { findTldrInsertionPoint } from "./tldr";
-export type { ScanOptions, WaymarkConfig } from "./types";
+export type { LanguageConfig, ScanOptions, WaymarkConfig } from "./types";

--- a/packages/core/src/languages.test.ts
+++ b/packages/core/src/languages.test.ts
@@ -1,0 +1,270 @@
+// tldr ::: tests for config-aware language resolution
+
+import { describe, expect, test } from "bun:test";
+
+import { DEFAULT_LANGUAGE_REGISTRY } from "@waymarks/grammar";
+
+import {
+  buildLanguageRegistry,
+  canHaveWaymarks,
+  getCommentLeaders,
+} from "./languages";
+import type { WaymarkConfig } from "./types";
+
+// Base config without languages (for spreading)
+const BASE_CONFIG = {
+  typeCase: "lowercase" as const,
+  idScope: "repo" as const,
+  allowTypes: [] as string[],
+  skipPaths: [] as string[],
+  includePaths: [] as string[],
+  respectGitignore: true,
+  scan: { includeCodetags: false },
+  format: { spaceAroundSigil: true, normalizeCase: true },
+  lint: {
+    duplicateProperty: "warn" as const,
+    unknownMarker: "warn" as const,
+    danglingRelation: "warn" as const,
+    duplicateCanonical: "warn" as const,
+  },
+  ids: {
+    mode: "auto" as const,
+    length: 6,
+    rememberUserChoice: true,
+    trackHistory: false,
+    assignOnRefresh: false,
+  },
+  index: {
+    refreshTriggers: [] as string[],
+    autoRefreshAfterMinutes: 0,
+  },
+};
+
+// Helper to create a config with language overrides
+function createConfig(languages: WaymarkConfig["languages"]): WaymarkConfig {
+  if (languages === undefined) {
+    return BASE_CONFIG;
+  }
+  return { ...BASE_CONFIG, languages };
+}
+
+describe("buildLanguageRegistry", () => {
+  test("returns default registry when no config provided", () => {
+    const registry = buildLanguageRegistry();
+    expect(registry).toBe(DEFAULT_LANGUAGE_REGISTRY);
+  });
+
+  test("returns default registry when no language overrides", () => {
+    const config = createConfig(undefined);
+    const registry = buildLanguageRegistry(config);
+    expect(registry).toBe(DEFAULT_LANGUAGE_REGISTRY);
+  });
+
+  test("merges extension overrides with defaults", () => {
+    const config = createConfig({
+      extensions: { ".xyz": ["//", "/*"] },
+    });
+    const registry = buildLanguageRegistry(config);
+
+    // Custom extension is added
+    const xyz = registry.byExtension.get(".xyz");
+    expect(xyz).toBeDefined();
+    expect([...(xyz?.leaders ?? [])]).toEqual(["//", "/*"]);
+
+    // Default extension still works
+    const ts = registry.byExtension.get(".ts");
+    expect(ts).toBeDefined();
+    expect([...(ts?.leaders ?? [])]).toEqual(["//", "/*"]);
+  });
+
+  test("merges basename overrides with defaults", () => {
+    const config = createConfig({
+      // biome-ignore lint/style/useNamingConvention: basenames match actual filenames
+      basenames: { MyConfig: ["#"] },
+    });
+    const registry = buildLanguageRegistry(config);
+
+    // Custom basename is added
+    const myConfig = registry.byBasename.get("MyConfig");
+    expect(myConfig).toBeDefined();
+    expect([...(myConfig?.leaders ?? [])]).toEqual(["#"]);
+
+    // Default basename still works
+    const dockerfile = registry.byBasename.get("Dockerfile");
+    expect(dockerfile).toBeDefined();
+    expect([...(dockerfile?.leaders ?? [])]).toEqual(["#"]);
+  });
+
+  test("overrides existing extension", () => {
+    const config = createConfig({
+      extensions: { ".json": ["//"] }, // Override JSON to support comments
+    });
+    const registry = buildLanguageRegistry(config);
+
+    const json = registry.byExtension.get(".json");
+    expect(json).toBeDefined();
+    expect([...(json?.leaders ?? [])]).toEqual(["//"]); // Overridden
+  });
+
+  test("normalizes extension case", () => {
+    const config = createConfig({
+      extensions: { ".XYZ": ["//"] },
+    });
+    const registry = buildLanguageRegistry(config);
+
+    // Should find via lowercase
+    const xyz = registry.byExtension.get(".xyz");
+    expect(xyz).toBeDefined();
+    expect([...(xyz?.leaders ?? [])]).toEqual(["//"]);
+  });
+});
+
+describe("canHaveWaymarks", () => {
+  describe("default behavior (no config)", () => {
+    test("returns true for known file types with comments", () => {
+      expect(canHaveWaymarks("src/index.ts")).toBe(true);
+      expect(canHaveWaymarks("src/app.tsx")).toBe(true);
+      expect(canHaveWaymarks("script.py")).toBe(true);
+      expect(canHaveWaymarks("config.yaml")).toBe(true);
+      expect(canHaveWaymarks("Dockerfile")).toBe(true);
+      expect(canHaveWaymarks("Makefile")).toBe(true);
+    });
+
+    test("returns false for known file types without comments", () => {
+      expect(canHaveWaymarks("data.json")).toBe(false);
+      expect(canHaveWaymarks("file.csv")).toBe(false);
+      expect(canHaveWaymarks("package-lock.json")).toBe(false);
+      expect(canHaveWaymarks("bun.lockb")).toBe(false);
+    });
+
+    test("returns true for unknown file types (try to parse)", () => {
+      expect(canHaveWaymarks("mystery.xyz")).toBe(true);
+      expect(canHaveWaymarks("unknown.abc")).toBe(true);
+    });
+
+    test("handles TypeScript declaration files", () => {
+      expect(canHaveWaymarks("types.d.ts")).toBe(true);
+      expect(canHaveWaymarks("globals.d.mts")).toBe(true);
+    });
+  });
+
+  describe("skipUnknown behavior", () => {
+    test("returns false for unknown files when skipUnknown is true", () => {
+      const config = createConfig({ skipUnknown: true });
+      expect(canHaveWaymarks("mystery.xyz", config)).toBe(false);
+      expect(canHaveWaymarks("unknown.abc", config)).toBe(false);
+    });
+
+    test("still returns true for known files when skipUnknown is true", () => {
+      const config = createConfig({ skipUnknown: true });
+      expect(canHaveWaymarks("src/index.ts", config)).toBe(true);
+      expect(canHaveWaymarks("config.yaml", config)).toBe(true);
+    });
+
+    test("still returns false for known no-comment files when skipUnknown is true", () => {
+      const config = createConfig({ skipUnknown: true });
+      expect(canHaveWaymarks("data.json", config)).toBe(false);
+    });
+  });
+
+  describe("extension overrides", () => {
+    test("enables comments for previously no-comment extension", () => {
+      const config = createConfig({
+        extensions: { ".json": ["//"] },
+      });
+      expect(canHaveWaymarks("data.json", config)).toBe(true);
+    });
+
+    test("disables comments with empty array override", () => {
+      const config = createConfig({
+        extensions: { ".ts": [] }, // Disable TypeScript comments
+      });
+      expect(canHaveWaymarks("src/index.ts", config)).toBe(false);
+    });
+
+    test("adds support for custom extension", () => {
+      const config = createConfig({
+        extensions: { ".custom": ["#"] },
+      });
+      expect(canHaveWaymarks("file.custom", config)).toBe(true);
+    });
+  });
+
+  describe("basename overrides", () => {
+    test("adds support for custom basename", () => {
+      const config = createConfig({
+        // biome-ignore lint/style/useNamingConvention: basenames match actual filenames
+        basenames: { MyConfig: ["#"] },
+      });
+      expect(canHaveWaymarks("MyConfig", config)).toBe(true);
+    });
+
+    test("overrides existing basename", () => {
+      const config = createConfig({
+        // biome-ignore lint/style/useNamingConvention: basenames match actual filenames
+        basenames: { Dockerfile: [] }, // Disable Dockerfile comments
+      });
+      expect(canHaveWaymarks("Dockerfile", config)).toBe(false);
+    });
+  });
+
+  describe("config merging", () => {
+    test("override affects only specified extension", () => {
+      const config = createConfig({
+        extensions: { ".json": ["//"] },
+      });
+
+      // JSON now has comments
+      expect(canHaveWaymarks("data.json", config)).toBe(true);
+
+      // Other extensions unchanged
+      expect(canHaveWaymarks("src/index.ts", config)).toBe(true);
+      expect(canHaveWaymarks("file.csv", config)).toBe(false);
+    });
+  });
+});
+
+describe("getCommentLeaders", () => {
+  describe("default behavior (no config)", () => {
+    test("returns leaders for known file types", () => {
+      expect(getCommentLeaders("src/index.ts")).toEqual(["//", "/*"]);
+      expect(getCommentLeaders("script.py")).toEqual(["#"]);
+      expect(getCommentLeaders("query.sql")).toEqual(["--"]);
+      expect(getCommentLeaders("doc.md")).toEqual(["<!--"]);
+      expect(getCommentLeaders("Dockerfile")).toEqual(["#"]);
+    });
+
+    test("returns empty array for no-comment file types", () => {
+      expect(getCommentLeaders("data.json")).toEqual([]);
+      expect(getCommentLeaders("file.csv")).toEqual([]);
+    });
+
+    test("returns empty array for unknown file types", () => {
+      expect(getCommentLeaders("mystery.xyz")).toEqual([]);
+    });
+  });
+
+  describe("with config overrides", () => {
+    test("returns overridden leaders for extension", () => {
+      const config = createConfig({
+        extensions: { ".json": ["//", "/*"] },
+      });
+      expect(getCommentLeaders("data.json", config)).toEqual(["//", "/*"]);
+    });
+
+    test("returns overridden leaders for basename", () => {
+      const config = createConfig({
+        // biome-ignore lint/style/useNamingConvention: basenames match actual filenames
+        basenames: { MyConfig: ["#", "//"] },
+      });
+      expect(getCommentLeaders("MyConfig", config)).toEqual(["#", "//"]);
+    });
+
+    test("returns empty array for disabled extension", () => {
+      const config = createConfig({
+        extensions: { ".ts": [] },
+      });
+      expect(getCommentLeaders("src/index.ts", config)).toEqual([]);
+    });
+  });
+});

--- a/packages/core/src/languages.ts
+++ b/packages/core/src/languages.ts
@@ -1,0 +1,180 @@
+// tldr ::: config-aware language resolution wrapping @waymarks/grammar registry
+
+import { basename, extname } from "node:path";
+
+import {
+  type CommentCapability,
+  DEFAULT_LANGUAGE_REGISTRY,
+  type LanguageRegistry,
+} from "@waymarks/grammar";
+
+import type { WaymarkConfig } from "./types";
+
+/**
+ * Build a language registry with config overrides merged on top of defaults.
+ * Config extensions and basenames override the corresponding default entries.
+ *
+ * @param config - Optional waymark config with language overrides
+ * @returns A LanguageRegistry with config overrides applied
+ *
+ * @example
+ * ```typescript
+ * const registry = buildLanguageRegistry({
+ *   languages: {
+ *     extensions: { ".xyz": ["//"] },
+ *     basenames: { "MyConfig": ["#"] }
+ *   }
+ * });
+ * ```
+ */
+export function buildLanguageRegistry(
+  config?: WaymarkConfig
+): LanguageRegistry {
+  const langConfig = config?.languages;
+
+  // No overrides - return default registry
+  if (!(langConfig?.extensions || langConfig?.basenames)) {
+    return DEFAULT_LANGUAGE_REGISTRY;
+  }
+
+  // Build extension map with overrides
+  const byExtension = new Map(DEFAULT_LANGUAGE_REGISTRY.byExtension);
+  if (langConfig.extensions) {
+    for (const [ext, leaders] of Object.entries(langConfig.extensions)) {
+      const normalizedExt = ext.toLowerCase();
+      byExtension.set(normalizedExt, {
+        language: "custom",
+        leaders: Object.freeze(leaders) as readonly string[],
+      });
+    }
+  }
+
+  // Build basename map with overrides
+  const byBasename = new Map(DEFAULT_LANGUAGE_REGISTRY.byBasename);
+  if (langConfig.basenames) {
+    for (const [name, leaders] of Object.entries(langConfig.basenames)) {
+      byBasename.set(name, {
+        language: "custom",
+        leaders: Object.freeze(leaders) as readonly string[],
+      });
+    }
+  }
+
+  return Object.freeze({
+    byExtension,
+    byBasename,
+  });
+}
+
+/**
+ * Look up comment capability for a file by its path, respecting config overrides.
+ * Checks basename first (for files like Dockerfile, Makefile), then extension.
+ *
+ * @param filePath - Path to the file
+ * @param registry - Language registry to use
+ * @returns Comment capability or undefined if file type is not recognized
+ */
+function getCommentCapability(
+  filePath: string,
+  registry: LanguageRegistry
+): CommentCapability | undefined {
+  const name = basename(filePath);
+
+  // Check basename first (for Dockerfile, Makefile, etc.)
+  const byBasename = registry.byBasename.get(name);
+  if (byBasename) {
+    return byBasename;
+  }
+
+  // Handle special case: .d.ts, .d.tsx, .d.mts, .d.cts
+  const lower = filePath.toLowerCase();
+  if (
+    lower.endsWith(".d.ts") ||
+    lower.endsWith(".d.mts") ||
+    lower.endsWith(".d.cts")
+  ) {
+    return registry.byExtension.get(".ts");
+  }
+  if (lower.endsWith(".d.tsx")) {
+    return registry.byExtension.get(".tsx");
+  }
+
+  // Check extension (case-insensitive)
+  const ext = extname(name).toLowerCase();
+  if (ext) {
+    return registry.byExtension.get(ext);
+  }
+
+  return;
+}
+
+/**
+ * Check if a file can have waymarks based on its extension or basename.
+ * Respects config overrides and the skipUnknown setting.
+ *
+ * @param filePath - Path to the file
+ * @param config - Optional waymark config with language settings
+ * @returns true if file can have waymarks, false if it cannot
+ *
+ * @example
+ * ```typescript
+ * canHaveWaymarks("src/index.ts")                    // => true
+ * canHaveWaymarks("data.json")                       // => false (no comments)
+ * canHaveWaymarks("mystery.xyz")                     // => true (unknown, try to parse)
+ * canHaveWaymarks("mystery.xyz", { languages: { skipUnknown: true } })  // => false
+ *
+ * // Override JSON to have comments
+ * canHaveWaymarks("data.json", { languages: { extensions: { ".json": ["//"] } } })
+ * // => true
+ * ```
+ */
+export function canHaveWaymarks(
+  filePath: string,
+  config?: WaymarkConfig
+): boolean {
+  const registry = buildLanguageRegistry(config);
+  const capability = getCommentCapability(filePath, registry);
+
+  // Unknown file type
+  if (capability === undefined) {
+    // skipUnknown: true means skip unknown files
+    // skipUnknown: false (default) means try to parse
+    return !(config?.languages?.skipUnknown ?? false);
+  }
+
+  // Known file type - check if it has comment support
+  return capability.leaders.length > 0;
+}
+
+/**
+ * Get comment leaders for a file based on its extension or basename.
+ * Respects config overrides.
+ *
+ * @param filePath - Path to the file
+ * @param config - Optional waymark config with language settings
+ * @returns Array of comment leader strings, or empty array if none found
+ *
+ * @example
+ * ```typescript
+ * getCommentLeaders("src/index.ts")   // => ["//", "/*"]
+ * getCommentLeaders("data.json")      // => []
+ * getCommentLeaders("mystery.xyz")    // => []
+ *
+ * // With config override
+ * getCommentLeaders("data.json", { languages: { extensions: { ".json": ["//"] } } })
+ * // => ["//"]
+ * ```
+ */
+export function getCommentLeaders(
+  filePath: string,
+  config?: WaymarkConfig
+): string[] {
+  const registry = buildLanguageRegistry(config);
+  const capability = getCommentCapability(filePath, registry);
+
+  if (capability === undefined) {
+    return [];
+  }
+
+  return [...capability.leaders];
+}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -3,6 +3,19 @@
 // Re-export grammar types for convenience
 export type { ParseOptions, WaymarkRecord } from "@waymarks/grammar";
 
+/**
+ * Configuration for language-specific comment handling.
+ * Allows overriding or extending the default language registry.
+ */
+export type LanguageConfig = {
+  /** Map file extension (with leading dot) to comment leaders */
+  extensions?: Record<string, string[]>;
+  /** Map exact basename to comment leaders */
+  basenames?: Record<string, string[]>;
+  /** When true, skip files with unknown extensions (default: false = try to parse) */
+  skipUnknown?: boolean;
+};
+
 /** Formatting controls for rendered waymark comments. */
 export type WaymarkFormatConfig = {
   spaceAroundSigil: boolean;
@@ -38,6 +51,7 @@ export type WaymarkConfig = {
   lint: WaymarkLintConfig;
   ids: WaymarkIdConfig;
   index: WaymarkIndexConfig;
+  languages?: LanguageConfig;
 };
 
 /** Partial configuration shape for overrides. */
@@ -53,6 +67,7 @@ export type PartialWaymarkConfig = {
   lint?: Partial<WaymarkLintConfig>;
   ids?: Partial<WaymarkIdConfig>;
   index?: Partial<WaymarkIndexConfig>;
+  languages?: Partial<LanguageConfig>;
 };
 
 /** Options that control scanning and filtering waymarks. */


### PR DESCRIPTION
## Summary

Add config-aware wrappers in `@waymarks/core` that merge user overrides with the grammar defaults. This allows users to add custom extensions or override default comment capability behavior.

## Changes

- Add `LanguageConfig` type with `extensions`, `basenames`, `skipUnknown` fields
- Add `languages` field to `WaymarkConfig`
- Add `buildLanguageRegistry()` to merge config with defaults
- Add `canHaveWaymarks()` for config-aware capability check
- Add `getCommentLeaders()` for config-aware leader lookup

## Behavior

| Scenario | `canHaveWaymarks()` returns |
|----------|---------------------------|
| Known extension with comments (`.ts`) | `true` |
| Known extension without comments (`.json`) | `false` |
| Unknown extension, `skipUnknown: false` (default) | `true` |
| Unknown extension, `skipUnknown: true` | `false` |
| Extension with empty leaders override | `false` |

## Test Plan

- [x] Default behavior delegates to grammar
- [x] Extension overrides work
- [x] Basename overrides work
- [x] `skipUnknown: true` behavior
- [x] Empty array override disables comments

Fixes WAY-97

🤖 Generated with [Claude Code](https://claude.ai/code)