### PR TITLE
feat(core): adopt error create() factories and re-export new types

### DIFF
--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -362,9 +362,9 @@ export function runAddCommand(
   return Result.tryPromise({
     try: () => runAddCommandInner(parsed, context),
     catch: (cause) =>
-      new InternalError({
-        message: `Add failed: ${cause instanceof Error ? cause.message : String(cause)}`,
-      }),
+      InternalError.create(
+        `Add failed: ${cause instanceof Error ? cause.message : String(cause)}`
+      ),
   });
 }
 

--- a/packages/cli/src/commands/check.ts
+++ b/packages/cli/src/commands/check.ts
@@ -336,9 +336,9 @@ export function runCheckCommand(
   return Result.tryPromise({
     try: () => runCheckCommandInner(context, options),
     catch: (cause) =>
-      new InternalError({
-        message: `Check failed: ${cause instanceof Error ? cause.message : String(cause)}`,
-      }),
+      InternalError.create(
+        `Check failed: ${cause instanceof Error ? cause.message : String(cause)}`
+      ),
   });
 }
 

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -67,9 +67,9 @@ export function runDoctorCommand(
   return Result.tryPromise({
     try: () => runDoctorCommandInner(context, options),
     catch: (cause) =>
-      new InternalError({
-        message: `Doctor diagnostics failed: ${cause instanceof Error ? cause.message : String(cause)}`,
-      }),
+      InternalError.create(
+        `Doctor diagnostics failed: ${cause instanceof Error ? cause.message : String(cause)}`
+      ),
   });
 }
 

--- a/packages/cli/src/commands/fmt.ts
+++ b/packages/cli/src/commands/fmt.ts
@@ -30,9 +30,9 @@ export function formatFile(
   return Result.tryPromise({
     try: () => formatFileInner(options, context),
     catch: (cause) =>
-      new InternalError({
-        message: `Format failed: ${cause instanceof Error ? cause.message : String(cause)}`,
-      }),
+      InternalError.create(
+        `Format failed: ${cause instanceof Error ? cause.message : String(cause)}`
+      ),
   });
 }
 
@@ -109,9 +109,9 @@ export function expandFormatPaths(
       return await filterFilesWithWaymarks(expanded);
     },
     catch: (cause) =>
-      new InternalError({
-        message: `Path expansion failed: ${cause instanceof Error ? cause.message : String(cause)}`,
-      }),
+      InternalError.create(
+        `Path expansion failed: ${cause instanceof Error ? cause.message : String(cause)}`
+      ),
   });
 }
 

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -37,9 +37,9 @@ export function runInitCommand(
   return Result.tryPromise({
     try: () => runInitCommandInner(options),
     catch: (cause) =>
-      new InternalError({
-        message: `Init failed: ${cause instanceof Error ? cause.message : String(cause)}`,
-      }),
+      InternalError.create(
+        `Init failed: ${cause instanceof Error ? cause.message : String(cause)}`
+      ),
   });
 }
 

--- a/packages/cli/src/commands/lint.ts
+++ b/packages/cli/src/commands/lint.ts
@@ -422,9 +422,9 @@ export function lintFiles(
   return Result.tryPromise({
     try: () => lintFilesInner(filePaths, allowTypes, config),
     catch: (cause) =>
-      new InternalError({
-        message: `Lint failed: ${cause instanceof Error ? cause.message : String(cause)}`,
-      }),
+      InternalError.create(
+        `Lint failed: ${cause instanceof Error ? cause.message : String(cause)}`
+      ),
   });
 }
 

--- a/packages/cli/src/commands/modify.ts
+++ b/packages/cli/src/commands/modify.ts
@@ -120,9 +120,9 @@ export function runModifyCommand(
   return Result.tryPromise({
     try: () => runModifyCommandInner(context, targetArg, options, io),
     catch: (cause) =>
-      new InternalError({
-        message: `Modify failed: ${cause instanceof Error ? cause.message : String(cause)}`,
-      }),
+      InternalError.create(
+        `Modify failed: ${cause instanceof Error ? cause.message : String(cause)}`
+      ),
   });
 }
 

--- a/packages/cli/src/commands/remove.ts
+++ b/packages/cli/src/commands/remove.ts
@@ -280,9 +280,9 @@ export function runRemoveCommand(
   return Result.tryPromise({
     try: () => runRemoveCommandInner(parsed, context, execution),
     catch: (cause) =>
-      new InternalError({
-        message: `Remove failed: ${cause instanceof Error ? cause.message : String(cause)}`,
-      }),
+      InternalError.create(
+        `Remove failed: ${cause instanceof Error ? cause.message : String(cause)}`
+      ),
   });
 }
 

--- a/packages/cli/src/commands/scan.ts
+++ b/packages/cli/src/commands/scan.ts
@@ -123,9 +123,9 @@ export function scanRecords(
   return Result.tryPromise({
     try: () => scanRecordsInner(filePaths, config, options),
     catch: (cause) =>
-      new InternalError({
-        message: `Scan failed: ${cause instanceof Error ? cause.message : String(cause)}`,
-      }),
+      InternalError.create(
+        `Scan failed: ${cause instanceof Error ? cause.message : String(cause)}`
+      ),
   });
 }
 

--- a/packages/cli/src/commands/unified/index.ts
+++ b/packages/cli/src/commands/unified/index.ts
@@ -29,9 +29,9 @@ export function runUnifiedCommand(
   return Result.tryPromise({
     try: () => runUnifiedCommandInner(options, context),
     catch: (cause) =>
-      new InternalError({
-        message: `Unified command failed: ${cause instanceof Error ? cause.message : String(cause)}`,
-      }),
+      InternalError.create(
+        `Unified command failed: ${cause instanceof Error ? cause.message : String(cause)}`
+      ),
   });
 }
 

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -209,9 +209,9 @@ export function runUpdateCommand(
   return Result.tryPromise({
     try: () => runUpdateCommandInner(options),
     catch: (cause) =>
-      new InternalError({
-        message: `Update failed: ${cause instanceof Error ? cause.message : String(cause)}`,
-      }),
+      InternalError.create(
+        `Update failed: ${cause instanceof Error ? cause.message : String(cause)}`
+      ),
   });
 }
 

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -140,13 +140,7 @@ export async function loadConfigFromDisk(
 
   if (resolvedExplicit) {
     if (!existsSync(resolvedExplicit)) {
-      return Result.err(
-        new NotFoundError({
-          message: `Config file not found: ${resolvedExplicit}`,
-          resourceType: "config",
-          resourceId: resolvedExplicit,
-        })
-      );
+      return Result.err(NotFoundError.create("config", resolvedExplicit));
     }
     return readAndResolve(resolvedExplicit);
   }
@@ -179,10 +173,10 @@ export async function loadConfigFromDisk(
       return Result.err(error);
     }
     return Result.err(
-      new ValidationError({
-        message: `Config loading failed: ${error instanceof Error ? error.message : String(error)}`,
-        field: "config",
-      })
+      ValidationError.create(
+        "config",
+        `loading failed: ${error instanceof Error ? error.message : String(error)}`
+      )
     );
   }
 }
@@ -222,20 +216,20 @@ async function readConfigOverrides(
     const parsed = parseConfigFile(raw, filePath);
     if (parsed.isErr()) {
       return Result.err(
-        new ValidationError({
-          message: `Unable to parse config at ${filePath}: ${parsed.error.message}`,
-          field: filePath,
-        })
+        ValidationError.create(
+          filePath,
+          `parse failed: ${parsed.error.message}`
+        )
       );
     }
     return Result.ok(normalizeConfigShape(parsed.value));
   }
 
   return Result.err(
-    new ValidationError({
-      message: `Unsupported config format: ${ext}. Use .toml, .yaml, or .yml`,
-      field: filePath,
-    })
+    ValidationError.create(
+      filePath,
+      `unsupported format: ${ext}. Use .toml, .yaml, or .yml`
+    )
   );
 }
 

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -2,10 +2,13 @@
 
 // biome-ignore lint/performance/noBarrelFile: Intentional re-export of contracts for convenience
 export {
+  AmbiguousError,
   type AnyKitError,
+  AssertionError,
   CancelledError,
   ConflictError,
   type ErrorCategory,
+  expect,
   getExitCode,
   InternalError,
   NotFoundError,
@@ -43,7 +46,8 @@ export type WaymarkError =
   | import("@outfitter/contracts").NotFoundError
   | import("@outfitter/contracts").ConflictError
   | import("@outfitter/contracts").InternalError
-  | import("@outfitter/contracts").CancelledError;
+  | import("@outfitter/contracts").CancelledError
+  | import("@outfitter/contracts").AmbiguousError;
 
 /** Convenience alias for a Result with a Waymark domain error. */
 export type WaymarkResult<T> = import("@outfitter/contracts").Result<

--- a/packages/core/src/id-index.ts
+++ b/packages/core/src/id-index.ts
@@ -151,13 +151,7 @@ export class JsonIdIndex {
     await this.init();
     const current = this.data.ids[id];
     if (!current) {
-      return Result.err(
-        new NotFoundError({
-          message: `Unknown waymark id: ${id}`,
-          resourceType: "waymark-id",
-          resourceId: id,
-        })
-      );
+      return Result.err(NotFoundError.create("waymark-id", id));
     }
     this.data.ids[id] = updater(current);
     await this.save();
@@ -297,10 +291,10 @@ export class JsonIdIndex {
       });
     } catch (error) {
       return Result.err(
-        new InternalError({
-          message: `Failed to parse ${this.indexPath}: ${error instanceof Error ? error.message : String(error)}`,
-          context: { path: this.indexPath },
-        })
+        InternalError.create(
+          `Failed to parse ${this.indexPath}: ${error instanceof Error ? error.message : String(error)}`,
+          { path: this.indexPath }
+        )
       );
     }
   }
@@ -315,10 +309,10 @@ export class JsonIdIndex {
       return Result.ok(Array.isArray(parsed) ? parsed : []);
     } catch (error) {
       return Result.err(
-        new InternalError({
-          message: `Failed to parse ${this.historyPath}: ${error instanceof Error ? error.message : String(error)}`,
-          context: { path: this.historyPath },
-        })
+        InternalError.create(
+          `Failed to parse ${this.historyPath}: ${error instanceof Error ? error.message : String(error)}`,
+          { path: this.historyPath }
+        )
       );
     }
   }

--- a/packages/core/src/ids.ts
+++ b/packages/core/src/ids.ts
@@ -74,9 +74,9 @@ export class WaymarkIdManager {
 
       if (this.reserved.has(normalized)) {
         return Result.err(
-          new ConflictError({
-            message: `Waymark ID already reserved in current batch: ${normalized}`,
-          })
+          ConflictError.create(
+            `Waymark ID already reserved in current batch: ${normalized}`
+          )
         );
       }
       this.reserved.add(normalized);
@@ -117,13 +117,7 @@ export class WaymarkIdManager {
     const normalized = normalizedResult.value;
 
     if (!this.reserved.has(normalized)) {
-      return Result.err(
-        new NotFoundError({
-          message: `Waymark ID ${normalized} was not reserved`,
-          resourceType: "waymark-id",
-          resourceId: normalized,
-        })
-      );
+      return Result.err(NotFoundError.create("waymark-id", normalized));
     }
     await this.index.set(this.buildEntry(normalized, metadata));
     this.reserved.delete(normalized);
@@ -222,10 +216,7 @@ export class WaymarkIdManager {
       // Reject empty brackets or whitespace-only content
       if (!content || content.trim().length === 0) {
         return Result.err(
-          new ValidationError({
-            message: `Invalid waymark ID format: ${id}`,
-            field: "id",
-          })
+          ValidationError.create("id", `invalid format: ${id}`)
         );
       }
       return Result.ok(id);
@@ -250,9 +241,10 @@ export class WaymarkIdManager {
       }
     }
     return Result.err(
-      new ConflictError({
-        message: `Waymark ID already in use: ${id}`,
-        context: { id, existingFile: exists.file, existingLine: exists.line },
+      ConflictError.create(`Waymark ID already in use: ${id}`, {
+        id,
+        existingFile: exists.file,
+        existingLine: exists.line,
       })
     );
   }
@@ -274,14 +266,14 @@ export class WaymarkIdManager {
     }
 
     return Result.err(
-      new InternalError({
-        message: "Unable to generate unique waymark ID after multiple attempts",
-        context: {
+      InternalError.create(
+        "Unable to generate unique waymark ID after multiple attempts",
+        {
           file: metadata.file,
           line: metadata.line,
           attempts: MAX_ID_GENERATION_ATTEMPTS,
-        },
-      })
+        }
+      )
     );
   }
 


### PR DESCRIPTION
- Re-export AmbiguousError, AssertionError, expect from @outfitter/contracts
- Add AmbiguousError to WaymarkError union type
- Convert 23 error construction sites to use static create() factories:
  - NotFoundError.create(resourceType, resourceId)
  - ValidationError.create(field, reason)
  - InternalError.create(message, context?)
  - ConflictError.create(message, context?)
- Skip cache files (use structured context that doesn't map to factories)

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)