### PR TITLE
fix(agents): sync coverage script extensions with language registry

### DIFF
--- a/.agents/skills/waymark-maintenance/scripts/coverage-report
+++ b/.agents/skills/waymark-maintenance/scripts/coverage-report
@@ -209,9 +209,9 @@ SOURCE_EXTS=(
   "clj" "cljs" "cljc" "edn"
   "el"        # Emacs Lisp
   "lisp" "cl" "scm" "rkt"
-  # Haskell/ML
+  "pro"       # Prolog
+  # Haskell
   "hs" "lhs"
-  "ml" "mli"
   # SQL
   "sql" "pgsql" "plsql"
   # Markup/docs


### PR DESCRIPTION
- Remove .ml/.mli (OCaml) - not in language registry
- Add .pro (Prolog) - present in registry with % comments

Addresses Greptile review feedback on PR #251.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>