### PR TITLE
feat(cli): add --include-ignored flag to scan command

### DIFF
--- a/packages/cli/src/commands/scan.ts
+++ b/packages/cli/src/commands/scan.ts
@@ -158,7 +158,10 @@ export async function scanRecords(
         continue;
       }
 
-      const parsed = parse(source, { file: filePath });
+      const parsed = parse(source, {
+        file: filePath,
+        includeIgnored: config.scan?.includeIgnored,
+      });
       if (config.scan?.includeCodetags) {
         parsed.push(...scanCodetags(source, filePath));
       }

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -95,11 +95,13 @@ function resolveGlobalOptions(program: Command): GlobalOptions {
   const configPath =
     configPathRaw.trim().length > 0 ? configPathRaw : undefined;
   const cacheEnabled = Boolean(opts.cache);
+  const includeIgnored = Boolean(opts.includeIgnored);
 
   return {
     scope: normalizeScope(scopeValue),
     ...(configPath ? { configPath } : {}),
     ...(cacheEnabled ? { cache: true } : {}),
+    ...(includeIgnored ? { includeIgnored: true } : {}),
   };
 }
 
@@ -1170,6 +1172,7 @@ export async function createProgram(): Promise<Command> {
     )
     .option("--config <path>", "load additional config file (JSON/YAML/TOML)")
     .option("--cache", "use scan cache for faster repeated runs")
+    .option("--include-ignored", "include waymarks inside wm:ignore fences")
     .option("--no-input", "fail if interactive input required")
     .option("--verbose", "enable verbose logging (info level)")
     .option("--debug", "enable debug logging")

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -10,6 +10,7 @@ export type GlobalOptions = {
   scope?: CliScopeOption;
   logLevel?: LogLevel;
   cache?: boolean;
+  includeIgnored?: boolean;
 };
 
 export type CommandContext = {

--- a/packages/cli/src/utils/context.ts
+++ b/packages/cli/src/utils/context.ts
@@ -28,6 +28,15 @@ export async function createContext(
     const message = error instanceof Error ? error.message : String(error);
     throw createConfigError(message);
   }
+
+  // Merge CLI-level scan overrides into config
+  if (globalOptions.includeIgnored) {
+    config = {
+      ...config,
+      scan: { ...config.scan, includeIgnored: true },
+    };
+  }
+
   const workspaceRoot = resolveWorkspaceRoot(loadOptions.cwd);
 
   return { config, globalOptions, workspaceRoot };

--- a/packages/cli/src/utils/display/formatters/styles.ts
+++ b/packages/cli/src/utils/display/formatters/styles.ts
@@ -157,9 +157,8 @@ export function styleType(
   const signalStr = (signals.flagged ? "~" : "") + (signals.starred ? "*" : "");
 
   if (signalStr) {
-    // Bold the signal and type with same color, use background for emphasis
-    // Use bgYellow for a subtle amber/yellow background that works across themes
-    return chalk.bgYellow(chalk.bold(color(signalStr + type)));
+    // Use inverse to swap fg/bg - works with all type colors without conflicts
+    return chalk.inverse(chalk.bold(color(signalStr + type)));
   }
 
   return color(type);


### PR DESCRIPTION
Integrates wm:ignore fence handling into the CLI scan workflow.

- Add --include-ignored global flag to program.ts
- Add includeIgnored to GlobalOptions type
- Wire flag through CommandContext to scanner
- Update styles formatter for consistent output

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>