### PR TITLE
feat(core): add language config section to config loader [WAY-99]

### DIFF
--- a/schemas/waymark-config.schema.json
+++ b/schemas/waymark-config.schema.json
@@ -108,6 +108,34 @@
           "pattern": "^@[a-z][A-Za-z0-9/_-]*$"
         }
       }
+    },
+    "languages": {
+      "type": "object",
+      "description": "Language and comment capability configuration",
+      "properties": {
+        "extensions": {
+          "type": "object",
+          "description": "Map file extensions to comment leaders",
+          "additionalProperties": {
+            "type": "array",
+            "items": { "type": "string" }
+          }
+        },
+        "basenames": {
+          "type": "object",
+          "description": "Map basenames to comment leaders",
+          "additionalProperties": {
+            "type": "array",
+            "items": { "type": "string" }
+          }
+        },
+        "skipUnknown": {
+          "type": "boolean",
+          "default": false,
+          "description": "Skip files with unrecognized extensions"
+        }
+      },
+      "additionalProperties": false
     }
   },
   "additionalProperties": false

--- a/schemas/waymark-config.schema.json
+++ b/schemas/waymark-config.schema.json
@@ -133,6 +133,11 @@
           "type": "boolean",
           "default": false,
           "description": "Skip files with unrecognized extensions"
+        },
+        "skip_unknown": {
+          "type": "boolean",
+          "default": false,
+          "description": "Skip files with unrecognized extensions (snake_case alias)"
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
## Summary

Add support for the `languages` configuration section so users can override extension mappings and control unknown file handling.

## Changes

- Add `assignLanguageOptions()` function following existing patterns
- Support extensions map (with dot normalization)
- Support basenames map for extensionless files
- Support `skipUnknown` boolean (camelCase and snake_case)
- Update JSON schema with languages section
- Add comprehensive tests for config loading

## Example Config

```yaml
languages:
  extensions:
    ".vue": ["<!--", "//"]
    ".jsonc": ["//"]
  basenames:
    "Justfile": ["#"]
  skipUnknown: false
```

## Test Plan

- [x] Valid extension overrides load correctly
- [x] Valid basename overrides load correctly
- [x] `skipUnknown` boolean loads correctly
- [x] Both camelCase and snake_case work
- [x] Invalid config is ignored gracefully

Fixes WAY-99

🤖 Generated with [Claude Code](https://claude.ai/code)