### PR TITLE
refactor(mcp): convert handlers to Result-based error handling

### DIFF
--- a/apps/mcp/src/resources/index.ts
+++ b/apps/mcp/src/resources/index.ts
@@ -23,12 +23,16 @@ export function registerResources(server: Server): void {
     ],
   }));
 
-  // biome-ignore lint/suspicious/useAwait: handler must return Promise per SDK contract
   server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
     const { uri } = request.params;
     if (uri === todosResourceDefinition.uri) {
-      return handleTodosResource();
+      const result = await handleTodosResource();
+      if (result.isErr()) {
+        throw new Error(result.error.message);
+      }
+      return result.value;
     }
+    // SDK boundary: unknown resource URIs are reported as protocol errors
     throw new Error(`Unknown resource: ${uri}`);
   });
 }

--- a/apps/mcp/src/resources/todos.test.ts
+++ b/apps/mcp/src/resources/todos.test.ts
@@ -43,10 +43,12 @@ describe("handleTodosResource", () => {
         ].join("\n")
       );
 
-      const response = await withWorkspace(workspace, () =>
+      const result = await withWorkspace(workspace, () =>
         handleTodosResource()
       );
-      const text = String(response.contents?.[0]?.text ?? "");
+      expect(result.isOk()).toBe(true);
+      const response = result.isOk() ? result.value : null;
+      const text = String(response?.contents?.[0]?.text ?? "");
       const payload = JSON.parse(text) as {
         todos: Array<{ content: string }>;
         truncated: boolean;
@@ -71,10 +73,12 @@ describe("handleTodosResource", () => {
       );
       await writeFixture(join(workspace, "src", "many.ts"), lines.join("\n"));
 
-      const response = await withWorkspace(workspace, () =>
+      const result = await withWorkspace(workspace, () =>
         handleTodosResource()
       );
-      const text = String(response.contents?.[0]?.text ?? "");
+      expect(result.isOk()).toBe(true);
+      const response = result.isOk() ? result.value : null;
+      const text = String(response?.contents?.[0]?.text ?? "");
       const payload = JSON.parse(text) as {
         todos: Array<{ content: string }>;
         truncated: boolean;

--- a/apps/mcp/src/tools/index.ts
+++ b/apps/mcp/src/tools/index.ts
@@ -1,9 +1,7 @@
 // tldr ::: tool registry for waymark MCP server
 
-import { Result } from "@outfitter/contracts";
 import type { McpServer } from "@outfitter/mcp";
 import { defineTool } from "@outfitter/mcp";
-import type { ToolContent } from "../types";
 import { waymarkToolInputSchema } from "../types";
 import { handleWaymarkTool, waymarkToolDescription } from "./waymark";
 
@@ -21,10 +19,7 @@ export function registerTools(
       name: "waymark",
       description: waymarkToolDescription,
       inputSchema: waymarkToolInputSchema,
-      handler: async (input, _ctx) => {
-        const result = await handleWaymarkTool(input, notifyResourceChanged);
-        return Result.ok(result) as Result<ToolContent, never>;
-      },
+      handler: (input, _ctx) => handleWaymarkTool(input, notifyResourceChanged),
     })
   );
 }

--- a/apps/mcp/src/tools/scan.ts
+++ b/apps/mcp/src/tools/scan.ts
@@ -1,5 +1,7 @@
 // tldr ::: scan tool handler for waymark MCP server
 
+import type { OutfitterError } from "@outfitter/contracts";
+import { InternalError, Result, ValidationError } from "@outfitter/contracts";
 import type { ConfigScope, WaymarkRecord } from "@waymarks/core";
 import { parse } from "@waymarks/core";
 import type { RenderFormat, ToolContent } from "../types";
@@ -15,10 +17,16 @@ import {
 /**
  * Handle the scan action for the MCP tool.
  * @param input - Raw tool input payload.
- * @returns MCP tool result with scan output.
+ * @returns Result containing MCP tool result with scan output, or an OutfitterError.
  */
-export async function handleScan(input: unknown): Promise<ToolContent> {
-  const { paths, format, configPath, scope } = scanInputSchema.parse(input);
+export async function handleScan(
+  input: unknown
+): Promise<Result<ToolContent, OutfitterError>> {
+  const parseResult = scanInputSchema.safeParse(input);
+  if (!parseResult.success) {
+    return Result.err(ValidationError.fromMessage(parseResult.error.message));
+  }
+  const { paths, format, configPath, scope } = parseResult.data;
   const collectOptions: { configPath?: string; scope?: ConfigScope } = {};
   if (configPath) {
     collectOptions.configPath = configPath;
@@ -26,18 +34,26 @@ export async function handleScan(input: unknown): Promise<ToolContent> {
   if (scope) {
     collectOptions.scope = scope;
   }
-  const { records } = await collectRecords(paths, collectOptions);
+  const collectResult = await collectRecords(paths, collectOptions);
+  if (collectResult.isErr()) {
+    return Result.err(collectResult.error);
+  }
+  const { records } = collectResult.value;
   const rendered = renderRecords(records, format);
-  return toTextResponse(rendered, mimeForFormat(format));
+  return Result.ok(toTextResponse(rendered, mimeForFormat(format)));
 }
 
 async function collectRecords(
   inputs: string[],
   options: { configPath?: string; scope?: ConfigScope }
-): Promise<{ records: WaymarkRecord[] }> {
-  let filePaths = await expandInputPaths(inputs);
+): Promise<Result<{ records: WaymarkRecord[] }, OutfitterError>> {
+  const expandResult = await expandInputPaths(inputs);
+  if (expandResult.isErr()) {
+    return Result.err(expandResult.error);
+  }
+  let filePaths = expandResult.value;
   if (filePaths.length === 0) {
-    return { records: [] };
+    return Result.ok({ records: [] });
   }
 
   const configResult = await loadConfig({
@@ -45,8 +61,10 @@ async function collectRecords(
     ...(options.configPath ? { configPath: options.configPath } : {}),
   });
   if (configResult.isErr()) {
-    throw new Error(
-      `Failed to load config: ${configResult.error instanceof Error ? configResult.error.message : String(configResult.error)}`
+    return Result.err(
+      InternalError.create(
+        `Failed to load config: ${configResult.error instanceof Error ? configResult.error.message : String(configResult.error)}`
+      )
     );
   }
   const config = configResult.value;
@@ -65,7 +83,7 @@ async function collectRecords(
     })
   );
 
-  return { records };
+  return Result.ok({ records });
 }
 
 function renderRecords(records: WaymarkRecord[], format: RenderFormat): string {

--- a/apps/mcp/src/tools/waymark.test.ts
+++ b/apps/mcp/src/tools/waymark.test.ts
@@ -11,21 +11,25 @@ const noopNotify = () => {
 
 describe("handleWaymarkTool", () => {
   test("returns help text", async () => {
-    const response = await handleWaymarkTool(
+    const result = await handleWaymarkTool(
       { action: "help" } as WaymarkToolInput,
       noopNotify
     );
-    const text = String(response.content?.[0]?.text ?? "");
+    expect(result.isOk()).toBe(true);
+    const response = result.isOk() ? result.value : null;
+    const text = String(response?.content?.[0]?.text ?? "");
     expect(text).toContain("Waymark MCP Tool");
     expect(text).toContain("scan");
   });
 
   test("returns topic-specific help", async () => {
-    const response = await handleWaymarkTool(
+    const result = await handleWaymarkTool(
       { action: "help", topic: "scan" } as WaymarkToolInput,
       noopNotify
     );
-    const text = String(response.content?.[0]?.text ?? "");
+    expect(result.isOk()).toBe(true);
+    const response = result.isOk() ? result.value : null;
+    const text = String(response?.content?.[0]?.text ?? "");
     expect(text).toContain("Action: scan");
   });
 });

--- a/apps/mcp/src/tools/waymark.ts
+++ b/apps/mcp/src/tools/waymark.ts
@@ -1,5 +1,7 @@
 // tldr ::: single MCP tool handler for waymark actions
 
+import type { OutfitterError } from "@outfitter/contracts";
+import { Result } from "@outfitter/contracts";
 import type { ToolContent, WaymarkToolInput } from "../types";
 import { handleAdd } from "./add";
 import { handleGraph } from "./graph";
@@ -11,12 +13,12 @@ import { handleScan } from "./scan";
  * Input is pre-validated by the framework's discriminatedUnion schema.
  * @param input - Validated tool input payload.
  * @param notifyResourceChanged - Callback to signal resource list changed.
- * @returns MCP tool result promise.
+ * @returns Result containing MCP tool result, or an OutfitterError.
  */
 export function handleWaymarkTool(
   input: WaymarkToolInput,
   notifyResourceChanged: () => void
-): Promise<ToolContent> {
+): Promise<Result<ToolContent, OutfitterError>> {
   switch (input.action) {
     case "scan":
       return handleScan(input);
@@ -25,7 +27,7 @@ export function handleWaymarkTool(
     case "add":
       return handleAdd(input, notifyResourceChanged);
     case "help":
-      return Promise.resolve(handleHelp(input));
+      return Promise.resolve(Result.ok(handleHelp(input)));
     default:
       // Exhaustive: input.action is validated by the framework's discriminatedUnion schema
       return input satisfies never;


### PR DESCRIPTION
Replace all throw statements in MCP handler and utility files with
Result<T, OutfitterError> return types. Security-boundary throws in
filesystem.ts are converted to ValidationError results propagated
through callers. Tests updated from rejects.toThrow() to isErr() checks.

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Systematically converts all MCP handler and utility functions from throwing exceptions to returning `Result<T, OutfitterError>`. Security-boundary path validation in `filesystem.ts` now returns `ValidationError` instead of throwing, with errors propagated through all callers. Tests comprehensively updated from `rejects.toThrow()` to `isErr()` assertions.

**Key changes:**
- Input validation uses `safeParse()` returning `ValidationError` on failure
- File operations return `NotFoundError` for missing files
- Config loading failures return `InternalError`
- Path traversal security checks return `ValidationError` 
- MCP SDK boundary in `resources/index.ts` unwraps Results and throws for protocol compliance
- All tests pass with new error handling pattern

<h3>Confidence Score: 5/5</h3>

- Safe to merge - comprehensive refactor with full test coverage
- All tests pass, error handling is systematic and type-safe, security boundary enforcement preserved, no breaking changes to external API
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/mcp/src/resources/index.ts | Unwraps Result at SDK boundary, converting errors to thrown Error for MCP protocol compliance |
| apps/mcp/src/resources/todos.ts | Converted to Result returns, propagating errors from `collectRecords()` and `expandInputPaths()` |
| apps/mcp/src/tools/add.ts | Replaced all throws with Result returns, using ValidationError, NotFoundError, and InternalError appropriately |
| apps/mcp/src/tools/waymark.ts | Updated return type to `Result<ToolContent, OutfitterError>`, wrapping help action in `Result.ok()` |
| apps/mcp/src/utils/filesystem.ts | Converted security-boundary throws to ValidationError results, maintaining workspace boundary enforcement |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[MCP Client Request] --> B[SDK Server Handler]
    B --> C{Tool or Resource?}
    
    C -->|Tool| D[handleWaymarkTool]
    C -->|Resource| E[handleTodosResource]
    
    D --> F{Action Type}
    F -->|scan| G[handleScan]
    F -->|graph| H[handleGraph]
    F -->|add| I[handleAdd]
    F -->|help| J[handleHelp]
    
    G --> K[collectRecords]
    H --> K
    I --> K
    E --> K
    
    K --> L[expandInputPaths]
    L --> M{Path valid?}
    M -->|No| N[Result.err ValidationError]
    M -->|Yes| O[collectFilesRecursive]
    
    O --> P{Escapes workspace?}
    P -->|Yes| N
    P -->|No| Q[Result.ok files]
    
    I --> R[Input Validation]
    R --> S{Valid?}
    S -->|No| T[Result.err ValidationError]
    S -->|Yes| U[Process & Write]
    
    U --> V[Result.ok ToolContent]
    J --> V
    Q --> V
    
    N --> W[SDK Boundary]
    T --> W
    V --> W
    
    W --> X{isErr?}
    X -->|Yes| Y[throw Error]
    X -->|No| Z[Return Value]
    
    Y --> AA[MCP Error Response]
    Z --> AB[MCP Success Response]
```
</details>


<sub>Last reviewed commit: c484757</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->