### PR TITLE
feat(core): add includeIgnored scan config option

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -36,6 +36,7 @@ export const DEFAULT_CONFIG: WaymarkConfig = {
   respectGitignore: true,
   scan: {
     includeCodetags: false,
+    includeIgnored: false,
   },
   format: {
     spaceAroundSigil: true,

--- a/packages/core/src/languages.test.ts
+++ b/packages/core/src/languages.test.ts
@@ -19,7 +19,7 @@ const BASE_CONFIG = {
   skipPaths: [] as string[],
   includePaths: [] as string[],
   respectGitignore: true,
-  scan: { includeCodetags: false },
+  scan: { includeCodetags: false, includeIgnored: false },
   format: { spaceAroundSigil: true, normalizeCase: true },
   lint: {
     duplicateProperty: "warn" as const,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -36,6 +36,8 @@ export type WaymarkLintConfig = {
 /** Scan-time toggles for including additional markers. */
 export type WaymarkScanConfig = {
   includeCodetags: boolean;
+  /** Include waymarks inside wm:ignore fences (default: false). */
+  includeIgnored: boolean;
 };
 
 /** Full configuration shape for waymark operations. */


### PR DESCRIPTION
Adds includeIgnored option to WaymarkScanConfig to control whether
waymarks inside wm:ignore fences are included in scan results.

- Add includeIgnored field to WaymarkScanConfig type (default: false)
- Wire config option through config loader

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>