### PR TITLE
feat(core): convert IDs and insert/remove to Result-based API

### DIFF
--- a/packages/cli/src/utils/logger.ts
+++ b/packages/cli/src/utils/logger.ts
@@ -1,10 +1,10 @@
 // tldr ::: @outfitter/logging-based logger configuration for CLI with level control
 
 import {
-  type LogLevel,
-  type LoggerInstance,
   createConsoleSink,
   createLogger as createOutfitterLogger,
+  type LoggerInstance,
+  type LogLevel,
 } from "@outfitter/logging";
 
 export type { LogLevel } from "@outfitter/logging";

--- a/packages/core/src/__tests__/contracts/ids.test.ts
+++ b/packages/core/src/__tests__/contracts/ids.test.ts
@@ -57,8 +57,16 @@ describe("ID contracts", () => {
         new JsonIdIndex({ workspaceRoot: workspaceB })
       );
 
-      const idA = await managerA.reserveId(metadata);
-      const idB = await managerB.reserveId(metadata);
+      const resultA = await managerA.reserveId(metadata);
+      const resultB = await managerB.reserveId(metadata);
+
+      expect(resultA.isOk()).toBe(true);
+      expect(resultB.isOk()).toBe(true);
+      if (!(resultA.isOk() && resultB.isOk())) {
+        throw new Error("Expected successful reservation");
+      }
+      const idA = resultA.value;
+      const idB = resultB.value;
 
       expect(idA).toBeDefined();
       expect(idB).toBeDefined();
@@ -84,8 +92,13 @@ describe("ID contracts", () => {
         new JsonIdIndex({ workspaceRoot: workspace })
       );
 
-      const id = await manager.reserveId(metadata);
+      const result = await manager.reserveId(metadata);
 
+      expect(result.isOk()).toBe(true);
+      if (!result.isOk()) {
+        throw new Error("Expected successful reservation");
+      }
+      const id = result.value;
       expect(id).toBeDefined();
       if (!id) {
         throw new Error("Expected generated ID");

--- a/packages/core/src/edit.ts
+++ b/packages/core/src/edit.ts
@@ -648,7 +648,7 @@ async function updateIdIndex(args: {
   }
 
   const contextWindow = buildContextWindow(lines, record.startLine - 1);
-  await idManager.updateLocation(id, {
+  const updateResult = await idManager.updateLocation(id, {
     file,
     line: record.startLine,
     type: record.type,
@@ -658,4 +658,7 @@ async function updateIdIndex(args: {
     ...(existing.source ? { source: existing.source } : {}),
     ...(existing.sourceType ? { sourceType: existing.sourceType } : {}),
   });
+  if (updateResult.isErr()) {
+    throw updateResult.error;
+  }
 }

--- a/packages/core/src/ids.test.ts
+++ b/packages/core/src/ids.test.ts
@@ -56,8 +56,16 @@ describe("WaymarkIdManager", () => {
         new JsonIdIndex({ workspaceRoot: workspaceB })
       );
 
-      const idA = await managerA.reserveId(metadata);
-      const idB = await managerB.reserveId(metadata);
+      const resultA = await managerA.reserveId(metadata);
+      const resultB = await managerB.reserveId(metadata);
+
+      expect(resultA.isOk()).toBe(true);
+      expect(resultB.isOk()).toBe(true);
+      if (!(resultA.isOk() && resultB.isOk())) {
+        throw new Error("Expected successful reservation");
+      }
+      const idA = resultA.value;
+      const idB = resultB.value;
 
       expect(idA).toBeDefined();
       expect(idB).toBeDefined();

--- a/packages/core/src/remove.ts
+++ b/packages/core/src/remove.ts
@@ -506,7 +506,13 @@ async function commitIdRemovals(
       removeOptions.removedBy = options.removedBy;
     }
     for (const id of removal.ids) {
-      await options.idManager.remove(id, removeOptions);
+      const removeResult = await options.idManager.remove(id, removeOptions);
+      if (removeResult.isErr()) {
+        options.logger?.warn("Failed to remove waymark ID from index", {
+          error: removeResult.error.message,
+          id,
+        });
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

- Convert `insertWaymarks()`, `removeWaymarks()`, and `editWaymark()` to return Results
- Convert ID generation/reservation to `Result<string, ValidationError | ConflictError>`
- ID index operations return Results
- All callers updated to unwrap Results

## Test plan

- [x] Insert/remove/edit tests updated for Result returns
- [x] Error path coverage for validation failures
- [x] `bun typecheck` passes
- [x] All 146 core tests pass

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)