### PR TITLE
feat(mcp): migrate to @outfitter/logging and Result-based config

### DIFF
--- a/apps/mcp/src/index.ts
+++ b/apps/mcp/src/index.ts
@@ -5,6 +5,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { registerResources } from "./resources";
 import { registerTools } from "./tools";
+import { logger } from "./utils/logger";
 
 const VERSION = process.env.npm_package_version ?? "1.0.0-beta.1";
 
@@ -21,7 +22,7 @@ async function main(): Promise<void> {
 main().catch((error) => {
   const message =
     error instanceof Error ? (error.stack ?? error.message) : String(error);
-  process.stderr.write(`${message}\n`);
+  logger.fatal(message, { error });
   process.exit(1);
 });
 

--- a/apps/mcp/src/resources/todos.ts
+++ b/apps/mcp/src/resources/todos.ts
@@ -47,10 +47,16 @@ async function collectRecords(
     return { records: [], truncated: false };
   }
 
-  const config = await loadConfig({
+  const configResult = await loadConfig({
     scope: (options.scope as "default" | "project" | "user") ?? "default",
     ...(options.configPath ? { configPath: options.configPath } : {}),
   });
+  if (configResult.isErr()) {
+    throw new Error(
+      `Failed to load config: ${configResult.error instanceof Error ? configResult.error.message : String(configResult.error)}`
+    );
+  }
+  const config = configResult.value;
 
   filePaths = applySkipPaths(filePaths, config.skipPaths ?? []);
 

--- a/apps/mcp/src/tools/graph.ts
+++ b/apps/mcp/src/tools/graph.ts
@@ -40,10 +40,16 @@ async function collectRecords(
     return { records: [] };
   }
 
-  const config = await loadConfig({
+  const configResult = await loadConfig({
     scope: options.scope ?? "default",
     ...(options.configPath ? { configPath: options.configPath } : {}),
   });
+  if (configResult.isErr()) {
+    throw new Error(
+      `Failed to load config: ${configResult.error instanceof Error ? configResult.error.message : String(configResult.error)}`
+    );
+  }
+  const config = configResult.value;
 
   filePaths = applySkipPaths(filePaths, config.skipPaths ?? []);
 

--- a/apps/mcp/src/tools/scan.ts
+++ b/apps/mcp/src/tools/scan.ts
@@ -41,10 +41,16 @@ async function collectRecords(
     return { records: [] };
   }
 
-  const config = await loadConfig({
+  const configResult = await loadConfig({
     scope: options.scope ?? "default",
     ...(options.configPath ? { configPath: options.configPath } : {}),
   });
+  if (configResult.isErr()) {
+    throw new Error(
+      `Failed to load config: ${configResult.error instanceof Error ? configResult.error.message : String(configResult.error)}`
+    );
+  }
+  const config = configResult.value;
 
   filePaths = applySkipPaths(filePaths, config.skipPaths ?? []);
 

--- a/apps/mcp/src/types.ts
+++ b/apps/mcp/src/types.ts
@@ -1,6 +1,5 @@
 // tldr ::: shared types and schemas for MCP server
 
-import type { ConfigScope } from "@waymarks/core";
 import { z } from "zod";
 
 export const configOptionsSchema = z.object({
@@ -74,13 +73,6 @@ export type SignalFlags = {
 export type CommentStyle = {
   leader: string;
   closing?: string;
-};
-
-export type ExpandedConfig = {
-  cwd: string;
-  env: NodeJS.ProcessEnv;
-  scope: ConfigScope;
-  explicitPath?: string;
 };
 
 export const TODOS_RESOURCE_URI = "waymark://todos";

--- a/apps/mcp/src/utils/config.ts
+++ b/apps/mcp/src/utils/config.ts
@@ -1,22 +1,22 @@
 // tldr ::: config loading helpers for MCP server
 
 import { resolve } from "node:path";
+import type { Result } from "@outfitter/contracts";
 import type { ConfigScope, WaymarkConfig } from "@waymarks/core";
 import { loadConfigFromDisk } from "@waymarks/core";
-import type { ExpandedConfig } from "../types";
 
 /**
  * Load MCP configuration based on scope and optional explicit path.
- * Unwraps the Result from loadConfigFromDisk; throws on error.
+ * Returns a Result wrapping the resolved configuration or a typed error.
  *
  * @param options - Scope and optional config path.
- * @returns Resolved configuration loaded from disk.
+ * @returns Result containing resolved configuration or an error.
  */
-export async function loadConfig(options: {
+export function loadConfig(options: {
   scope: ConfigScope;
   configPath?: string;
-}): Promise<WaymarkConfig> {
-  const loadOptions: ExpandedConfig = {
+}): Promise<Result<WaymarkConfig, unknown>> {
+  const loadOptions = {
     cwd: process.cwd(),
     env: process.env,
     scope: options.scope,
@@ -25,8 +25,7 @@ export async function loadConfig(options: {
       : {}),
   };
 
-  const result = await loadConfigFromDisk(loadOptions);
-  return result.unwrap();
+  return loadConfigFromDisk(loadOptions);
 }
 
 /**

--- a/apps/mcp/src/utils/errors.ts
+++ b/apps/mcp/src/utils/errors.ts
@@ -16,10 +16,11 @@ export async function safeReadFile(
     const { readFile } = await import("node:fs/promises");
     return await readFile(filePath, encoding);
   } catch (error) {
-    logger.debug(
-      { error, filePath, context: logContext },
-      `Failed to read file: ${filePath}`
-    );
+    logger.debug(`Failed to read file: ${filePath}`, {
+      error,
+      filePath,
+      context: logContext,
+    });
     return null;
   }
 }

--- a/apps/mcp/src/utils/logger.ts
+++ b/apps/mcp/src/utils/logger.ts
@@ -1,49 +1,13 @@
-// tldr ::: minimal console logger for MCP server
+// tldr ::: @outfitter/logging-based logger for MCP server
 
-type LogLevel = "debug" | "info" | "warn" | "error";
-type LogMeta = Record<string, unknown>;
+import {
+  createConsoleSink,
+  createLogger as createOutfitterLogger,
+  type LoggerInstance,
+} from "@outfitter/logging";
 
-class Logger {
-  private level: LogLevel = "info";
-
-  setLevel(level: LogLevel): void {
-    this.level = level;
-  }
-
-  debug(meta: LogMeta, message: string): void {
-    if (this.shouldLog("debug")) {
-      // biome-ignore lint/suspicious/noConsole: MCP server logs to stderr
-      console.error(`[DEBUG] ${message}`, meta);
-    }
-  }
-
-  info(meta: LogMeta, message: string): void {
-    if (this.shouldLog("info")) {
-      // biome-ignore lint/suspicious/noConsole: MCP server logs to stderr
-      console.error(`[INFO] ${message}`, meta);
-    }
-  }
-
-  warn(meta: LogMeta, message: string): void {
-    if (this.shouldLog("warn")) {
-      // biome-ignore lint/suspicious/noConsole: MCP server logs to stderr
-      console.error(`[WARN] ${message}`, meta);
-    }
-  }
-
-  error(meta: LogMeta, message: string): void {
-    if (this.shouldLog("error")) {
-      // biome-ignore lint/suspicious/noConsole: MCP server logs to stderr
-      console.error(`[ERROR] ${message}`, meta);
-    }
-  }
-
-  private shouldLog(level: LogLevel): boolean {
-    const levels: LogLevel[] = ["debug", "info", "warn", "error"];
-    const currentIndex = levels.indexOf(this.level);
-    const targetIndex = levels.indexOf(level);
-    return targetIndex >= currentIndex;
-  }
-}
-
-export const logger = new Logger();
+export const logger: LoggerInstance = createOutfitterLogger({
+  name: "waymark-mcp",
+  level: "warn",
+  sinks: [createConsoleSink({ colors: false })],
+});

--- a/packages/cli/src/commands/update.test.ts
+++ b/packages/cli/src/commands/update.test.ts
@@ -43,7 +43,9 @@ describe("runUpdateCommand", () => {
       return Promise.resolve(0);
     });
 
-    const result = (await runUpdateCommand({ force: true, yes: true })).unwrap();
+    const result = (
+      await runUpdateCommand({ force: true, yes: true })
+    ).unwrap();
 
     expect(result.skipped).toBeUndefined();
     expect(calls).toHaveLength(1);
@@ -68,7 +70,7 @@ describe("runUpdateCommand", () => {
       return Promise.resolve(0);
     });
 
-    const result = (
+    const _result = (
       await runUpdateCommand({
         command: "pnpm",
         force: true,


### PR DESCRIPTION
## Summary

- Convert MCP tool handlers to unwrap core Results
- Replace console.error logger with `@outfitter/logging`
- Config loading uses Result-based `loadConfig()` from core

## Test plan

- [x] MCP tools/list responds correctly
- [x] `bun typecheck` passes (apps/mcp)
- [x] All 17 MCP tests pass

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)