### PR TITLE
feat(cli): replace Pino with @outfitter/logging

### DIFF
--- a/.agents/plans/outfitter-init/PLAN.md
+++ b/.agents/plans/outfitter-init/PLAN.md
@@ -24,7 +24,7 @@ Adopt `@outfitter/*` packages in the Waymark monorepo to replace ad-hoc error ha
 
 ## Current State (Scan Results)
 
-```
+```text
 Anti-Pattern                 Count    Files
 ─────────────────────────────────────────────
 throw statements             103      ~30 files

--- a/bun.lock
+++ b/bun.lock
@@ -56,8 +56,6 @@
         "ignore": "7.0.5",
         "inquirer": "12.9.6",
         "ora": "9.0.0",
-        "pino": "9.12.0",
-        "pino-pretty": "13.1.1",
         "simple-update-notifier": "2.0.0",
         "yaml": "2.8.1",
         "zod": "4.1.12",
@@ -939,8 +937,6 @@
     "@outfitter/config/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "@outfitter/contracts/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
-
-    "@waymarks/cli/pino": ["pino@9.12.0", "", { "dependencies": { "atomic-sleep": "^1.0.0", "on-exit-leak-free": "^2.1.0", "pino-abstract-transport": "^2.0.0", "pino-std-serializers": "^7.0.0", "process-warning": "^5.0.0", "quick-format-unescaped": "^4.0.3", "real-require": "^0.2.0", "safe-stable-stringify": "^2.3.1", "slow-redact": "^0.3.0", "sonic-boom": "^4.0.1", "thread-stream": "^3.0.0" }, "bin": { "pino": "bin.js" } }, "sha512-0Gd0OezGvqtqMwgYxpL7P0pSHHzTJ0Lx992h+mNlMtRVfNnqweWmf0JmRWk5gJzHalyd2mxTzKjhiNbGS2Ztfw=="],
 
     "@waymarks/mcp/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -30,8 +30,6 @@
     "ignore": "7.0.5",
     "inquirer": "12.9.6",
     "ora": "9.0.0",
-    "pino": "9.12.0",
-    "pino-pretty": "13.1.1",
     "simple-update-notifier": "2.0.0",
     "yaml": "2.8.1",
     "zod": "4.1.12"

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -374,10 +374,10 @@ export async function runAddCommand(
     config: context.config,
     format: true,
     logger: {
-      debug: (msg, meta) => logger.debug(meta ?? {}, msg),
-      info: (msg, meta) => logger.info(meta ?? {}, msg),
-      warn: (msg, meta) => logger.warn(meta ?? {}, msg),
-      error: (msg, meta) => logger.error(meta ?? {}, msg),
+      debug: (msg, meta) => logger.debug(msg, meta),
+      info: (msg, meta) => logger.info(msg, meta),
+      warn: (msg, meta) => logger.warn(msg, meta),
+      error: (msg, meta) => logger.error(msg, meta),
     },
   };
 

--- a/packages/cli/src/commands/remove.ts
+++ b/packages/cli/src/commands/remove.ts
@@ -289,10 +289,10 @@ export async function runRemoveCommand(
     ...(mergedOptions.reason ? { reason: mergedOptions.reason } : {}),
     removedBy: "cli",
     logger: {
-      debug: (msg, meta) => logger.debug(meta ?? {}, msg),
-      info: (msg, meta) => logger.info(meta ?? {}, msg),
-      warn: (msg, meta) => logger.warn(meta ?? {}, msg),
-      error: (msg, meta) => logger.error(meta ?? {}, msg),
+      debug: (msg, meta) => logger.debug(msg, meta),
+      info: (msg, meta) => logger.info(msg, meta),
+      warn: (msg, meta) => logger.warn(msg, meta),
+      error: (msg, meta) => logger.error(msg, meta),
     },
   };
 

--- a/packages/cli/src/commands/scan.ts
+++ b/packages/cli/src/commands/scan.ts
@@ -199,7 +199,7 @@ export async function scanRecords(
   if (options.metrics) {
     Object.assign(options.metrics, metrics);
   }
-  logger.debug({ cache: cacheEnabled, ...metrics }, "scan completed");
+  logger.debug("scan completed", { cache: cacheEnabled, ...metrics });
 
   return records;
 }
@@ -212,10 +212,9 @@ function createCache(options: ScanRuntimeOptions): WaymarkCache | undefined {
     ? WaymarkCache.open({ dbPath: options.cachePath })
     : WaymarkCache.open();
   if (result.isErr()) {
-    logger.warn(
-      { error: result.error.message },
-      "Failed to open cache, proceeding without caching"
-    );
+    logger.warn("Failed to open cache, proceeding without caching", {
+      error: result.error.message,
+    });
     return;
   }
   return result.value;

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -77,10 +77,9 @@ export function detectInstallMethod(executablePath?: string): InstallDetection {
       ? realpathSync(executablePath)
       : realpathSync(process.argv[1] ?? "");
   } catch (error) {
-    logger.debug(
-      { error },
-      "Failed to resolve executable path for update detection"
-    );
+    logger.debug("Failed to resolve executable path for update detection", {
+      error,
+    });
     resolvedPath = executablePath ?? "";
   }
 
@@ -228,7 +227,7 @@ export async function runUpdateCommand(
   }
 
   if (options.command && command !== "npm") {
-    logger.warn({ command }, "Using custom update command for wm update");
+    logger.warn("Using custom update command for wm update", { command });
   }
 
   if (options.dryRun) {
@@ -254,16 +253,13 @@ export async function runUpdateCommand(
     return confirmationResult;
   }
 
-  logger.info(
-    {
-      command,
-      args: NPM_UPDATE_ARGS,
-      cwd: process.cwd(),
-      method: detection.method,
-      location: detection.binaryPath,
-    },
-    "Executing wm update via npm"
-  );
+  logger.info("Executing wm update via npm", {
+    command,
+    args: NPM_UPDATE_ARGS,
+    cwd: process.cwd(),
+    method: detection.method,
+    location: detection.binaryPath,
+  });
 
   try {
     const exitCode = await runChild(command, NPM_UPDATE_ARGS);
@@ -273,7 +269,7 @@ export async function runUpdateCommand(
       exitCode,
     };
   } catch (error) {
-    logger.error({ error }, "wm update failed to launch npm command");
+    logger.error("wm update failed to launch npm command", { error });
     return {
       command: commandString,
       method: detection.method,

--- a/packages/cli/src/utils/logger.test.ts
+++ b/packages/cli/src/utils/logger.test.ts
@@ -1,4 +1,4 @@
-// tldr ::: tests for pino logger configuration and level control
+// tldr ::: tests for @outfitter/logging-based CLI logger with level control
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { createLogger } from "./logger.ts";
@@ -36,7 +36,7 @@ describe("logger utility", () => {
     expect(logger.level).toBe("error");
   });
 
-  test("logger level can be changed after creation", () => {
+  test("logger level can be changed after creation via setter", () => {
     const logger = createLogger({ level: "warn" });
     expect(logger.level).toBe("warn");
 
@@ -44,16 +44,21 @@ describe("logger utility", () => {
     expect(logger.level).toBe("debug");
   });
 
-  test("creates logger with pretty format in development", () => {
-    process.env.NODE_ENV = "development";
+  test("logger level can be changed after creation via setLevel", () => {
+    const logger = createLogger({ level: "warn" });
+    expect(logger.level).toBe("warn");
+
+    logger.setLevel("debug");
+    expect(logger.level).toBe("debug");
+  });
+
+  test("creates logger with pretty option without crashing", () => {
     const logger = createLogger({ pretty: true });
-    // Can't easily test pino-pretty integration, but verify it doesn't crash
     expect(logger).toBeDefined();
     expect(logger.level).toBe("warn");
   });
 
-  test("creates logger without pretty format in production", () => {
-    process.env.NODE_ENV = "production";
+  test("creates logger with pretty disabled", () => {
     const logger = createLogger({ pretty: false });
     expect(logger).toBeDefined();
     expect(logger.level).toBe("warn");
@@ -79,5 +84,6 @@ describe("logger utility", () => {
     expect(typeof logger.warn).toBe("function");
     expect(typeof logger.error).toBe("function");
     expect(typeof logger.fatal).toBe("function");
+    expect(typeof logger.setLevel).toBe("function");
   });
 });


### PR DESCRIPTION
## Summary

- Replace Pino + pino-pretty with `@outfitter/logging` (createLogger + createConsoleSink)
- Preserve `--verbose`/`--debug`/`--quiet` flag behavior via level mapping
- Message-first API: `logger.info("message", { data })` instead of `logger.info({ data }, "message")`
- Remove `pino` and `pino-pretty` dependencies

## Test plan

- [x] `wm --version` prints correctly
- [x] `wm --debug scan .` shows debug output
- [x] `wm --quiet scan .` suppresses non-error output
- [x] `bun typecheck` passes
- [x] All CLI tests pass

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)