### PR TITLE
refactor(agents): sync coverage script extensions with language registry [WAY-100]

### DIFF
--- a/.agents/skills/waymark-maintenance/SKILL.md
+++ b/.agents/skills/waymark-maintenance/SKILL.md
@@ -1,0 +1,272 @@
+---
+name: waymark-maintenance
+description: Places and maintains waymarks across a codebase, focusing on TLDR coverage and accuracy. Delegates to the waymarker agent for systematic auditing and placement. Use when adding TLDRs to files, auditing waymark coverage, updating stale waymarks, or when "add waymarks", "TLDR coverage", "waymark audit" is mentioned.
+version: 1.0.0
+agent: waymark:waymarker
+context: fork
+allowed-tools:
+  - Read
+  - Edit
+  - Grep
+  - Glob
+  - Bash(*/find-waymarks *)
+  - Bash(*/coverage-report *)
+---
+
+# Waymark Maintenance
+
+This skill guides systematic waymark placement and maintenance across a codebase. It delegates to the `waymarker` agent for execution. The agent loads the `waymarks` skill for grammar reference and search commands.
+
+## Quick Start
+
+Check current TLDR coverage:
+
+!`.agents/skills/waymark-maintenance/scripts/coverage-report --stats`
+
+## Priority: TLDR Coverage
+
+TLDRs are the foundation of waymark coverage. Every source file should have a TLDR describing what it does. Without TLDRs, codebase navigation is impaired for both humans and agents.
+
+### Coverage Workflow
+
+1. **Audit**: Run `coverage-report --missing-tldr` to find gaps
+2. **Prioritize**: Start with entry points, core modules, then utilities
+3. **Write**: Add TLDRs following the patterns below
+4. **Verify**: Re-run coverage to confirm improvement
+
+## Writing TLDRs
+
+### The Rules
+
+- **One per file**: Exactly one `tldr :::` per file
+- **First waymark**: Place after shebang/frontmatter, before code
+- **8-14 words**: Concise, active voice, capability-first
+- **No filler**: Avoid "This file contains...", "Module for...", "Utilities..."
+
+### Placement by File Type
+
+**TypeScript/JavaScript:**
+
+```typescript
+// tldr ::: handles user authentication and JWT token lifecycle
+
+import { sign, verify } from 'jsonwebtoken';
+```
+
+**Python:**
+
+```python
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+# tldr ::: manages database migrations and schema versioning
+
+import sqlite3
+```
+
+**Markdown:**
+
+```markdown
+---
+title: API Guide
+---
+
+<!-- tldr ::: REST API reference with authentication examples #docs -->
+
+# API Guide
+```
+
+**Shell:**
+
+```bash
+#!/bin/bash
+
+# tldr ::: deployment script for production Kubernetes cluster
+
+set -euo pipefail
+```
+
+### Sentence Patterns
+
+Write one sentence describing what the file delivers:
+
+| Pattern | Template | Example |
+|---------|----------|---------|
+| Action | `[verb] [domain] [method]` | `validates payment webhooks using Stripe signatures` |
+| Component | `[component] [action] [scope]` | `React hooks exposing authentication state` |
+| Purpose | `[capability] for [purpose]` | `rate limiting middleware for API endpoints` |
+| Integration | `[integration] [domain] with [tech]` | `Stripe webhook handler with signature verification` |
+
+### Strong Verbs
+
+Use active, specific verbs:
+
+- validates, processes, transforms, parses
+- renders, displays, presents
+- manages, orchestrates, coordinates
+- fetches, retrieves, queries
+- generates, creates, builds
+- handles, routes, dispatches
+
+### Starred TLDRs
+
+Use `*tldr` for critical files that must be read first:
+
+```typescript
+// *tldr ::: main application entry wiring Express middleware
+// *tldr ::: core authentication service all routes depend on
+```
+
+Reserve for: entry points, core infrastructure, security-critical modules.
+
+### Documentation TLDRs
+
+Documentation files **must** include `#docs` tag:
+
+```markdown
+<!-- tldr ::: API authentication guide using JWT tokens #docs/guide -->
+<!-- tldr ::: database schema migration reference #docs/reference -->
+```
+
+## Writing About Waymarks
+
+`about :::` markers describe the code section immediately following them.
+
+### Placement
+
+Place directly above the construct (6-12 words):
+
+```typescript
+// about ::: validates JWT tokens and extracts claims
+export function validateToken(token: string): Claims {
+```
+
+### Patterns by Construct
+
+| Construct | Pattern | Example |
+|-----------|---------|---------|
+| Class | `encapsulates/manages [domain] [behavior]` | `encapsulates session lifecycle state` |
+| Function | `validates/transforms/fetches [input] [action]` | `validates webhook signatures before processing` |
+| Component | `renders [element] with [feature]` | `renders account overview with metrics` |
+
+### Scope Rule
+
+Focus on the section, not the file. Don't restate the TLDR:
+
+```typescript
+// tldr ::: user authentication service
+
+// about ::: validates password against security policy  // ✓ Section-specific
+function validatePassword(password: string) {}
+
+// about ::: handles user authentication  // ✗ Too broad, same as tldr
+function validatePassword(password: string) {}
+```
+
+## Maintaining Waymarks
+
+### Stale Waymark Detection
+
+Waymarks become stale when code changes but waymarks don't. Look for:
+
+- **Completed todos**: `todo :::` for work that's done
+- **Fixed bugs**: `fix :::` for bugs that are resolved
+- **Inaccurate descriptions**: TLDRs/abouts that don't match current behavior
+- **Orphaned references**: `see:#token` pointing to removed code
+
+### Update Process
+
+1. Read the code to understand current behavior
+2. Compare against existing waymark content
+3. Update waymark to match reality, or delete if no longer relevant
+4. Never leave inaccurate waymarks—they're worse than none
+
+### Pre-Merge Audit
+
+Before merging, check for items that should be cleared:
+
+```bash
+find-waymarks -F              # Flagged items (must clear before merge)
+find-waymarks -S              # Starred items (should address)
+find-waymarks -t wip          # WIP markers
+```
+
+See the `waymarks` skill for full search options.
+
+## Files to Skip
+
+Don't add waymarks to:
+
+- **Generated files**: `*.d.ts`, `*.generated.*`, `@generated` headers
+- **Index/barrel files**: TLDR optional if only re-exports
+- **Test fixtures**: Skip unless complex logic exists
+- **Lock files**: `package-lock.json`, `bun.lockb`, etc.
+- **Build artifacts**: `dist/`, `build/`, `.next/`
+- **Empty files**: Flag for removal rather than adding waymarks
+
+## Files That Need TLDRs
+
+Prioritize in this order:
+
+1. **Entry points**: `index.ts`, `main.ts`, `app.ts`
+2. **Core services**: Authentication, database, API handlers
+3. **Utilities**: Shared helpers, formatters, validators
+4. **Configuration**: Non-trivial config files
+5. **Documentation**: All markdown files (with `#docs` tag)
+6. **Tests**: Test files with complex setup
+
+## Common Mistakes
+
+### Too Vague
+
+```typescript
+// Bad:  // tldr ::: utilities
+// Good: // tldr ::: date parsing utilities with timezone normalization
+```
+
+### Too Long
+
+```typescript
+// Bad:  // tldr ::: this file contains the main authentication service that handles user login, registration, password reset, and session management using JWT tokens
+// Good: // tldr ::: authentication service with login, registration, and JWT sessions
+```
+
+### Wrong Placement
+
+```typescript
+// Bad:
+import { hash } from 'bcrypt';
+// tldr ::: authentication service  // Too late!
+
+// Good:
+// tldr ::: authentication service with bcrypt password hashing
+import { hash } from 'bcrypt';
+```
+
+### Missing Required Tag
+
+```markdown
+<!-- Bad:  tldr ::: API documentation for user endpoints -->
+<!-- Good: tldr ::: API documentation for user endpoints #docs/api -->
+```
+
+## Coverage Script
+
+```bash
+coverage-report              # Files missing TLDRs
+coverage-report --stats      # Coverage percentage
+coverage-report --all        # All files with status
+coverage-report --json       # JSON output for tooling
+coverage-report --help       # All options
+```
+
+Script location: `.agents/skills/waymark-maintenance/scripts/coverage-report`
+
+## Delegation
+
+This skill delegates to the `waymarker` agent which operates in two modes:
+
+- **Conservative (default)**: Reports findings, suggests waymarks, doesn't modify files
+- **Autonomous**: Adds waymarks directly when instructed with "go ahead", "add them", etc.
+
+Always start with conservative mode to review suggestions before bulk changes.

--- a/.agents/skills/waymark-maintenance/scripts/coverage-report
+++ b/.agents/skills/waymark-maintenance/scripts/coverage-report
@@ -242,6 +242,10 @@ TYPE_GLOBS=()
 for ext in "${SOURCE_EXTS[@]}"; do
   TYPE_GLOBS+=("--glob" "*.${ext}")
 done
+# Add explicit basename patterns for files without extensions
+# (the "dockerfile" ext only matches *.dockerfile, not Dockerfile/Containerfile)
+TYPE_GLOBS+=("--glob" "Dockerfile")
+TYPE_GLOBS+=("--glob" "Containerfile")
 
 # --- Find all source files ---
 all_files=()
@@ -252,8 +256,10 @@ for path in "${PATHS[@]}"; do
 done
 
 # --- Find files with TLDRs ---
+# Use the same TYPE_GLOBS filter as all_files to avoid inflating coverage
+# with non-source files (.rst, .txt) that happen to contain TLDRs
 files_with_tldr=()
-tldr_output=$(rg -l 'tldr\s+:::' "${RG_GLOBS[@]}" "${PATHS[@]}" 2>/dev/null || true)
+tldr_output=$(rg -l 'tldr\s+:::' "${RG_GLOBS[@]}" "${TYPE_GLOBS[@]}" "${PATHS[@]}" 2>/dev/null || true)
 while IFS= read -r file; do
   [[ -n "$file" ]] && files_with_tldr+=("$file")
 done <<< "$tldr_output"

--- a/.agents/skills/waymark-maintenance/scripts/coverage-report
+++ b/.agents/skills/waymark-maintenance/scripts/coverage-report
@@ -1,0 +1,344 @@
+#!/usr/bin/env bash
+# coverage-report - Show waymark coverage across source files
+# Reports files with TLDRs, missing TLDRs, and overall coverage stats
+
+set -euo pipefail
+
+VERSION="1.0.0"
+
+show_help() {
+  cat <<'HELP'
+coverage-report - Analyze waymark coverage in your codebase
+
+USAGE:
+    coverage-report [OPTIONS] [PATH...]
+
+OPTIONS:
+    --with-tldr       Show files that have TLDRs
+    --missing-tldr    Show files missing TLDRs (default if no option given)
+    --all             Show both with and without TLDRs
+    --stats           Show only summary statistics
+    --json            Output as JSON
+    -h, --help        Show this help
+    -V, --version     Show version
+
+EXAMPLES:
+    coverage-report                      # Files missing TLDRs in cwd
+    coverage-report src/                 # Files missing TLDRs in src/
+    coverage-report --all                # All files with coverage status
+    coverage-report --stats              # Just the numbers
+    coverage-report --json               # JSON output for tooling
+
+OUTPUT:
+    Files are categorized as:
+    ✓  Has TLDR waymark
+    ✗  Missing TLDR waymark
+
+EXCLUDED:
+    - .gitignore patterns
+    - node_modules/, dist/, build/, .next/, coverage/
+    - *.d.ts, *.generated.*, *.min.*
+    - Lock files (package-lock.json, bun.lockb, yarn.lock, etc.)
+    - Binary and media files
+HELP
+}
+
+show_version() {
+  echo "coverage-report $VERSION"
+}
+
+# --- Defaults ---
+SHOW_WITH_TLDR=false
+SHOW_MISSING_TLDR=false
+STATS_ONLY=false
+JSON_OUTPUT=false
+PATHS=()
+
+# --- Parse args ---
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --with-tldr)
+      SHOW_WITH_TLDR=true
+      shift
+      ;;
+    --missing-tldr)
+      SHOW_MISSING_TLDR=true
+      shift
+      ;;
+    --all)
+      SHOW_WITH_TLDR=true
+      SHOW_MISSING_TLDR=true
+      shift
+      ;;
+    --stats)
+      STATS_ONLY=true
+      shift
+      ;;
+    --json)
+      JSON_OUTPUT=true
+      shift
+      ;;
+    -h|--help)
+      show_help
+      exit 0
+      ;;
+    -V|--version)
+      show_version
+      exit 0
+      ;;
+    -*)
+      echo "Unknown option: $1" >&2
+      echo "Run 'coverage-report --help' for usage" >&2
+      exit 2
+      ;;
+    *)
+      PATHS+=("$1")
+      shift
+      ;;
+  esac
+done
+
+# Default to current directory
+if [[ ${#PATHS[@]} -eq 0 ]]; then
+  PATHS=(".")
+fi
+
+# Default to showing missing if no specific option given
+if [[ "$SHOW_WITH_TLDR" == false && "$SHOW_MISSING_TLDR" == false && "$STATS_ONLY" == false ]]; then
+  SHOW_MISSING_TLDR=true
+fi
+
+# --- Check dependencies ---
+if ! command -v rg &>/dev/null; then
+  echo "Error: ripgrep (rg) is required but not installed." >&2
+  exit 1
+fi
+
+# --- Exclusion patterns ---
+# Directories to always exclude
+EXCLUDE_DIRS=(
+  "node_modules"
+  "dist"
+  "build"
+  ".next"
+  "coverage"
+  ".git"
+  ".svn"
+  "__pycache__"
+  ".pytest_cache"
+  ".mypy_cache"
+  "vendor"
+  "target"        # Rust
+  "pkg"           # Go
+  ".turbo"
+  ".vercel"
+  ".netlify"
+)
+
+# File patterns to exclude
+EXCLUDE_PATTERNS=(
+  "*.d.ts"
+  "*.generated.*"
+  "*.min.*"
+  "*.map"
+  "*.lock"
+  "package-lock.json"
+  "bun.lockb"
+  "yarn.lock"
+  "pnpm-lock.yaml"
+  "Cargo.lock"
+  "composer.lock"
+  "Gemfile.lock"
+  "poetry.lock"
+)
+
+# Build rg glob exclusions
+RG_GLOBS=()
+for dir in "${EXCLUDE_DIRS[@]}"; do
+  RG_GLOBS+=("--glob" "!${dir}/**")
+done
+for pattern in "${EXCLUDE_PATTERNS[@]}"; do
+  RG_GLOBS+=("--glob" "!${pattern}")
+done
+
+# --- Source file extensions ---
+# Files that should have TLDRs - must support comments.
+#
+# SOURCE OF TRUTH: @waymarks/grammar DEFAULT_LANGUAGE_REGISTRY
+# This list should stay in sync with extensions that have non-empty
+# comment leaders in packages/grammar/src/languages.ts
+#
+# Note: .json is excluded (no comment syntax). Use .jsonc or .json5 for
+# JSON files that need waymarks.
+SOURCE_EXTS=(
+  # TypeScript/JavaScript
+  "ts" "tsx" "mts" "cts"
+  "js" "jsx" "mjs" "cjs"
+  # JSON with comments
+  "jsonc" "json5"
+  # Systems languages
+  "go" "rs"
+  "c" "h" "cpp" "cc" "cxx" "hpp" "hxx"
+  # JVM languages
+  "java" "kt" "kts" "scala" "groovy"
+  # .NET
+  "cs" "fs"
+  # Mobile
+  "swift" "m" "mm"
+  # Web
+  "php" "dart" "v" "zig"
+  # CSS/styling
+  "css" "scss" "sass" "less" "styl"
+  # Python
+  "py" "pyi" "pyw" "pyx"
+  # Ruby
+  "rb" "rake" "gemspec"
+  # Shell
+  "sh" "bash" "zsh" "fish" "ksh" "csh"
+  # Config formats
+  "yaml" "yml" "toml" "ini" "conf" "cfg"
+  # Other scripting
+  "r" "R" "pl" "pm"
+  "ex" "exs"  # Elixir
+  "jl"        # Julia
+  "lua"
+  "coffee"
+  "cr"        # Crystal
+  "nim"
+  # Lisp family
+  "clj" "cljs" "cljc" "edn"
+  "el"        # Emacs Lisp
+  "lisp" "cl" "scm" "rkt"
+  # Haskell/ML
+  "hs" "lhs"
+  "ml" "mli"
+  # SQL
+  "sql" "pgsql" "plsql"
+  # Markup/docs
+  "md" "mdx" "markdown"
+  "html" "htm" "xhtml"
+  "xml" "svg"
+  # Frontend frameworks
+  "vue" "svelte" "astro"
+  # Infrastructure
+  "tf" "tfvars" "hcl"
+  "dockerfile"
+  "nix"
+  # PowerShell
+  "ps1" "psm1" "psd1"
+  # LaTeX
+  "tex" "sty" "cls" "bib"
+  # Erlang
+  "erl" "hrl"
+  # Ada/VHDL
+  "ada" "adb" "ads"
+  "vhd" "vhdl"
+  # Assembly
+  "asm" "s" "S"
+)
+
+# Build type filter
+TYPE_GLOBS=()
+for ext in "${SOURCE_EXTS[@]}"; do
+  TYPE_GLOBS+=("--glob" "*.${ext}")
+done
+
+# --- Find all source files ---
+all_files=()
+for path in "${PATHS[@]}"; do
+  while IFS= read -r file; do
+    [[ -n "$file" ]] && all_files+=("$file")
+  done < <(rg --files "${RG_GLOBS[@]}" "${TYPE_GLOBS[@]}" "$path" 2>/dev/null | sort)
+done
+
+# --- Find files with TLDRs ---
+files_with_tldr=()
+tldr_output=$(rg -l 'tldr\s+:::' "${RG_GLOBS[@]}" "${PATHS[@]}" 2>/dev/null || true)
+while IFS= read -r file; do
+  [[ -n "$file" ]] && files_with_tldr+=("$file")
+done <<< "$tldr_output"
+
+# --- Calculate missing ---
+declare -A tldr_map
+for file in "${files_with_tldr[@]}"; do
+  tldr_map["$file"]=1
+done
+
+files_missing_tldr=()
+for file in "${all_files[@]}"; do
+  if [[ -z "${tldr_map[$file]:-}" ]]; then
+    files_missing_tldr+=("$file")
+  fi
+done
+
+# --- Calculate stats ---
+total=${#all_files[@]}
+with_tldr=${#files_with_tldr[@]}
+missing_tldr=${#files_missing_tldr[@]}
+if [[ $total -gt 0 ]]; then
+  coverage_pct=$((with_tldr * 100 / total))
+else
+  coverage_pct=0
+fi
+
+# --- Output ---
+if [[ "$JSON_OUTPUT" == true ]]; then
+  # JSON output
+  echo "{"
+  echo "  \"total\": $total,"
+  echo "  \"with_tldr\": $with_tldr,"
+  echo "  \"missing_tldr\": $missing_tldr,"
+  echo "  \"coverage_percent\": $coverage_pct,"
+
+  if [[ "$STATS_ONLY" == false ]]; then
+    echo "  \"files_with_tldr\": ["
+    first=true
+    for file in "${files_with_tldr[@]}"; do
+      [[ "$first" == true ]] && first=false || echo ","
+      printf '    "%s"' "$file"
+    done
+    echo ""
+    echo "  ],"
+
+    echo "  \"files_missing_tldr\": ["
+    first=true
+    for file in "${files_missing_tldr[@]}"; do
+      [[ "$first" == true ]] && first=false || echo ","
+      printf '    "%s"' "$file"
+    done
+    echo ""
+    echo "  ]"
+  fi
+  echo "}"
+  exit 0
+fi
+
+# Text output
+if [[ "$STATS_ONLY" == true ]]; then
+  echo "Coverage Report"
+  echo "==============="
+  echo "Total files:    $total"
+  echo "With TLDR:      $with_tldr ($coverage_pct%)"
+  echo "Missing TLDR:   $missing_tldr"
+  exit 0
+fi
+
+if [[ "$SHOW_WITH_TLDR" == true ]]; then
+  echo "Files with TLDR ($with_tldr):"
+  echo "─────────────────────────────"
+  for file in "${files_with_tldr[@]}"; do
+    echo "✓ $file"
+  done
+  echo ""
+fi
+
+if [[ "$SHOW_MISSING_TLDR" == true ]]; then
+  echo "Files missing TLDR ($missing_tldr):"
+  echo "───────────────────────────────────"
+  for file in "${files_missing_tldr[@]}"; do
+    echo "✗ $file"
+  done
+  echo ""
+fi
+
+echo "Summary: $with_tldr/$total files have TLDRs ($coverage_pct% coverage)"


### PR DESCRIPTION
## Summary

Update the coverage report script to use an extension list that matches the language registry in `@waymarks/grammar`. This ensures consistency between what the scanner considers "comment-capable" and what the coverage tool considers "should have TLDRs".

## Changes

- Remove `.json` (no comment syntax in standard JSON)
- Add `.jsonc` and `.json5` (JSON with comment support)
- Add comprehensive list of ~90 extensions organized by category
- Add documentation pointing to `@waymarks/grammar` as source of truth
- Organize extensions by language family with inline comments

## Extension List Source of Truth

The `SOURCE_EXTS` array should stay in sync with `DEFAULT_LANGUAGE_REGISTRY` in `packages/grammar/src/languages.ts`.

## Test Plan

- [x] Coverage script runs successfully
- [x] JSON files excluded from coverage
- [x] JSONC/JSON5 files included
- [x] Stats output correct

Fixes WAY-100

🤖 Generated with [Claude Code](https://claude.ai/code)