### PR TITLE
feat(cli): convert write commands to Result-based handlers

### DIFF
--- a/packages/cli/src/commands/add.test.ts
+++ b/packages/cli/src/commands/add.test.ts
@@ -98,8 +98,7 @@ describe("runAddCommand", () => {
       globalOptions: {},
     };
 
-    const result = await runAddCommand(parsed, context);
-    expect(result.exitCode).toBe(0);
+    const result = (await runAddCommand(parsed, context)).unwrap();
     expect(result.summary.successful).toBe(1);
 
     const fileContents = await readFile(sourcePath, "utf8");
@@ -137,9 +136,11 @@ describe("runAddCommand", () => {
       globalOptions: {},
     };
 
-    await expect(runAddCommand(parsed, context)).rejects.toThrow(
-      JSON_VALIDATION_ERROR_REGEX
-    );
+    const result = await runAddCommand(parsed, context);
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toMatch(JSON_VALIDATION_ERROR_REGEX);
+    }
 
     // Clean up
     await rm(testWorkspace, { recursive: true, force: true });
@@ -168,9 +169,11 @@ describe("runAddCommand", () => {
       globalOptions: {},
     };
 
-    await expect(runAddCommand(parsed, context)).rejects.toThrow(
-      JSON_VALIDATION_ERROR_REGEX
-    );
+    const result = await runAddCommand(parsed, context);
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toMatch(JSON_VALIDATION_ERROR_REGEX);
+    }
 
     // Clean up
     await rm(testWorkspace, { recursive: true, force: true });
@@ -214,8 +217,7 @@ describe("runAddCommand", () => {
       globalOptions: {},
     };
 
-    const result = await runAddCommand(parsed, context);
-    expect(result.exitCode).toBe(0);
+    const result = (await runAddCommand(parsed, context)).unwrap();
     expect(result.summary.successful).toBe(1);
 
     const fileContents = await readFile(sourcePath, "utf8");
@@ -250,8 +252,7 @@ describe("runAddCommand", () => {
       globalOptions: {},
     };
 
-    const result = await runAddCommand(parsed, context);
-    expect(result.exitCode).toBe(0);
+    const result = (await runAddCommand(parsed, context)).unwrap();
     expect(result.summary.successful).toBe(2);
     expect(result.summary.filesModified).toBe(1);
 
@@ -287,8 +288,7 @@ describe("runAddCommand", () => {
       globalOptions: {},
     };
 
-    const result = await runAddCommand(parsed, context);
-    expect(result.exitCode).toBe(0);
+    const result = (await runAddCommand(parsed, context)).unwrap();
     expect(result.summary.successful).toBe(2);
     expect(result.summary.filesModified).toBe(1);
 
@@ -328,8 +328,7 @@ describe("runAddCommand", () => {
         globalOptions: {},
       };
 
-      const result = await runAddCommand(parsed, context);
-      expect(result.exitCode).toBe(0);
+      const result = (await runAddCommand(parsed, context)).unwrap();
       expect(result.summary.successful).toBe(2);
       expect(result.summary.filesModified).toBe(1);
       expect(readStdinSpy).toHaveBeenCalledTimes(1);

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -5,6 +5,7 @@ import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join, resolve } from "node:path";
 import { promptSelect } from "@outfitter/cli/prompt";
+import { InternalError, Result } from "@outfitter/contracts";
 import { CliError } from "../errors.ts";
 import { ExitCode } from "../exit-codes.ts";
 import { logger } from "../utils/logger.ts";
@@ -28,10 +29,22 @@ const CONFIG_SCOPES: ConfigScope[] = ["project", "user"];
 /**
  * Execute the `wm init` command to generate configuration files.
  * @param options - CLI options for format, preset, and scope.
- * @returns Promise that resolves when initialization completes.
+ * @returns Result wrapping void on success.
  */
+export function runInitCommand(
+  options: InitCommandOptions = {}
+): Promise<Result<void, InternalError>> {
+  return Result.tryPromise({
+    try: () => runInitCommandInner(options),
+    catch: (cause) =>
+      new InternalError({
+        message: `Init failed: ${cause instanceof Error ? cause.message : String(cause)}`,
+      }),
+  });
+}
+
 // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: sequential prompt branching for interactive init
-export async function runInitCommand(
+async function runInitCommandInner(
   options: InitCommandOptions = {}
 ): Promise<void> {
   let format: ConfigFormat;

--- a/packages/cli/src/commands/modify.test.ts
+++ b/packages/cli/src/commands/modify.test.ts
@@ -149,12 +149,14 @@ describe("runModifyCommand integration", () => {
     const filePath = join(workspace, "auth.ts");
     await writeFile(filePath, "// todo ::: implement OAuth\n", "utf8");
 
-    const result = await runModifyCommand(
-      context,
-      `${filePath}:1`,
-      { type: "fix", write: true },
-      { stdin: Readable.from([]) }
-    );
+    const result = (
+      await runModifyCommand(
+        context,
+        `${filePath}:1`,
+        { type: "fix", write: true },
+        { stdin: Readable.from([]) }
+      )
+    ).unwrap();
 
     expect(result.payload.applied).toBe(true);
     const text = await readFile(filePath, "utf8");
@@ -169,12 +171,14 @@ describe("runModifyCommand integration", () => {
       "utf8"
     );
 
-    const result = await runModifyCommand(
-      context,
-      `${filePath}:1`,
-      { content: "validate JWT", write: true },
-      { stdin: Readable.from([]) }
-    );
+    const result = (
+      await runModifyCommand(
+        context,
+        `${filePath}:1`,
+        { content: "validate JWT", write: true },
+        { stdin: Readable.from([]) }
+      )
+    ).unwrap();
 
     expect(result.payload.after.content).toBe("validate JWT [[a3k9m2p]]");
     const text = await readFile(filePath, "utf8");
@@ -189,12 +193,14 @@ describe("runModifyCommand integration", () => {
       "utf8"
     );
 
-    const result = await runModifyCommand(
-      context,
-      `${filePath}:1`,
-      { starred: true, write: true },
-      { stdin: Readable.from([]) }
-    );
+    const result = (
+      await runModifyCommand(
+        context,
+        `${filePath}:1`,
+        { starred: true, write: true },
+        { stdin: Readable.from([]) }
+      )
+    ).unwrap();
 
     expect(result.payload.after.raw).toBe("// *todo ::: implement OAuth");
     const text = await readFile(filePath, "utf8");
@@ -207,12 +213,14 @@ describe("runModifyCommand integration", () => {
     await writeFile(filePath, "// todo ::: implement OAuth\n", "utf8");
 
     const stdin = Readable.from(["validate JWT"]);
-    const result = await runModifyCommand(
-      context,
-      `${filePath}:1`,
-      { content: "-", write: true },
-      { stdin }
-    );
+    const result = (
+      await runModifyCommand(
+        context,
+        `${filePath}:1`,
+        { content: "-", write: true },
+        { stdin }
+      )
+    ).unwrap();
 
     expect(result.payload.after.content).toBe("validate JWT");
     const text = await readFile(filePath, "utf8");
@@ -243,12 +251,14 @@ describe("runModifyCommand integration", () => {
       updatedAt: Date.now(),
     });
 
-    await runModifyCommand(
-      context,
-      `${filePath}:1`,
-      { starred: true, write: true },
-      { stdin: Readable.from([]) }
-    );
+    (
+      await runModifyCommand(
+        context,
+        `${filePath}:1`,
+        { starred: true, write: true },
+        { stdin: Readable.from([]) }
+      )
+    ).unwrap();
 
     const refreshedIndex = new JsonIdIndex({ workspaceRoot: workspace });
     const updated = await refreshedIndex.get("[[test123]]");
@@ -282,12 +292,14 @@ describe("runModifyCommand integration", () => {
       updatedAt: Date.now(),
     });
 
-    await runModifyCommand(
-      context,
-      undefined,
-      { id: "[[abc123]]", noSignal: true, write: true },
-      { stdin: Readable.from([]) }
-    );
+    (
+      await runModifyCommand(
+        context,
+        undefined,
+        { id: "[[abc123]]", noSignal: true, write: true },
+        { stdin: Readable.from([]) }
+      )
+    ).unwrap();
 
     const text = await readFile(filePath, "utf8");
     expect(text).toBe("// todo ::: implement OAuth [[abc123]]\n");

--- a/packages/cli/src/commands/remove.test.ts
+++ b/packages/cli/src/commands/remove.test.ts
@@ -76,14 +76,14 @@ describe("runRemoveCommand", () => {
       options: { write: true },
     });
 
-    const preview = await runRemoveCommand(parsed, context, {
-      writeOverride: false,
-    });
+    const preview = (
+      await runRemoveCommand(parsed, context, { writeOverride: false })
+    ).unwrap();
     expect(preview.summary.successful).toBe(2);
 
-    const actual = await runRemoveCommand(parsed, context, {
-      writeOverride: true,
-    });
+    const actual = (
+      await runRemoveCommand(parsed, context, { writeOverride: true })
+    ).unwrap();
 
     expect(actual.summary.successful).toBe(2);
     const contents = await readFile(filePath, "utf8");
@@ -122,9 +122,9 @@ describe("runRemoveCommand", () => {
       options: { write: true, id: ["[[test-456]]"] },
     });
 
-    const actual = await runRemoveCommand(parsed, context, {
-      writeOverride: true,
-    });
+    const actual = (
+      await runRemoveCommand(parsed, context, { writeOverride: true })
+    ).unwrap();
 
     expect(actual.summary.successful).toBe(1);
     const remaining = await readFile(filePath, "utf8");
@@ -163,9 +163,9 @@ describe("runRemoveCommand", () => {
       targets: [],
       options: { from: jsonPath, write: true, json: true },
     });
-    const actual = await runRemoveCommand(parsed, context, {
-      writeOverride: true,
-    });
+    const actual = (
+      await runRemoveCommand(parsed, context, { writeOverride: true })
+    ).unwrap();
     expect(actual.summary.successful).toBe(1);
     expect(actual.options.write).toBe(true);
     expect(actual.options.json).toBe(true);
@@ -190,9 +190,11 @@ describe("runRemoveCommand", () => {
       options: { from: invalidJsonPath },
     });
 
-    await expect(runRemoveCommand(parsed, context)).rejects.toThrow(
-      JSON_VALIDATION_ERROR_REGEX
-    );
+    const result = await runRemoveCommand(parsed, context);
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toMatch(JSON_VALIDATION_ERROR_REGEX);
+    }
   });
 
   test("rejects invalid criteria with clear errors", async () => {
@@ -209,9 +211,11 @@ describe("runRemoveCommand", () => {
       options: { from: invalidJsonPath },
     });
 
-    await expect(runRemoveCommand(parsed, context)).rejects.toThrow(
-      JSON_VALIDATION_ERROR_REGEX
-    );
+    const result = await runRemoveCommand(parsed, context);
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toMatch(JSON_VALIDATION_ERROR_REGEX);
+    }
   });
 
   test("validates removal spec types properly", async () => {
@@ -229,9 +233,11 @@ describe("runRemoveCommand", () => {
       options: { from: invalidJsonPath },
     });
 
-    await expect(runRemoveCommand(parsed, context)).rejects.toThrow(
-      JSON_VALIDATION_ERROR_REGEX
-    );
+    const result = await runRemoveCommand(parsed, context);
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toMatch(JSON_VALIDATION_ERROR_REGEX);
+    }
   });
 
   test("accepts valid JSON with all removal methods", async () => {
@@ -273,6 +279,6 @@ describe("runRemoveCommand", () => {
     });
     // Since we're testing validation, not actual removal logic,
     // we just check that it doesn't throw a validation error
-    expect(result.exitCode).toBeDefined();
+    expect(result.isOk()).toBe(true);
   });
 });

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, spyOn, test } from "bun:test";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { Result } from "@outfitter/contracts";
 import { resolveConfig } from "@waymarks/core";
 import type { Command } from "commander";
 import { findRecords } from "./commands/find";
@@ -82,13 +83,15 @@ async function withTempFile(
 describe("CLI handlers", () => {
   test("format command normalizes types", async () => {
     const { file, cleanup } = await withTempFile("// TODO ::: needs cleanup\n");
-    const { formattedText, edits } = await formatFile(
-      {
-        filePath: file,
-        write: false,
-      },
-      defaultContext
-    );
+    const { formattedText, edits } = (
+      await formatFile(
+        {
+          filePath: file,
+          write: false,
+        },
+        defaultContext
+      )
+    ).unwrap();
     expect(formattedText).toBe("// todo ::: needs cleanup\n");
     expect(edits).toHaveLength(1);
     await cleanup();
@@ -98,7 +101,9 @@ describe("CLI handlers", () => {
     const { file, cleanup } = await withTempFile(
       "// waymark-ignore-file\n// todo ::: ignore this\n"
     );
-    const paths = await expandFormatPaths([file], defaultContext.config);
+    const paths = (
+      await expandFormatPaths([file], defaultContext.config)
+    ).unwrap();
     expect(paths).toEqual([]);
     await cleanup();
   });
@@ -1079,12 +1084,13 @@ describe("Commander integration", () => {
       specs: [],
       options: { write: false, json: true, jsonl: false },
     });
-    const runSpy = spyOn(addModule, "runAddCommand").mockResolvedValue({
-      results: [],
-      summary: { total: 0, successful: 0, failed: 0, filesModified: 0 },
-      output: "",
-      exitCode: 0,
-    });
+    const runSpy = spyOn(addModule, "runAddCommand").mockResolvedValue(
+      Result.ok({
+        results: [],
+        summary: { total: 0, successful: 0, failed: 0, filesModified: 0 },
+        output: "",
+      })
+    );
     const contextSpy = spyOn(contextModule, "createContext").mockResolvedValue(
       defaultContext
     );
@@ -1134,11 +1140,12 @@ describe("Commander integration", () => {
       indexRefreshed: false,
       noChange: false,
     };
-    const runSpy = spyOn(modifyModule, "runModifyCommand").mockResolvedValue({
-      output: "",
-      payload: mockPayload,
-      exitCode: 0,
-    });
+    const runSpy = spyOn(modifyModule, "runModifyCommand").mockResolvedValue(
+      Result.ok({
+        output: "",
+        payload: mockPayload,
+      })
+    );
     const contextSpy = spyOn(contextModule, "createContext").mockResolvedValue(
       defaultContext
     );
@@ -1170,17 +1177,18 @@ describe("Commander integration", () => {
         jsonl: false,
       },
     });
-    const runSpy = spyOn(removeModule, "runRemoveCommand").mockResolvedValue({
-      results: [],
-      summary: { total: 0, successful: 0, failed: 0, filesModified: 0 },
-      output: "",
-      exitCode: 0,
-      options: {
-        write: false,
-        json: true,
-        jsonl: false,
-      },
-    });
+    const runSpy = spyOn(removeModule, "runRemoveCommand").mockResolvedValue(
+      Result.ok({
+        results: [],
+        summary: { total: 0, successful: 0, failed: 0, filesModified: 0 },
+        output: "",
+        options: {
+          write: false,
+          json: true,
+          jsonl: false,
+        },
+      })
+    );
     const contextSpy = spyOn(contextModule, "createContext").mockResolvedValue(
       defaultContext
     );


### PR DESCRIPTION
## Summary

- Convert 7 write commands (format, migrate, init, add, modify, remove, update) to Result-based handlers
- Wrap remaining action handlers with `runCommand()`
- Remove last ~20 `process.exit` calls from write command paths

## Test plan

- [x] `wm format . --write` normalizes files
- [x] `wm init --help` shows usage
- [x] `bun typecheck` passes
- [x] All 53 CLI tests pass

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)