### PR TITLE
refactor(cli): convert modify.ts and add.ts to typed error flow

### DIFF
--- a/packages/cli/src/commands/modify.ts
+++ b/packages/cli/src/commands/modify.ts
@@ -1,7 +1,13 @@
 // tldr ::: edit command implementation for wm CLI
 
 import { readFile, writeFile } from "node:fs/promises";
-import { InternalError, Result } from "@outfitter/contracts";
+import {
+  type AnyKitError,
+  InternalError,
+  NotFoundError,
+  Result,
+  ValidationError,
+} from "@outfitter/contracts";
 import {
   fingerprintContent,
   fingerprintContext,
@@ -119,13 +125,17 @@ export function runModifyCommand(
   targetArg: string | undefined,
   options: ModifyOptions,
   io: ModifyIo = DEFAULT_IO
-): Promise<Result<ModifyCommandResult, InternalError>> {
+): Promise<Result<ModifyCommandResult, AnyKitError>> {
   return Result.tryPromise({
     try: () => runModifyCommandInner(context, targetArg, options, io),
-    catch: (cause) =>
-      new InternalError({
-        message: `Modify failed: ${cause instanceof Error ? cause.message : String(cause)}`,
-      }),
+    catch: (cause) => {
+      if (cause instanceof Error && "category" in cause) {
+        return cause as AnyKitError;
+      }
+      return InternalError.create(
+        `Modify failed: ${cause instanceof Error ? cause.message : String(cause)}`
+      );
+    },
   });
 }
 
@@ -139,7 +149,11 @@ async function runModifyCommandInner(
   const snapshot = await loadWaymarkSnapshot(target);
   const originalFirstLine = snapshot.lines[snapshot.lineIndex];
   if (!originalFirstLine) {
-    throw new Error(`Line ${snapshot.lineIndex + 1} not found in file`);
+    throw NotFoundError.create(
+      "line",
+      String(snapshot.lineIndex + 1),
+      { file: target.file }
+    );
   }
   const originalContent = extractFirstLineContent(originalFirstLine);
   const existingId = extractTrailingId(originalContent);
@@ -271,7 +285,10 @@ async function loadWaymarkSnapshot(target: ModifyTarget): Promise<Snapshot> {
   const records = parse(fileContent, { file: target.file });
   const record = records.find((entry) => entry.startLine === target.line);
   if (!record) {
-    throw new Error(`No waymark found at ${target.file}:${target.line}`);
+    throw NotFoundError.create(
+      "waymark",
+      `${target.file}:${target.line}`
+    );
   }
   const lineIndex = record.startLine - 1;
   return {
@@ -346,7 +363,7 @@ function determineType(current: string, requested?: string): string {
   }
   const trimmed = requested.trim();
   if (!trimmed) {
-    throw new Error("Waymark type cannot be empty");
+    throw ValidationError.create("type", "cannot be empty");
   }
   return trimmed;
 }
@@ -458,10 +475,14 @@ async function resolveTarget(
   idOption?: string
 ): Promise<ModifyTarget> {
   if (targetArg && idOption) {
-    throw new Error("Cannot specify both file:line and --id");
+    throw ValidationError.fromMessage(
+      "Cannot specify both file:line and --id"
+    );
   }
   if (!(targetArg || idOption)) {
-    throw new Error("Must provide a target (file:line) or --id");
+    throw ValidationError.fromMessage(
+      "Must provide a target (file:line) or --id"
+    );
   }
 
   if (idOption) {
@@ -469,7 +490,9 @@ async function resolveTarget(
   }
 
   if (!targetArg) {
-    throw new Error("Target argument is required when --id is not provided");
+    throw ValidationError.fromMessage(
+      "Target argument is required when --id is not provided"
+    );
   }
 
   return parseFileLineTarget(targetArg, {
@@ -486,7 +509,7 @@ async function resolveTargetFromId(
   const index = new JsonIdIndex({ workspaceRoot });
   const entry = await index.get(normalized);
   if (!entry) {
-    throw new Error(`Waymark ID ${normalized} not found in index`);
+    throw NotFoundError.create("waymark ID", normalized);
   }
   return {
     file: entry.file,
@@ -678,7 +701,7 @@ function ensureModificationsSpecified(options: ModifyOptions): void {
   const hasContent = options.content !== undefined;
 
   if (!(hasType || hasSignals || hasContent)) {
-    throw new Error(
+    throw ValidationError.fromMessage(
       "No modifications specified. Use --type, --flagged, --starred, --clear-signals, --content, or run without arguments for interactive prompts."
     );
   }

--- a/packages/cli/src/commands/modify.ts
+++ b/packages/cli/src/commands/modify.ts
@@ -149,11 +149,9 @@ async function runModifyCommandInner(
   const snapshot = await loadWaymarkSnapshot(target);
   const originalFirstLine = snapshot.lines[snapshot.lineIndex];
   if (!originalFirstLine) {
-    throw NotFoundError.create(
-      "line",
-      String(snapshot.lineIndex + 1),
-      { file: target.file }
-    );
+    throw NotFoundError.create("line", String(snapshot.lineIndex + 1), {
+      file: target.file,
+    });
   }
   const originalContent = extractFirstLineContent(originalFirstLine);
   const existingId = extractTrailingId(originalContent);
@@ -285,10 +283,7 @@ async function loadWaymarkSnapshot(target: ModifyTarget): Promise<Snapshot> {
   const records = parse(fileContent, { file: target.file });
   const record = records.find((entry) => entry.startLine === target.line);
   if (!record) {
-    throw NotFoundError.create(
-      "waymark",
-      `${target.file}:${target.line}`
-    );
+    throw NotFoundError.create("waymark", `${target.file}:${target.line}`);
   }
   const lineIndex = record.startLine - 1;
   return {
@@ -475,9 +470,7 @@ async function resolveTarget(
   idOption?: string
 ): Promise<ModifyTarget> {
   if (targetArg && idOption) {
-    throw ValidationError.fromMessage(
-      "Cannot specify both file:line and --id"
-    );
+    throw ValidationError.fromMessage("Cannot specify both file:line and --id");
   }
   if (!(targetArg || idOption)) {
     throw ValidationError.fromMessage(


### PR DESCRIPTION
refactor(cli): convert modify.ts and add.ts to typed error flow

Replace throw new Error(...) with typed contract errors
(ValidationError, NotFoundError) in modify and add command handlers.
Update Result.tryPromise catch handlers to preserve error category
instead of wrapping all errors as InternalError.

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)

refactor(cli): convert remaining CLI handlers to typed error flow

Convert throws in init.ts, remove.ts, scan.ts, update.ts, fmt.ts,
lint.ts, check.ts, and doctor.ts to use typed contract errors
(ValidationError, InternalError) instead of generic Error. Update all
Result.tryPromise catch handlers to preserve error categories via
AnyKitError duck-typing.

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Refactored CLI command handlers to use typed error flow instead of generic `Error` throws. Replaced `throw new Error(...)` with `ValidationError`, `NotFoundError`, and `InternalError` from `@outfitter/contracts`. Updated all `Result.tryPromise` catch handlers to preserve error categories using duck-typing pattern (`"category" in cause`) instead of wrapping everything as `InternalError`.

Key changes across 10 files:
- Validation errors now use `ValidationError.fromMessage()` or `ValidationError.create(field, message)`
- Not-found scenarios use `NotFoundError.create(type, identifier, context?)`
- Result handlers check for `"category"` property to preserve typed errors
- Return types changed from `Result<T, InternalError>` to `Result<T, AnyKitError>`

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The refactoring consistently applies a well-defined pattern across all files. The changes are purely error handling improvements that preserve existing behavior while adding type safety. All modified code follows the same duck-typing pattern for error category preservation, and the conversion from generic errors to typed errors is straightforward and correct.
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/cli/src/commands/add.ts | Converted from generic Error to typed ValidationError, preserved error categories in Result.tryPromise catch handler using duck-typing pattern |
| packages/cli/src/commands/modify.ts | Converted to typed ValidationError and NotFoundError, updated Result.tryPromise to preserve error categories via duck-typing |
| packages/cli/src/commands/fmt.ts | Converted to typed ValidationError, updated both formatFile and expandFormatPaths Result.tryPromise handlers to preserve error categories |
| packages/cli/src/commands/init.ts | Converted to typed ValidationError using .create() and .fromMessage() methods, updated Result.tryPromise catch handler |
| packages/cli/src/commands/scan.ts | Converted to typed ValidationError, updated Result.tryPromise catch handler to preserve error categories |

</details>


</details>


<sub>Last reviewed commit: 16bb9a7</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->