### PR TITLE
feat(mcp): add tool annotations to waymark tool

### DIFF
--- a/apps/mcp/src/tools/index.ts
+++ b/apps/mcp/src/tools/index.ts
@@ -21,6 +21,12 @@ export function registerTools(
       name: "waymark",
       description: waymarkToolDescription,
       inputSchema: waymarkToolInputSchema,
+      annotations: {
+        readOnlyHint: false, // "add" action mutates files
+        destructiveHint: false, // "add" is additive, not destructive
+        idempotentHint: false, // "add" creates new waymarks each call
+        openWorldHint: false, // operates on local filesystem only
+      },
       handler: async (input, _ctx) => {
         const result = await handleWaymarkTool(input, notifyResourceChanged);
         return Result.ok(result) as Result<ToolContent, never>;


### PR DESCRIPTION
Declares behavioral hints per MCP spec: readOnlyHint, destructiveHint,
idempotentHint, openWorldHint. Helps clients understand tool behavior
without invoking it.

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)