### PR TITLE
refactor(grammar): externalize comment leader detection

### DIFF
--- a/packages/grammar/src/parser.ts
+++ b/packages/grammar/src/parser.ts
@@ -67,7 +67,7 @@ export function parseLine(
   options: ParseOptions = {}
 ): WaymarkRecord | null {
   const normalizedLine = normalizeLine(line);
-  const header = parseHeader(normalizedLine);
+  const header = parseHeader(normalizedLine, options.leaders);
 
   if (!header) {
     return null;
@@ -119,7 +119,7 @@ export function parse(
       continue;
     }
 
-    const header = parseHeader(rawLine);
+    const header = parseHeader(rawLine, options.leaders);
     if (!header) {
       inWaymarkContext = false;
       continue;

--- a/packages/grammar/src/tokenizer.test.ts
+++ b/packages/grammar/src/tokenizer.test.ts
@@ -1,8 +1,8 @@
-// tldr ::: tests for block comment waymark header parsing in tokenizer
+// tldr ::: tests for tokenizer utilities including comment leader detection
 
 import { describe, expect, it } from "bun:test";
 
-import { parseHeader } from "./tokenizer";
+import { findCommentLeader, parseHeader } from "./tokenizer";
 
 describe("block comment support", () => {
   it("parses single-line /* ... */ waymarks", () => {
@@ -26,5 +26,79 @@ describe("block comment support", () => {
     const result = parseHeader("/* fix ::: memory leak*/");
     expect(result?.type).toBe("fix");
     expect(result?.content.trim()).toBe("memory leak");
+  });
+});
+
+describe("findCommentLeader", () => {
+  describe("default behavior (no leaders parameter)", () => {
+    it("finds // comment leader", () => {
+      expect(findCommentLeader("// todo ::: implement")).toBe("//");
+    });
+
+    it("finds # comment leader", () => {
+      expect(findCommentLeader("# tldr ::: module description")).toBe("#");
+    });
+
+    it("finds -- comment leader", () => {
+      expect(findCommentLeader("-- note ::: SQL comment")).toBe("--");
+    });
+
+    it("finds <!-- comment leader", () => {
+      expect(findCommentLeader("<!-- todo ::: html comment -->")).toBe("<!--");
+    });
+
+    it("finds /* comment leader", () => {
+      expect(findCommentLeader("/* css style */")).toBe("/*");
+    });
+
+    it("returns null for no comment leader", () => {
+      expect(findCommentLeader("const x = 1")).toBeNull();
+    });
+  });
+
+  describe("with custom leaders parameter", () => {
+    it("uses provided leaders array", () => {
+      const leaders = ["%%", ";;"] as const;
+      expect(findCommentLeader("%% custom comment", leaders)).toBe("%%");
+      expect(findCommentLeader(";; lisp style", leaders)).toBe(";;");
+    });
+
+    it("returns null when text does not match any custom leader", () => {
+      const leaders = ["%%"] as const;
+      expect(findCommentLeader("// not matched", leaders)).toBeNull();
+    });
+
+    it("matches first leader when multiple could match", () => {
+      // Order matters - first match wins
+      const leaders = ["//", "///"] as const;
+      expect(findCommentLeader("/// doc comment", leaders)).toBe("//");
+    });
+
+    it("handles single-character leaders", () => {
+      const leaders = ["%"] as const;
+      expect(findCommentLeader("% latex comment", leaders)).toBe("%");
+    });
+
+    it("handles empty leaders array", () => {
+      const leaders: readonly string[] = [];
+      expect(findCommentLeader("// any text", leaders)).toBeNull();
+    });
+
+    it("respects language-specific leaders from registry", () => {
+      // Simulate Python (# only)
+      const pythonLeaders = ["#"] as const;
+      expect(findCommentLeader("# python comment", pythonLeaders)).toBe("#");
+      expect(findCommentLeader("// not python", pythonLeaders)).toBeNull();
+
+      // Simulate SQL (-- only)
+      const sqlLeaders = ["--"] as const;
+      expect(findCommentLeader("-- select", sqlLeaders)).toBe("--");
+      expect(findCommentLeader("# not sql", sqlLeaders)).toBeNull();
+
+      // Simulate CSS (/* only, no //)
+      const cssLeaders = ["/*"] as const;
+      expect(findCommentLeader("/* css */", cssLeaders)).toBe("/*");
+      expect(findCommentLeader("// not css", cssLeaders)).toBeNull();
+    });
   });
 });

--- a/packages/grammar/src/tokenizer.ts
+++ b/packages/grammar/src/tokenizer.ts
@@ -2,6 +2,15 @@
 
 import { SIGIL } from "./constants";
 
+/**
+ * Default comment leaders used when no language-specific leaders are provided.
+ * Prefer passing leaders from LanguageRegistry.getCommentCapability() for
+ * accurate language-specific comment detection.
+ *
+ * @remarks
+ * Order matters: longer prefixes (like "<!--") must precede shorter ones
+ * that they contain to ensure correct matching.
+ */
 const COMMENT_LEADERS = ["<!--", "//", "--", "#", "/*"] as const;
 const ANY_WHITESPACE_REGEX = /\s/;
 const LEADING_WHITESPACE_REGEX = /^\s*/;
@@ -32,10 +41,16 @@ export function normalizeLine(line: string): string {
 /**
  * Find the comment leader at the start of a string.
  * @param text - Text to inspect.
+ * @param leaders - Optional array of comment leaders to use instead of defaults.
+ *                  When provided, only these leaders are checked.
  * @returns Comment leader token or null.
  */
-export function findCommentLeader(text: string): string | null {
-  for (const leader of COMMENT_LEADERS) {
+export function findCommentLeader(
+  text: string,
+  leaders?: readonly string[]
+): string | null {
+  const leaderList = leaders ?? COMMENT_LEADERS;
+  for (const leader of leaderList) {
     if (text.startsWith(leader)) {
       return leader;
     }
@@ -107,14 +122,18 @@ export function parseSignalsAndType(segment: string): {
 /**
  * Parse a full waymark header line into structured data.
  * @param line - Raw line text.
+ * @param leaders - Optional comment leaders to use instead of defaults.
  * @returns Parsed header or null when invalid.
  */
-export function parseHeader(line: string): ParsedHeader | null {
+export function parseHeader(
+  line: string,
+  leaders?: readonly string[]
+): ParsedHeader | null {
   const indentMatch = line.match(LEADING_WHITESPACE_REGEX);
   const indent = indentMatch ? indentMatch[0].length : 0;
   const trimmed = line.slice(indent);
 
-  const commentLeader = findCommentLeader(trimmed);
+  const commentLeader = findCommentLeader(trimmed, leaders);
   if (!commentLeader) {
     return null;
   }

--- a/packages/grammar/src/types.ts
+++ b/packages/grammar/src/types.ts
@@ -34,4 +34,7 @@ export type ParseOptions = {
   language?: string;
   /** Include waymarks inside wm:ignore fences (default: false). */
   includeIgnored?: boolean;
+  /** Comment leaders to use for parsing. When provided, only these leaders
+   *  are recognized. Typically sourced from LanguageRegistry for the file type. */
+  leaders?: readonly string[];
 };


### PR DESCRIPTION
## Summary

Adds optional `leaders` parameter to the comment leader detection pipeline, allowing callers to provide language-specific comment leaders instead of relying on hardcoded defaults.

- Add `leaders?: readonly string[]` to `ParseOptions` type
- Update `findCommentLeader()` to accept optional leaders array
- Thread leaders through `parseHeader()` and parser pipeline
- Document `COMMENT_LEADERS` as fallback when no registry-based leaders provided

This enables integration with `LanguageRegistry.getCommentCapability()` for more accurate language-specific comment detection.

## Test plan

- [x] Existing tokenizer tests pass
- [x] Existing parser tests pass
- [x] New tests for custom leaders parameter
- [x] `bun check:all` passes

🤖 Generated with [Claude Code](https://claude.ai/code)